### PR TITLE
Add time-utc scale, similar to d3.time.scale.utc

### DIFF
--- a/docs/scales-and-data.md
+++ b/docs/scales-and-data.md
@@ -37,5 +37,7 @@ All scale properties are prepended with the name of the attribute, for instance 
     Categorical scale, each new value gets the next value from the range. Similar to d3.scale.category\[Number\], but works with other values besides colors.
     * `'time'`  
     Time scale. Similar to [d3.time.scale](https://github.com/mbostock/d3/wiki/Time-Scales).
+    * `'time-utc'`  
+    Time UTC scale. Similar to [d3.time.scale.utc](https://github.com/d3/d3/wiki/Time-Scales#utc).
     * `'log'`  
     Log scale. Similar to [d3.scale.log](https://github.com/mbostock/d3/wiki/Quantitative-Scales#log).

--- a/src/lib/utils/scales-utils.js
+++ b/src/lib/utils/scales-utils.js
@@ -65,6 +65,13 @@ const LOG_SCALE_TYPE = 'log';
 const TIME_SCALE_TYPE = 'time';
 
 /**
+ * Time UTC scale name.
+ * @type {string}
+ * @const
+ */
+const TIME_UTC_SCALE_TYPE = 'time-utc';
+
+/**
  * Scale functions that are supported in the library.
  * @type {Object}
  * @const
@@ -74,7 +81,8 @@ const SCALE_FUNCTIONS = {
   [ORDINAL_SCALE_TYPE]: d3Scale.scaleOrdinal,
   [CATEGORY_SCALE_TYPE]: d3Scale.scaleOrdinal,
   [LOG_SCALE_TYPE]: d3Scale.scaleLog,
-  [TIME_SCALE_TYPE]: d3Scale.scaleTime
+  [TIME_SCALE_TYPE]: d3Scale.scaleTime,
+  [TIME_UTC_SCALE_TYPE]: d3Scale.scaleUtc
 };
 
 /**


### PR DESCRIPTION
Tested locally by modifying `src/example/plot/time-chart.js` to use `time-utc`.