### PR TITLE
Eliminate the use of external fonts for the library

### DIFF
--- a/src/example/main.scss
+++ b/src/example/main.scss
@@ -1,3 +1,5 @@
+@import url(https://fonts.googleapis.com/css?family=Sintony:400,700);
+
 @import "../main";
 
 body {

--- a/src/main.scss
+++ b/src/main.scss
@@ -1,7 +1,3 @@
-@import url(https://fonts.googleapis.com/css?family=Sintony:400,700);
-
-$rv-font-family: 'Sintony', sans-serif;
-
 @import "styles/treemap";
 @import "styles/table";
 @import "styles/plot";

--- a/src/styles/plot.scss
+++ b/src/styles/plot.scss
@@ -12,7 +12,6 @@ $rv-xy-plot-tooltip-padding: 7px 10px;
 .rv-xy-plot {
   color: #c3c3c3;
   position: relative;
-  font-family: $rv-font-family;
 }
 
 .rv-xy-plot__inner {

--- a/src/styles/treemap.scss
+++ b/src/styles/treemap.scss
@@ -1,5 +1,4 @@
 .rv-treemap {
-  font-family: $rv-font-family;
   font-size: 12px;
   position: relative;
 }


### PR DESCRIPTION
Previous decision of having external custom fonts in the library was questionable. External fonts are removed from the library and applied in examples only. The user may define his own fonts in the body of the document and the fonts will be picked up well.

This PR fixes #82 