### PR TITLE
Avoid excessive animation on properties that were not passed

### DIFF
--- a/src/lib/utils/animation-utils.js
+++ b/src/lib/utils/animation-utils.js
@@ -77,7 +77,9 @@ export function getCSSAnimation(props, style) {
     const animationKeys = keys
       .filter(key => Boolean(style[key]))
       .map(key => `${key} ${animation.duration / 1000}s`);
-    transition = animationKeys.join(',');
+    if (animationKeys.length) {
+      transition = animationKeys.join(',');
+    }
   }
   return {
     transition,


### PR DESCRIPTION
Sometimes null properties are animated and produce unpredictable results.

@uber-common/data-visualization , please review.
