### PR TITLE
Update broken link for Travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# react-vis ![Build Status](https://travis-ci.org/uber-common/react-vis.svg?branch=master)
+# react-vis ![Build Status](https://travis-ci.org/uber/react-vis.svg?branch=master)
 
 ![Demo of XYPlot](docs/assets/react-vis.gif?raw=true)
 


### PR DESCRIPTION
It was pointing to a uber-common organization