### PR TITLE
Fix bar series distance calculation

### DIFF
--- a/src/lib/utils/scales-utils.js
+++ b/src/lib/utils/scales-utils.js
@@ -83,7 +83,7 @@ const SCALE_FUNCTIONS = {
  * @returns {number} Index of an element where the smallest distance was found.
  * @private
  */
-function _getSmallestDistanceIndex(values, scaleObject) {
+export function _getSmallestDistanceIndex(values, scaleObject) {
   const scaleFn = _getScaleFnFromScaleObject(scaleObject);
   let result = 0;
   if (scaleFn) {

--- a/src/lib/utils/scales-utils.js
+++ b/src/lib/utils/scales-utils.js
@@ -78,6 +78,8 @@ const SCALE_FUNCTIONS = {
 /**
  * Find the smallest distance between the values on a given scale and return
  * the index of the element, where the smallest distance was found.
+ * It returns the first occurrence of i where
+ * `scale(value[i]) - scale(value[i - 1])` is minimal
  * @param {Array} values Array of values.
  * @param {Object} scaleObject Scale object.
  * @returns {number} Index of an element where the smallest distance was found.
@@ -88,14 +90,14 @@ export function _getSmallestDistanceIndex(values, scaleObject) {
   let result = 0;
   if (scaleFn) {
     let nextValue;
-    let currentValue = scaleFn(values[1]);
-    let distance = currentValue - scaleFn(values[0]);
+    let currentValue = scaleFn(values[0]);
+    let distance = Infinity;
     let nextDistance;
 
     for (let i = 1; i < values.length; i++) {
       nextValue = scaleFn(values[i]);
       nextDistance = Math.abs(nextValue - currentValue);
-      if (distance <= nextDistance) {
+      if (nextDistance < distance) {
         distance = nextDistance;
         result = i;
       }

--- a/src/test/scales-utils.js
+++ b/src/test/scales-utils.js
@@ -163,11 +163,10 @@ test('scales-utils/_getSmallestDistanceIndex', function t(assert) {
   };
 
   assert.equal(runTest([0, 0, 2]), 1);
-  assert.equal(runTest([0, 1, 2]), 1, 'returns first index with smallest dist');
+  assert.equal(runTest([0, 1, 2]), 1);
   assert.equal(runTest([0, 2, 2]), 2);
   assert.equal(runTest([0, 2, 2]), 2);
   assert.equal(runTest([1, 2, 2]), 2);
-  assert.equal(runTest([2, 2, 2]), 1);
   assert.equal(runTest([2, 2, 2]), 1);
   assert.end();
 

--- a/src/test/scales-utils.js
+++ b/src/test/scales-utils.js
@@ -161,13 +161,14 @@ test('scales-utils/_getSmallestDistanceIndex', function t(assert) {
     domain: [0, 1],
     range: [0, 1]
   };
+
   assert.equal(runTest([0, 0, 2]), 1);
-  assert.equal(runTest([0, 1, 2]), 2, 'returns last index with smallest dist');
+  assert.equal(runTest([0, 1, 2]), 1, 'returns first index with smallest dist');
   assert.equal(runTest([0, 2, 2]), 2);
   assert.equal(runTest([0, 2, 2]), 2);
   assert.equal(runTest([1, 2, 2]), 2);
-  assert.equal(runTest([2, 2, 2]), 2);
-  assert.equal(runTest([2, 2, 2]), 2);
+  assert.equal(runTest([2, 2, 2]), 1);
+  assert.equal(runTest([2, 2, 2]), 1);
   assert.end();
 
   function runTest(arg) {

--- a/src/test/scales-utils.js
+++ b/src/test/scales-utils.js
@@ -26,7 +26,9 @@ import {
   getScalePropTypesByAttribute,
   getAttributeFunctor,
   getAttributeScale,
-  getAttributeValue} from '../lib/utils/scales-utils';
+  getAttributeValue,
+  _getSmallestDistanceIndex
+} from '../lib/utils/scales-utils';
 
 function isScaleConsistent(scaleObject, attr) {
   return scaleObject && scaleObject.range && scaleObject.domain &&
@@ -153,3 +155,22 @@ test('scales-utils/getAttributeValue with valid props', function t(assert) {
   assert.end();
 });
 
+test('scales-utils/_getSmallestDistanceIndex', function t(assert) {
+  const scaleObj = {
+    type: 'linear',
+    domain: [0, 1],
+    range: [0, 1]
+  };
+  assert.equal(runTest([0, 0, 2]), 1);
+  assert.equal(runTest([0, 1, 2]), 2, 'returns last index with smallest dist');
+  assert.equal(runTest([0, 2, 2]), 2);
+  assert.equal(runTest([0, 2, 2]), 2);
+  assert.equal(runTest([1, 2, 2]), 2);
+  assert.equal(runTest([2, 2, 2]), 2);
+  assert.equal(runTest([2, 2, 2]), 2);
+  assert.end();
+
+  function runTest(arg) {
+    return _getSmallestDistanceIndex(arg, scaleObj);
+  }
+});


### PR DESCRIPTION
The bar series distance calculation should calculate the minimum distance between the points, and use that to create bars that don't overlap.

- Add failing test cases

Fixes #68