### PR TITLE
Event listeners for the series

### DIFF
--- a/src/lib/plot/series/abstract-series.js
+++ b/src/lib/plot/series/abstract-series.js
@@ -45,11 +45,107 @@ export default class AbstractSeries extends PureRenderComponent {
       data: React.PropTypes.array,
       onValueMouseOver: React.PropTypes.func,
       onValueMouseOut: React.PropTypes.func,
+      onValueClick: React.PropTypes.func,
       onSeriesMouseOver: React.PropTypes.func,
       onSeriesMouseOut: React.PropTypes.func,
+      onSeriesClick: React.PropTypes.func,
       onNearestX: React.PropTypes.func,
       animation: AnimationPropType
     };
+  }
+
+  constructor(props) {
+    super(props);
+
+    /**
+     * Mouse over handler for the series without single values.
+     * @type {function}
+     * @protected
+     */
+    this._mouseOver = this._mouseOverHandler.bind(this, false);
+
+    /**
+     * Mouse over handler for the series **with** single values.
+     * @type {function}
+     * @protected
+     */
+    this._mouseOverWithValue = this._mouseOverHandler.bind(this, true);
+
+    /**
+     * Mouse out handler for the series without single values.
+     * @type {function}
+     * @protected
+     */
+    this._mouseOut = this._mouseOutHandler.bind(this, false);
+
+    /**
+     * Mouse out handler for the series **with** single values.
+     * @type {function}
+     * @protected
+     */
+    this._mouseOutWithValue = this._mouseOutHandler.bind(this, true);
+
+    /**
+     * Click handler for the series without single values.
+     * @type {function}
+     * @protected
+     */
+    this._click = this._clickHandler.bind(this, false);
+
+    /**
+     * Click handler for the series **with** single values.
+     * @type {function}
+     * @protected
+     */
+    this._clickWithValue = this._clickHandler.bind(this, true);
+  }
+
+  /**
+   * Mouse over handler for all series.
+   * @param {boolean} useValue Use value handler if true.
+   * @param {Object} d Value object
+   * @private
+   */
+  _mouseOverHandler(useValue, d) {
+    const {onValueMouseOver, onSeriesMouseOver} = this.props;
+    if (useValue && onValueMouseOver) {
+      onValueMouseOver(d, {event: d3Selection.event});
+    }
+    if (onSeriesMouseOver) {
+      onSeriesMouseOver({event: d3Selection.event});
+    }
+  }
+
+  /**
+   * Mouse out handler for all series.
+   * @param {boolean} useValue Use value handler if true.
+   * @param {Object} d Value object
+   * @private
+   */
+  _mouseOutHandler(useValue, d) {
+    const {onValueMouseOut, onSeriesMouseOut} = this.props;
+    if (useValue && onValueMouseOut) {
+      onValueMouseOut(d, {event: d3Selection.event});
+    }
+    if (onSeriesMouseOut) {
+      onSeriesMouseOut({event: d3Selection.event});
+    }
+  }
+
+  /**
+   * Click handler for all series.
+   * @param {boolean} useValue Use value handler if true.
+   * @param {Object} d Value object
+   * @private
+   */
+  _clickHandler(useValue, d) {
+    const {onValueClick, onSeriesClick} = this.props;
+    if (useValue && onValueClick) {
+      onValueClick(d, {event: d3Selection.event});
+    }
+    if (onSeriesClick) {
+      onSeriesClick({event: d3Selection.event});
+    }
   }
 
   /**

--- a/src/lib/plot/series/area-series.js
+++ b/src/lib/plot/series/area-series.js
@@ -29,38 +29,12 @@ import {DEFAULT_OPACITY} from '../../theme';
 
 class AreaSeries extends AbstractSeries {
 
-  constructor(props) {
-    super(props);
-    this._mouseOut = this._mouseOut.bind(this);
-    this._mouseOver = this._mouseOver.bind(this);
-  }
-
   componentDidMount() {
     this._updateSeries();
   }
 
   componentDidUpdate() {
     this._updateSeries();
-  }
-
-  _mouseOver(d) {
-    const {onValueMouseOver, onSeriesMouseOver} = this.props;
-    if (onValueMouseOver) {
-      onValueMouseOver(d, {event: d3Selection.event});
-    }
-    if (onSeriesMouseOver) {
-      onSeriesMouseOver({event: d3Selection.event});
-    }
-  }
-
-  _mouseOut(d) {
-    const {onValueMouseOut, onSeriesMouseOut} = this.props;
-    if (onValueMouseOut) {
-      onValueMouseOut(d, {event: d3Selection.event});
-    }
-    if (onSeriesMouseOut) {
-      onSeriesMouseOut({event: d3Selection.event});
-    }
   }
 
   _updateSeries() {
@@ -85,8 +59,9 @@ class AreaSeries extends AbstractSeries {
     const d = line(data);
 
     const path = d3Selection.select(lineElement)
-      .on('mouseover', this._onMouseOver)
-      .on('mouseout', this._onMouseOut);
+      .on('mouseover', this._mouseOver)
+      .on('mouseout', this._mouseOut)
+      .on('click', this._click);
 
     this._applyTransition(path)
       .attr('d', d)

--- a/src/lib/plot/series/bar-series.js
+++ b/src/lib/plot/series/bar-series.js
@@ -36,48 +36,12 @@ class BarSeries extends AbstractSeries {
     };
   }
 
-  constructor(props) {
-    super(props);
-    this._mouseOver = this._mouseOver.bind(this);
-    this._mouseOut = this._mouseOut.bind(this);
-  }
-
   componentDidMount() {
     this._updateSeries();
   }
 
   componentDidUpdate() {
     this._updateSeries();
-  }
-
-  /**
-   * Mouseover handler. Triggers mouseover-related actions if they were set.
-   * @param {Object} d Data point.
-   * @private
-   */
-  _mouseOver(d) {
-    const {onValueMouseOver, onSeriesMouseOver} = this.props;
-    if (onValueMouseOver) {
-      onValueMouseOver(d, {event: d3Selection.event});
-    }
-    if (onSeriesMouseOver) {
-      onSeriesMouseOver({event: d3Selection.event});
-    }
-  }
-
-  /**
-   * Mouseout handler. Triggers mouseout-related actions if they were set.
-   * @param {Object} d Data point.
-   * @private
-   */
-  _mouseOut(d) {
-    const {onValueMouseOut, onSeriesMouseOut} = this.props;
-    if (onValueMouseOut) {
-      onValueMouseOut(d, {event: d3Selection.event});
-    }
-    if (onSeriesMouseOut) {
-      onSeriesMouseOut({event: d3Selection.event});
-    }
   }
 
   _updateSeries() {
@@ -110,8 +74,9 @@ class BarSeries extends AbstractSeries {
 
     const rects = d3Selection.select(container).selectAll('rect')
       .data(data)
-      .on('mouseover', this._mouseOver)
-      .on('mouseout', this._mouseOut);
+      .on('mouseover', this._mouseOverWithValue)
+      .on('mouseout', this._mouseOutWithValue)
+      .on('click', this._clickWithValue);
 
     const itemSize = (distance / 2) * 0.85;
 

--- a/src/lib/plot/series/heatmap-series.js
+++ b/src/lib/plot/series/heatmap-series.js
@@ -31,38 +31,12 @@ class HeatmapSeries extends AbstractSeries {
     return {isDomainAdjustmentNeeded};
   }
 
-  constructor(props) {
-    super(props);
-    this._mouseOver = this._mouseOver.bind(this);
-    this._mouseOut = this._mouseOut.bind(this);
-  }
-
   componentDidMount() {
     this._updateSeries();
   }
 
   componentDidUpdate() {
     this._updateSeries();
-  }
-
-  _mouseOver(d) {
-    const {onValueMouseOver, onSeriesMouseOver} = this.props;
-    if (onValueMouseOver) {
-      onValueMouseOver(d, {event: d3Selection.event});
-    }
-    if (onSeriesMouseOver) {
-      onSeriesMouseOver({event: d3Selection.event});
-    }
-  }
-
-  _mouseOut(d) {
-    const {onValueMouseOut, onSeriesMouseOut} = this.props;
-    if (onValueMouseOut) {
-      onValueMouseOut(d, {event: d3Selection.event});
-    }
-    if (onSeriesMouseOut) {
-      onSeriesMouseOut({event: d3Selection.event});
-    }
   }
 
   _updateSeries() {
@@ -78,8 +52,9 @@ class HeatmapSeries extends AbstractSeries {
 
     const rects = d3Selection.select(container).selectAll('rect')
       .data(data)
-      .on('mouseover', this._mouseOver)
-      .on('mouseout', this._mouseOut);
+      .on('mouseover', this._mouseOverWithValue)
+      .on('mouseout', this._mouseOutWithValue)
+      .on('click', this._clickWithValue);
 
     this._applyTransition(rects)
       .style('opacity', this._getAttributeFunctor('opacity'))

--- a/src/lib/plot/series/line-series.js
+++ b/src/lib/plot/series/line-series.js
@@ -41,32 +41,12 @@ class LineSeries extends AbstractSeries {
     };
   }
 
-  constructor(props) {
-    super(props);
-    this._mouseOver = this._mouseOver.bind(this);
-    this._mouseOut = this._mouseOut.bind(this);
-  }
-
   componentDidMount() {
     this._updateSeries();
   }
 
   componentDidUpdate() {
     this._updateSeries();
-  }
-
-  _mouseOver() {
-    const {onSeriesMouseOver} = this.props;
-    if (onSeriesMouseOver) {
-      onSeriesMouseOver({event: d3Selection.event});
-    }
-  }
-
-  _mouseOut() {
-    const {onSeriesMouseOut} = this.props;
-    if (onSeriesMouseOut) {
-      onSeriesMouseOut({event: d3Selection.event});
-    }
   }
 
   _updateSeries() {
@@ -84,7 +64,8 @@ class LineSeries extends AbstractSeries {
     const d = line(data);
     const path = d3Selection.select(lineElement)
       .on('mouseover', this._mouseOver)
-      .on('mouseout', this._mouseOut);
+      .on('mouseout', this._mouseOut)
+      .on('click', this._click);
     this._applyTransition(path)
       .attr('d', d)
       .style('stroke', stroke)

--- a/src/lib/plot/series/mark-series.js
+++ b/src/lib/plot/series/mark-series.js
@@ -28,38 +28,12 @@ import {DEFAULT_SIZE, DEFAULT_OPACITY} from '../../theme';
 
 class MarkSeries extends AbstractSeries {
 
-  constructor(props) {
-    super(props);
-    this._mouseOver = this._mouseOver.bind(this);
-    this._mouseOut = this._mouseOut.bind(this);
-  }
-
   componentDidMount() {
     this._updateSeries();
   }
 
   componentDidUpdate() {
     this._updateSeries();
-  }
-
-  _mouseOver(d) {
-    const {onValueMouseOver, onSeriesMouseOver} = this.props;
-    if (onValueMouseOver) {
-      onValueMouseOver(d, {event: d3Selection.event});
-    }
-    if (onSeriesMouseOver) {
-      onSeriesMouseOver({event: d3Selection.event});
-    }
-  }
-
-  _mouseOut(d) {
-    const {onValueMouseOut, onSeriesMouseOut} = this.props;
-    if (onValueMouseOut) {
-      onValueMouseOut(d, {event: d3Selection.event});
-    }
-    if (onSeriesMouseOut) {
-      onSeriesMouseOut({event: d3Selection.event});
-    }
   }
 
   _updateSeries() {
@@ -70,8 +44,9 @@ class MarkSeries extends AbstractSeries {
     }
     const circles = d3Selection.select(container).selectAll('circle')
       .data(data)
-      .on('mouseover', this._mouseOver)
-      .on('mouseout', this._mouseOut);
+      .on('mouseover', this._mouseOverWithValue)
+      .on('mouseout', this._mouseOutWithValue)
+      .on('click', this._clickWithValue);
 
     // TODO(anton): radius should be the half of the size.
     this._applyTransition(circles)


### PR DESCRIPTION
- Click handler was added to the series.
- All event listeners are moved to AbstractSeries to avoid code duplication.
- Event listeners for area series are fixed (didn't work previously).

This PR fixes #81 and also a freshly found bug (no mouse interactions with area series work)