### PR TITLE
Upgrade to modular d3@4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,15 @@
   },
   "main": "index.js",
   "dependencies": {
-    "d3": "^3.5.6",
+    "d3-array": "^0.7.1",
+    "d3-axis": "^0.3.1",
+    "d3-collection": "^0.1.2",
+    "d3-color": "^0.4.2",
+    "d3-hierarchy": "^0.2.2",
+    "d3-scale": "^0.7.0",
+    "d3-selection": "^0.7.1",
+    "d3-shape": "^0.6.0",
+    "d3-transition": "^0.2.8",
     "deep-equal": "^1.0.1",
     "global": "^4.3.0",
     "warning": "^2.1.0"

--- a/src/lib/plot/axis.js
+++ b/src/lib/plot/axis.js
@@ -19,10 +19,11 @@
 // THE SOFTWARE.
 
 import React from 'react';
-import d3 from 'd3';
+import d3Selection from 'd3-selection';
 
 import PureRenderComponent from '../pure-render-component';
 import {getDOMNode} from '../utils/react-utils';
+import {AXIS_ORIENTATION, getAxisFnByOrientation} from '../utils/axis-utils';
 import {getAttributeScale} from '../utils/scales-utils';
 
 import {AnimationPropType, applyTransition} from '../utils/animation-utils';
@@ -45,7 +46,7 @@ class Axis extends PureRenderComponent {
       title: React.PropTypes.string,
       classSet: React.PropTypes.object,
       attr: React.PropTypes.string.isRequired,
-      orientation: React.PropTypes.string.isRequired,
+      orientation: React.PropTypes.oneOf(AXIS_ORIENTATION),
       labelFormat: React.PropTypes.func,
       labelValues: React.PropTypes.array,
       tickValues: React.PropTypes.array,
@@ -82,7 +83,7 @@ class Axis extends PureRenderComponent {
       axis.tickFormat(labelFormat);
     }
     axis.tickSize(0, 0);
-    axis.outerTickSize(0);
+    axis.tickSizeOuter(0);
     axis.tickPadding(14);
     return axis;
   }
@@ -102,7 +103,7 @@ class Axis extends PureRenderComponent {
     }
     axis.tickFormat('');
     axis.tickSize(tickSize);
-    axis.outerTickSize(0);
+    axis.tickSizeOuter(0);
     return axis;
   }
 
@@ -118,11 +119,10 @@ class Axis extends PureRenderComponent {
     }
 
     const {labels, ticks} = this.refs;
-    const selectedLabels = d3.select(getDOMNode(labels));
-    const selectedTicks = d3.select(getDOMNode(ticks));
-
-    let axis = d3.svg.axis().scale(scale).orient(orientation);
-    axis = this._setAxisLabels(axis);
+    const selectedLabels = d3Selection.select(getDOMNode(labels));
+    const selectedTicks = d3Selection.select(getDOMNode(ticks));
+    const axisFn = getAxisFnByOrientation(orientation);
+    const axis = this._setAxisLabels(axisFn(scale));
 
     applyTransition(this.props, selectedLabels)
       .call(this._setAxisLabels(axis));

--- a/src/lib/plot/axis.js
+++ b/src/lib/plot/axis.js
@@ -23,7 +23,7 @@ import d3Selection from 'd3-selection';
 
 import PureRenderComponent from '../pure-render-component';
 import {getDOMNode} from '../utils/react-utils';
-import {AXIS_ORIENTATION, getAxisFnByOrientation} from '../utils/axis-utils';
+import {AXIS_ORIENTATIONS, getAxisFnByOrientation} from '../utils/axis-utils';
 import {getAttributeScale} from '../utils/scales-utils';
 
 import {AnimationPropType, applyTransition} from '../utils/animation-utils';
@@ -46,7 +46,7 @@ class Axis extends PureRenderComponent {
       title: React.PropTypes.string,
       classSet: React.PropTypes.object,
       attr: React.PropTypes.string.isRequired,
-      orientation: React.PropTypes.oneOf(AXIS_ORIENTATION),
+      orientation: React.PropTypes.oneOf(AXIS_ORIENTATIONS),
       labelFormat: React.PropTypes.func,
       labelValues: React.PropTypes.array,
       tickValues: React.PropTypes.array,

--- a/src/lib/plot/grid-lines.js
+++ b/src/lib/plot/grid-lines.js
@@ -19,11 +19,12 @@
 // THE SOFTWARE.
 
 import React from 'react';
-import d3 from 'd3';
+import d3Selection from 'd3-selection';
 
 import PureRenderComponent from '../pure-render-component';
 import {getDOMNode} from '../utils/react-utils';
 import {getAttributeScale} from '../utils/scales-utils';
+import {AXIS_ORIENTATION, getAxisFnByOrientation} from '../utils/axis-utils';
 
 import {AnimationPropType, applyTransition} from '../utils/animation-utils';
 
@@ -35,9 +36,7 @@ class GridLines extends PureRenderComponent {
       ticksTotal: React.PropTypes.number,
       values: React.PropTypes.array,
       attr: React.PropTypes.string.isRequired,
-      orientation: React.PropTypes.oneOf([
-        'left', 'top', 'bottom', 'right'
-      ]),
+      orientation: React.PropTypes.oneOf(AXIS_ORIENTATION),
       top: React.PropTypes.number,
       left: React.PropTypes.number,
       marginTop: React.PropTypes.number,
@@ -67,11 +66,9 @@ class GridLines extends PureRenderComponent {
     if (!scale) {
       return;
     }
-    const container = d3.select(getDOMNode(this.refs.container));
-    const axis = d3.svg
-      .axis()
-      .scale(scale)
-      .orient(orientation)
+    const container = d3Selection.select(getDOMNode(this.refs.container));
+    const axisFn = getAxisFnByOrientation(orientation);
+    const axis = axisFn(scale)
       .tickFormat('')
       .tickSize(tickSize, 0, 0);
     if (!values) {

--- a/src/lib/plot/grid-lines.js
+++ b/src/lib/plot/grid-lines.js
@@ -24,7 +24,7 @@ import d3Selection from 'd3-selection';
 import PureRenderComponent from '../pure-render-component';
 import {getDOMNode} from '../utils/react-utils';
 import {getAttributeScale} from '../utils/scales-utils';
-import {AXIS_ORIENTATION, getAxisFnByOrientation} from '../utils/axis-utils';
+import {AXIS_ORIENTATIONS, getAxisFnByOrientation} from '../utils/axis-utils';
 
 import {AnimationPropType, applyTransition} from '../utils/animation-utils';
 
@@ -36,7 +36,7 @@ class GridLines extends PureRenderComponent {
       ticksTotal: React.PropTypes.number,
       values: React.PropTypes.array,
       attr: React.PropTypes.string.isRequired,
-      orientation: React.PropTypes.oneOf(AXIS_ORIENTATION),
+      orientation: React.PropTypes.oneOf(AXIS_ORIENTATIONS),
       top: React.PropTypes.number,
       left: React.PropTypes.number,
       marginTop: React.PropTypes.number,

--- a/src/lib/plot/series/abstract-series.js
+++ b/src/lib/plot/series/abstract-series.js
@@ -19,7 +19,7 @@
 // THE SOFTWARE.
 
 import React from 'react';
-import d3 from 'd3';
+import d3Selection from 'd3-selection';
 
 import PureRenderComponent from '../../pure-render-component';
 import {
@@ -129,8 +129,8 @@ export default class AbstractSeries extends PureRenderComponent {
     let value = null;
 
     // TODO(antonb): WAT?
-    d3.event = event.nativeEvent;
-    const coordinate = d3.mouse(event.currentTarget)[0] - marginLeft;
+    d3Selection.event = event.nativeEvent;
+    const coordinate = d3Selection.mouse(event.currentTarget)[0] - marginLeft;
     const xScaleFn = this._getAttributeFunctor('x');
 
     data.forEach(item => {

--- a/src/lib/plot/series/area-series.js
+++ b/src/lib/plot/series/area-series.js
@@ -19,7 +19,8 @@
 // THE SOFTWARE.
 
 import React from 'react';
-import d3 from 'd3';
+import d3Selection from 'd3-selection';
+import d3Shape from 'd3-shape';
 
 import AbstractSeries from './abstract-series';
 import {getDOMNode} from '../../utils/react-utils';
@@ -45,20 +46,20 @@ class AreaSeries extends AbstractSeries {
   _mouseOver(d) {
     const {onValueMouseOver, onSeriesMouseOver} = this.props;
     if (onValueMouseOver) {
-      onValueMouseOver(d, {event: d3.event});
+      onValueMouseOver(d, {event: d3Selection.event});
     }
     if (onSeriesMouseOver) {
-      onSeriesMouseOver({event: d3.event});
+      onSeriesMouseOver({event: d3Selection.event});
     }
   }
 
   _mouseOut(d) {
     const {onValueMouseOut, onSeriesMouseOut} = this.props;
     if (onValueMouseOut) {
-      onValueMouseOut(d, {event: d3.event});
+      onValueMouseOut(d, {event: d3Selection.event});
     }
     if (onSeriesMouseOut) {
-      onSeriesMouseOut({event: d3.event});
+      onSeriesMouseOut({event: d3Selection.event});
     }
   }
 
@@ -78,12 +79,12 @@ class AreaSeries extends AbstractSeries {
     const stroke = this._getAttributeValue('stroke') ||
       this._getAttributeValue('color');
 
-    const line = d3.svg.area().x(x).y0(y0).y1(y);
+    const line = d3Shape.area().x(x).y0(y0).y1(y);
 
     const opacity = this._getAttributeValue('opacity') || DEFAULT_OPACITY;
     const d = line(data);
 
-    const path = d3.select(lineElement)
+    const path = d3Selection.select(lineElement)
       .on('mouseover', this._onMouseOver)
       .on('mouseout', this._onMouseOut);
 

--- a/src/lib/plot/series/bar-series.js
+++ b/src/lib/plot/series/bar-series.js
@@ -19,7 +19,7 @@
 // THE SOFTWARE.
 
 import React from 'react';
-import d3 from 'd3';
+import d3Selection from 'd3-selection';
 
 import AbstractSeries from './abstract-series';
 import {getDOMNode} from '../../utils/react-utils';
@@ -58,10 +58,10 @@ class BarSeries extends AbstractSeries {
   _mouseOver(d) {
     const {onValueMouseOver, onSeriesMouseOver} = this.props;
     if (onValueMouseOver) {
-      onValueMouseOver(d, {event: d3.event});
+      onValueMouseOver(d, {event: d3Selection.event});
     }
     if (onSeriesMouseOver) {
-      onSeriesMouseOver({event: d3.event});
+      onSeriesMouseOver({event: d3Selection.event});
     }
   }
 
@@ -73,10 +73,10 @@ class BarSeries extends AbstractSeries {
   _mouseOut(d) {
     const {onValueMouseOut, onSeriesMouseOut} = this.props;
     if (onValueMouseOut) {
-      onValueMouseOut(d, {event: d3.event});
+      onValueMouseOut(d, {event: d3Selection.event});
     }
     if (onSeriesMouseOut) {
-      onSeriesMouseOut({event: d3.event});
+      onSeriesMouseOut({event: d3Selection.event});
     }
   }
 
@@ -108,7 +108,7 @@ class BarSeries extends AbstractSeries {
       sameTypeIndex = 0;
     }
 
-    const rects = d3.select(container).selectAll('rect')
+    const rects = d3Selection.select(container).selectAll('rect')
       .data(data)
       .on('mouseover', this._mouseOver)
       .on('mouseout', this._mouseOut);

--- a/src/lib/plot/series/heatmap-series.js
+++ b/src/lib/plot/series/heatmap-series.js
@@ -19,7 +19,7 @@
 // THE SOFTWARE.
 
 import React from 'react';
-import d3 from 'd3';
+import d3Selection from 'd3-selection';
 
 import AbstractSeries from './abstract-series';
 import {getDOMNode} from '../../utils/react-utils';
@@ -48,20 +48,20 @@ class HeatmapSeries extends AbstractSeries {
   _mouseOver(d) {
     const {onValueMouseOver, onSeriesMouseOver} = this.props;
     if (onValueMouseOver) {
-      onValueMouseOver(d, {event: d3.event});
+      onValueMouseOver(d, {event: d3Selection.event});
     }
     if (onSeriesMouseOver) {
-      onSeriesMouseOver({event: d3.event});
+      onSeriesMouseOver({event: d3Selection.event});
     }
   }
 
   _mouseOut(d) {
     const {onValueMouseOut, onSeriesMouseOut} = this.props;
     if (onValueMouseOut) {
-      onValueMouseOut(d, {event: d3.event});
+      onValueMouseOut(d, {event: d3Selection.event});
     }
     if (onSeriesMouseOut) {
-      onSeriesMouseOut({event: d3.event});
+      onSeriesMouseOut({event: d3Selection.event});
     }
   }
 
@@ -76,7 +76,7 @@ class HeatmapSeries extends AbstractSeries {
     const x = this._getAttributeFunctor('x');
     const y = this._getAttributeFunctor('y');
 
-    const rects = d3.select(container).selectAll('rect')
+    const rects = d3Selection.select(container).selectAll('rect')
       .data(data)
       .on('mouseover', this._mouseOver)
       .on('mouseout', this._mouseOut);

--- a/src/lib/plot/series/line-series.js
+++ b/src/lib/plot/series/line-series.js
@@ -19,7 +19,8 @@
 // THE SOFTWARE.
 
 import React from 'react';
-import d3 from 'd3';
+import d3Selection from 'd3-selection';
+import d3Shape from 'd3-shape';
 
 import AbstractSeries from './abstract-series';
 import {getDOMNode} from '../../utils/react-utils';
@@ -57,14 +58,14 @@ class LineSeries extends AbstractSeries {
   _mouseOver() {
     const {onSeriesMouseOver} = this.props;
     if (onSeriesMouseOver) {
-      onSeriesMouseOver({event: d3.event});
+      onSeriesMouseOver({event: d3Selection.event});
     }
   }
 
   _mouseOut() {
     const {onSeriesMouseOut} = this.props;
     if (onSeriesMouseOut) {
-      onSeriesMouseOut({event: d3.event});
+      onSeriesMouseOut({event: d3Selection.event});
     }
   }
 
@@ -79,9 +80,9 @@ class LineSeries extends AbstractSeries {
     const stroke = this._getAttributeValue('stroke') ||
       this._getAttributeValue('color');
     const opacity = this._getAttributeValue('opacity') || DEFAULT_OPACITY;
-    const line = d3.svg.line().x(x).y(y);
+    const line = d3Shape.line().x(x).y(y);
     const d = line(data);
-    const path = d3.select(lineElement)
+    const path = d3Selection.select(lineElement)
       .on('mouseover', this._mouseOver)
       .on('mouseout', this._mouseOut);
     this._applyTransition(path)

--- a/src/lib/plot/series/mark-series.js
+++ b/src/lib/plot/series/mark-series.js
@@ -19,7 +19,7 @@
 // THE SOFTWARE.
 
 import React from 'react';
-import d3 from 'd3';
+import d3Selection from 'd3-selection';
 
 import AbstractSeries from './abstract-series';
 import {getDOMNode} from '../../utils/react-utils';
@@ -45,20 +45,20 @@ class MarkSeries extends AbstractSeries {
   _mouseOver(d) {
     const {onValueMouseOver, onSeriesMouseOver} = this.props;
     if (onValueMouseOver) {
-      onValueMouseOver(d, {event: d3.event});
+      onValueMouseOver(d, {event: d3Selection.event});
     }
     if (onSeriesMouseOver) {
-      onSeriesMouseOver({event: d3.event});
+      onSeriesMouseOver({event: d3Selection.event});
     }
   }
 
   _mouseOut(d) {
     const {onValueMouseOut, onSeriesMouseOut} = this.props;
     if (onValueMouseOut) {
-      onValueMouseOut(d, {event: d3.event});
+      onValueMouseOut(d, {event: d3Selection.event});
     }
     if (onSeriesMouseOut) {
-      onSeriesMouseOut({event: d3.event});
+      onSeriesMouseOut({event: d3Selection.event});
     }
   }
 
@@ -68,7 +68,7 @@ class MarkSeries extends AbstractSeries {
     if (!data) {
       return;
     }
-    const circles = d3.select(container).selectAll('circle')
+    const circles = d3Selection.select(container).selectAll('circle')
       .data(data)
       .on('mouseover', this._mouseOver)
       .on('mouseout', this._mouseOut);

--- a/src/lib/radial-chart/radial-chart.js
+++ b/src/lib/radial-chart/radial-chart.js
@@ -20,7 +20,8 @@
 
 import React from 'react';
 import equal from 'deep-equal';
-import d3 from 'd3';
+import d3Selection from 'd3-selection';
+import d3Shape from 'd3-shape';
 
 import {getAttributeFunctor} from '../utils/scales-utils';
 
@@ -127,7 +128,7 @@ export default class RadialChart extends React.Component {
   _triggerSectionHandler(handler, d) {
     if (handler) {
       const [x, y] = this._arc.centroid(d);
-      handler(d.data, {event: d3.event, x, y});
+      handler(d.data, {event: d3Selection.event, x, y});
     }
   }
 
@@ -233,21 +234,19 @@ export default class RadialChart extends React.Component {
   _updateChart() {
     const {data} = this.state;
     const container = getDOMNode(this.refs.container);
-    const pie = d3.layout.pie()
-      .sort(null)
-      .value(d => d.angle);
+    const pie = d3Shape.pie().sort(null).value(d => d.angle);
 
     const radiusFn = this._getAttributeFunctor('radius');
     const innerRadiusFn = this._getAttributeFunctor('innerRadius');
     if (!radiusFn) {
       return;
     }
-    const arc = d3.svg.arc()
+    const arc = d3Shape.arc()
       .outerRadius(radiusFn)
       .innerRadius(innerRadiusFn);
     this._arc = arc;
 
-    const sections = d3.select(container).selectAll('path')
+    const sections = d3Selection.select(container).selectAll('path')
       .data(pie(data))
       .on('click', this._sectionClick)
       .on('mouseover', this._sectionMouseOver)

--- a/src/lib/utils/animation-utils.js
+++ b/src/lib/utils/animation-utils.js
@@ -20,6 +20,12 @@
 
 import React from 'react';
 
+// Not obvious: d3-transition adds .transition() method to the selection
+// prototype (!!!). Do not remove this import.
+/* eslint-disable no-unused-vars */
+import d3Transition from 'd3-transition';
+/* eslint-enable no-unused-vars */
+
 /**
  * Property type for the animation.
  */

--- a/src/lib/utils/animation-utils.js
+++ b/src/lib/utils/animation-utils.js
@@ -22,9 +22,7 @@ import React from 'react';
 
 // Not obvious: d3-transition adds .transition() method to the selection
 // prototype (!!!). Do not remove this import.
-/* eslint-disable no-unused-vars */
-import d3Transition from 'd3-transition';
-/* eslint-enable no-unused-vars */
+import 'd3-transition';
 
 /**
  * Property type for the animation.

--- a/src/lib/utils/axis-utils.js
+++ b/src/lib/utils/axis-utils.js
@@ -27,7 +27,7 @@ const AXIS_FNS = {
   bottom: d3Axis.axisBottom
 };
 
-export const AXIS_ORIENTATION = Object.keys(AXIS_FNS);
+export const AXIS_ORIENTATIONS = Object.keys(AXIS_FNS);
 
 export function getAxisFnByOrientation(orientation) {
   return AXIS_FNS[orientation];

--- a/src/lib/utils/axis-utils.js
+++ b/src/lib/utils/axis-utils.js
@@ -18,6 +18,21 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+import d3Axis from 'd3-axis';
+
+const AXIS_FNS = {
+  left: d3Axis.axisLeft,
+  right: d3Axis.axisRight,
+  top: d3Axis.axisTop,
+  bottom: d3Axis.axisBottom
+};
+
+export const AXIS_ORIENTATION = Object.keys(AXIS_FNS);
+
+export function getAxisFnByOrientation(orientation) {
+  return AXIS_FNS[orientation];
+}
+
 /**
  * Get total amount of ticks from a given size in pixels.
  * @param {number} size Size of the axis in pixels.

--- a/src/lib/utils/scales-utils.js
+++ b/src/lib/utils/scales-utils.js
@@ -18,7 +18,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import d3 from 'd3';
+import d3Scale from 'd3-scale';
+import d3Array from 'd3-array';
+import d3Collection from 'd3-collection';
 import React from 'react';
 import warning from 'warning';
 
@@ -68,11 +70,11 @@ const TIME_SCALE_TYPE = 'time';
  * @const
  */
 const SCALE_FUNCTIONS = {
-  [LINEAR_SCALE_TYPE]: d3.scale.linear,
-  [ORDINAL_SCALE_TYPE]: d3.scale.ordinal,
-  [CATEGORY_SCALE_TYPE]: d3.scale.ordinal,
-  [LOG_SCALE_TYPE]: d3.scale.log,
-  [TIME_SCALE_TYPE]: d3.time.scale
+  [LINEAR_SCALE_TYPE]: d3Scale.scaleLinear,
+  [ORDINAL_SCALE_TYPE]: d3Scale.scaleOrdinal,
+  [CATEGORY_SCALE_TYPE]: d3Scale.scaleOrdinal,
+  [LOG_SCALE_TYPE]: d3Scale.scaleLog,
+  [TIME_SCALE_TYPE]: d3Scale.scaleTime
 };
 
 /**
@@ -149,9 +151,9 @@ function _getDomainByAttr(allData, attr, type) {
 
   // Create proper domain depending on the type of the scale.
   if (type !== ORDINAL_SCALE_TYPE && type !== CATEGORY_SCALE_TYPE) {
-    domain = d3.extent(values);
+    domain = d3Array.extent(values);
   } else {
-    domain = d3.set(values).values();
+    domain = d3Collection.set(values).values();
   }
   return domain;
 }

--- a/src/styles/plot.scss
+++ b/src/styles/plot.scss
@@ -50,8 +50,9 @@ $rv-xy-plot-tooltip-padding: 7px 10px;
   line {
     stroke: $rv-xy-plot-axis-line-color;
   }
+  // Hide the axis path from the grid: not needed.
   .domain {
-    opacity: 0;
+    display: none;
   }
 }
 

--- a/src/styles/plot.scss
+++ b/src/styles/plot.scss
@@ -50,6 +50,9 @@ $rv-xy-plot-tooltip-padding: 7px 10px;
   line {
     stroke: $rv-xy-plot-axis-line-color;
   }
+  .domain {
+    opacity: 0;
+  }
 }
 
 .rv-xy-plot__series--line {


### PR DESCRIPTION
This PR upgrades the library to d3@4.0. Currently all use of old version is eliminated, all the tests are passing, however, there might be some issues related to the new library.

Several things require some additional attention (but work though):
- Axes and treemaps are implemented very differently in the new d3 (new API, new tiling).
- Transitions are weird: they are adding themselves to `d3.selection`'s prototype. It might produce interesting side-effects in future.
- Some parts of d3, that are currently used, can be eliminated. For instance, `d3-collection` might be replaced with something less heavyweight since only sets are used.

This issue fixes #29 

@chrisirhc, @jckr, @mcnuttandrew, please take a look.