### PR TITLE
Added simple legend for plot charts

### DIFF
--- a/src/example/main.js
+++ b/src/example/main.js
@@ -51,6 +51,8 @@ import SimpleRadialChart from './radial-chart/simple-radial-chart';
 
 import CustomRadiusRadialChart from './radial-chart/custom-radius-radial-chart';
 
+import Legend from './plot/legend';
+
 import {isReactDOMSupported} from '../lib/utils/react-utils';
 
 const examples = (
@@ -135,6 +137,10 @@ const examples = (
         <h3>Time Chart</h3>
         <TimeChart />
       </section>
+      <section>
+        <h3>Legend</h3>
+        <Legend />
+      </section>
 
       <h1>Radial Chart</h1>
       <section>
@@ -167,6 +173,7 @@ const examples = (
         <p>Updates each 5 seconds</p>
         <DynamicTable />
       </section>
+
     </article>
   </main>
 );

--- a/src/example/plot/legend.js
+++ b/src/example/plot/legend.js
@@ -1,0 +1,68 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import React from 'react';
+
+import {
+  XYPlot,
+  XAxis,
+  YAxis,
+  VerticalGridLines,
+  HorizontalGridLines,
+  VerticalBarSeries} from '../../';
+
+export default class Example extends React.Component {
+  render() {
+    return (
+      <XYPlot
+        width={300}
+        height={300}
+        hasLegend={true}
+        >
+        <VerticalGridLines />
+        <HorizontalGridLines />
+        <XAxis />
+        <YAxis />
+        <VerticalBarSeries
+          data={[
+            {x: 1, y: 10},
+            {x: 2, y: 5},
+            {x: 3, y: 15}
+          ]}
+          label="My Series"
+        />
+        <VerticalBarSeries
+          data={[
+            {x: 1, y: 12},
+            {x: 2, y: 2},
+            {x: 3, y: 11}
+          ]}
+        />
+        <VerticalBarSeries
+          data={[
+            {x: 1, y: 1},
+            {x: 2, y: 2},
+            {x: 3, y: 3}
+          ]}
+        />
+      </XYPlot>
+    );
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -42,6 +42,9 @@ export {default as YAxis} from './lib/plot/y-axis';
 export {default as VerticalGridLines} from './lib/plot/vertical-grid-lines';
 export {default as HorizontalGridLines} from './lib/plot/horizontal-grid-lines';
 
+export {default as Legend} from './lib/plot/legend';
+
 export {default as RadialChart} from './lib/radial-chart/radial-chart';
 
 export {default as makeWidthFlexible} from './lib/make-vis-flexible';
+

--- a/src/lib/plot/legend-item.js
+++ b/src/lib/plot/legend-item.js
@@ -1,0 +1,59 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import React, {Component} from 'react';
+import LegendPill from './legend-pill';
+
+class LegendItem extends Component {
+
+  static get propTypes() {
+    return {
+      color: React.PropTypes.string,
+      index: React.PropTypes.number,
+      label: React.PropTypes.string
+    };
+  }
+
+  static get defaultProps() {
+    return {
+      color: 'black'
+    };
+  }
+
+  render() {
+    const {props: {color, index, label}} = this;
+
+    return (
+      <div
+        className="rv-xy-plot__legend__item"
+        key={index}
+      >
+        <LegendPill color={color} label={label}/>
+        <h6 className="rv-xy-plot__legend__item__title">
+          {label || `Series ${index}`}
+        </h6>
+      </div>
+    );
+  }
+}
+
+LegendItem.displayName = 'LegendItem';
+
+export default LegendItem;

--- a/src/lib/plot/legend-pill.js
+++ b/src/lib/plot/legend-pill.js
@@ -1,0 +1,52 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import React, {Component} from 'react';
+
+class LegendPill extends Component {
+
+  static get propTypes() {
+    return {
+      color: React.PropTypes.string
+    };
+  }
+
+  static get defaultProps() {
+    return {
+      color: 'black'
+    };
+  }
+
+  render() {
+    const {props: {color}} = this;
+    return (
+      <span
+        className="rv-xy-plot__legend__pill"
+        style={{
+          backgroundColor: color
+        }}
+      />
+    );
+  }
+}
+
+LegendPill.displayName = 'LegendPill';
+
+export default LegendPill;

--- a/src/lib/plot/legend.js
+++ b/src/lib/plot/legend.js
@@ -1,0 +1,52 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import React, {Component} from 'react';
+import LegendItem from './legend-item';
+import {color} from '../utils/series-utils';
+
+class Legend extends Component {
+
+  render() {
+    const {props: {data, seriesLabels = []}} = this;
+    let items;
+    if (data) {
+      items = data.map((series, index) => {
+        return (
+          <LegendItem
+            color={color(index)}
+            index={index}
+            key={index}
+            label={seriesLabels[index]}/>
+        );
+      });
+    }
+
+    return (
+      <div className="rv-xy-plot__legend">
+        {items}
+      </div>
+    );
+  }
+}
+
+Legend.displayName = 'Legend';
+
+export default Legend;

--- a/src/lib/plot/series/abstract-series.js
+++ b/src/lib/plot/series/abstract-series.js
@@ -50,7 +50,8 @@ export default class AbstractSeries extends PureRenderComponent {
       onSeriesMouseOut: React.PropTypes.func,
       onSeriesClick: React.PropTypes.func,
       onNearestX: React.PropTypes.func,
-      animation: AnimationPropType
+      animation: AnimationPropType,
+      label: React.PropTypes.string
     };
   }
 

--- a/src/lib/plot/xy-plot.js
+++ b/src/lib/plot/xy-plot.js
@@ -24,9 +24,11 @@ import equal from 'deep-equal';
 import {
   getStackedData,
   getSeriesChildren,
-  getSeriesPropsFromChildren} from '../utils/series-utils';
+  getSeriesPropsFromChildren,
+  getSeriesLabels} from '../utils/series-utils';
 
 import {getInnerDimensions} from '../utils/chart-utils';
+import Legend from './legend';
 
 import {
   CONTINUOUS_COLOR_RANGE,
@@ -61,7 +63,8 @@ class XYPlot extends React.Component {
       onMouseMove: React.PropTypes.func,
       onMouseEnter: React.PropTypes.func,
       animation: AnimationPropType,
-      stackBy: React.PropTypes.oneOf(ATTRIBUTES)
+      stackBy: React.PropTypes.oneOf(ATTRIBUTES),
+      hasLegend: React.PropTypes.bool
     };
   }
 
@@ -72,7 +75,8 @@ class XYPlot extends React.Component {
         right: 10,
         top: 10,
         bottom: 40
-      }
+      },
+      hasLegend: false
     };
   }
 
@@ -84,9 +88,11 @@ class XYPlot extends React.Component {
     const {stackBy} = props;
     const children = getSeriesChildren(props.children);
     const data = getStackedData(children, stackBy);
+    const seriesLabels = getSeriesLabels(children);
     this.state = {
       scaleMixins: this._getScaleMixins(data, props),
-      data
+      data,
+      seriesLabels
     };
   }
 
@@ -237,10 +243,11 @@ class XYPlot extends React.Component {
    * @private
    */
   _getClonedChildComponents() {
-    const {animation} = this.props;
-    const {scaleMixins, data} = this.state;
-    const dimensions = getInnerDimensions(this.props);
-    const children = React.Children.toArray(this.props.children);
+    const {props, state} = this;
+    const {animation} = props;
+    const {scaleMixins, data} = state;
+    const dimensions = getInnerDimensions(props);
+    const children = React.Children.toArray(props.children);
     const seriesProps = getSeriesPropsFromChildren(children);
     return children.map((child, index) => {
       let dataProps = null;
@@ -262,7 +269,8 @@ class XYPlot extends React.Component {
   }
 
   render() {
-    const {width, height} = this.props;
+    const {width, height, hasLegend} = this.props;
+    const {data, seriesLabels} = this.state;
 
     if (this._isPlotEmpty()) {
       return (
@@ -275,6 +283,8 @@ class XYPlot extends React.Component {
       );
     }
     const components = this._getClonedChildComponents();
+    const legend = hasLegend ?
+      <Legend data={data} seriesLabels={seriesLabels} /> : null;
 
     return (
       <div
@@ -283,6 +293,7 @@ class XYPlot extends React.Component {
           height: `${height}px`
         }}
         className="rv-xy-plot">
+        {legend}
         <svg
           className="rv-xy-plot__inner"
           width={width}

--- a/src/lib/utils/series-utils.js
+++ b/src/lib/utils/series-utils.js
@@ -124,8 +124,7 @@ export function getSeriesPropsFromChildren(children) {
     let props;
     if (isSeriesChild(child)) {
       const seriesTypeInfo = seriesTypesInfo[child.type.displayName];
-      const _colorValue = DISCRETE_COLOR_RANGE[seriesIndex %
-        DISCRETE_COLOR_RANGE.length];
+      const _colorValue = color(seriesIndex);
       props = {
         ...seriesTypeInfo,
         seriesIndex,
@@ -139,4 +138,27 @@ export function getSeriesPropsFromChildren(children) {
     result.push(props);
   });
   return result;
+}
+
+/**
+ * Returns a list of labels for all series.
+ * A label is defined by passing the prop "title" to a series element
+ * @param {Array} children
+ * @returns {Array} List of strings|null is title is not defined
+ */
+export function getSeriesLabels(children) {
+  return children.map(child => {
+    const {props: {label}} = child;
+    return label;
+  });
+}
+
+/**
+ * Return the color code for the given index.
+ * It is used to pick a color for a given series by pasing the series id
+ * @param {Integer} index
+ * @returns {string} the color code
+ */
+export function color(index) {
+  return DISCRETE_COLOR_RANGE[index % DISCRETE_COLOR_RANGE.length];
 }

--- a/src/styles/plot.scss
+++ b/src/styles/plot.scss
@@ -9,6 +9,11 @@ $rv-xy-plot-tooltip-border-radius: 4px;
 $rv-xy-plot-tooltip-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
 $rv-xy-plot-tooltip-padding: 7px 10px;
 
+$rv-xy-plot-legend-pill-width: 30px;
+$rv-xy-plot-legend-pill-height: 5px;
+$rv-xy-plot-legend-font-color: #000;
+$rv-xy-plot-legend-pill-border-radius: 5px 5px 5px 5px;
+
 .rv-xy-plot {
   color: #c3c3c3;
   position: relative;
@@ -59,6 +64,27 @@ $rv-xy-plot-tooltip-padding: 7px 10px;
   fill: none;
   stroke: #000;
   stroke-width: 2px;
+}
+
+.rv-xy-plot__legend__item {
+  display: inline-block;
+  margin-left: 5px;
+  margin-right: 5px;
+}
+
+.rv-xy-plot__legend__item__title {
+  color: $rv-xy-plot-legend-font-color;
+  margin: 5px 0;
+}
+
+.rv-xy-plot__legend__pill {
+  display: block;
+  width: $rv-xy-plot-legend-pill-width;
+  height: $rv-xy-plot-legend-pill-height;
+  background-color: $rv-xy-plot-legend-font-color;
+  border-radius: $rv-xy-plot-legend-pill-border-radius;
+  -moz-border-radius: $rv-xy-plot-legend-pill-border-radius;
+  -webkit-border-radius: $rv-xy-plot-legend-pill-border-radius;
 }
 
 .rv-crosshair {

--- a/src/test/xy-plot.js
+++ b/src/test/xy-plot.js
@@ -24,6 +24,7 @@ import {shallow} from 'enzyme';
 import VerticalBarSeries from '../lib/plot/series/vertical-bar-series';
 import XAxis from '../lib/plot/x-axis';
 import XYPlot from '../lib/plot/xy-plot';
+import Legend from '../lib/plot/legend';
 
 test('Render a stacked bar chart', assert => {
   const wrapper = shallow(
@@ -110,6 +111,63 @@ test('Render a stacked bar chart with other children', assert => {
     ],
     'Second bar series data contains y0 values'
   );
+
+  assert.end();
+});
+
+test('Render chart with no legend by default', assert => {
+  const wrapper = shallow(
+    <XYPlot
+      width={300}
+      height={300}>
+      <XAxis />
+      <VerticalBarSeries
+        data={[
+          {x: 1, y: 0}
+        ]}
+      />
+      <VerticalBarSeries
+        data={[
+          {x: 1, y: 2}
+        ]}/>
+    </XYPlot>
+  );
+
+  const renderedLegendWrapper = wrapper.find(Legend);
+
+  assert.equal(
+    renderedLegendWrapper.length,
+    0,
+    'Validating creation of 0 Legend element by default');
+
+  assert.end();
+});
+
+test('Render chart with legend', assert => {
+  const wrapper = shallow(
+    <XYPlot
+      width={300}
+      height={300}
+      hasLegend={true}>
+      <XAxis />
+      <VerticalBarSeries
+        data={[
+          {x: 1, y: 0}
+        ]}
+      />
+      <VerticalBarSeries
+        data={[
+          {x: 1, y: 2}
+        ]}/>
+    </XYPlot>
+  );
+
+  const renderedLegendWrapper = wrapper.find(Legend);
+
+  assert.equal(
+    renderedLegendWrapper.length,
+    1,
+    'Validating creation of 1 Legend element');
 
   assert.end();
 });


### PR DESCRIPTION
The legend is being displayed on top of the chart. the legend item list is generated by reading all series along with their titles.
Title is new attribute for AbstractrSeries that is only used by Legend to diplay the name of serires along with its color.
If no title is provided the legend will display 'Series [index]' as label.

I added an example to the example page.

![screen shot 2016-06-09 at 9 59 42 am](https://cloud.githubusercontent.com/assets/2554552/15944136/fd9fe31e-2e40-11e6-943e-4f3915d052c5.png)
