### PR TITLE
Add 'dataKey' prop to MarkSeries

### DIFF
--- a/src/example/plot/scatteplot.js
+++ b/src/example/plot/scatteplot.js
@@ -41,12 +41,13 @@ export default class Example extends React.Component {
         <MarkSeries
           sizeRange={[5, 15]}
           data={[
-            {x: 1, y: 10, size: 30},
-            {x: 1.7, y: 12, size: 10},
-            {x: 2, y: 5, size: 1},
-            {x: 3, y: 15, size: 12},
-            {x: 2.5, y: 7, size: 4}
-          ]}/>
+            {id: 1, x: 1, y: 10, size: 30},
+            {id: 2, x: 1.7, y: 12, size: 10},
+            {id: 3, x: 2, y: 5, size: 1},
+            {id: 4, x: 3, y: 15, size: 12},
+            {id: 5, x: 2.5, y: 7, size: 4}
+          ]}
+          dataKey={(d, i) => (d && d.id) || i}/>
       </XYPlot>
     );
   }

--- a/src/lib/plot/series/mark-series.js
+++ b/src/lib/plot/series/mark-series.js
@@ -28,6 +28,13 @@ import {DEFAULT_SIZE, DEFAULT_OPACITY} from '../../theme';
 
 class MarkSeries extends AbstractSeries {
 
+  static get propTypes() {
+    return {
+      ... AbstractSeries.propTypes,
+      dataKey: React.PropTypes.func
+    };
+  }
+
   constructor(props) {
     super(props);
     this._mouseOver = this._mouseOver.bind(this);
@@ -64,12 +71,14 @@ class MarkSeries extends AbstractSeries {
 
   _updateSeries() {
     const container = getDOMNode(this.refs.container);
-    const {data} = this.props;
+    const {
+      data,
+      dataKey} = this.props;
     if (!data) {
       return;
     }
     const circles = d3.select(container).selectAll('circle')
-      .data(data)
+      .data(data, dataKey)
       .on('mouseover', this._mouseOver)
       .on('mouseout', this._mouseOut);
 


### PR DESCRIPTION
The `dataKey` prop is passed to D3's `data()` function to override the default by-index behavior:

https://github.com/mbostock/d3/wiki/Selections#data

This is particularly useful when animating a scatterplot.
