### PR TITLE
Fix ordinal scales for d3 4.0

### DIFF
--- a/src/lib/utils/scales-utils.js
+++ b/src/lib/utils/scales-utils.js
@@ -78,7 +78,7 @@ const TIME_UTC_SCALE_TYPE = 'time-utc';
  */
 const SCALE_FUNCTIONS = {
   [LINEAR_SCALE_TYPE]: d3Scale.scaleLinear,
-  [ORDINAL_SCALE_TYPE]: d3Scale.scaleOrdinal,
+  [ORDINAL_SCALE_TYPE]: d3Scale.scalePoint,
   [CATEGORY_SCALE_TYPE]: d3Scale.scaleOrdinal,
   [LOG_SCALE_TYPE]: d3Scale.scaleLog,
   [TIME_SCALE_TYPE]: d3Scale.scaleTime,
@@ -128,10 +128,7 @@ function _getScaleFnFromScaleObject(scaleObject) {
     return null;
   }
   const {type, domain, range} = scaleObject;
-  if (type !== ORDINAL_SCALE_TYPE) {
-    return SCALE_FUNCTIONS[type]().domain(domain).range(range);
-  }
-  return SCALE_FUNCTIONS[type]().domain(domain).rangePoints(range, 1);
+  return SCALE_FUNCTIONS[type]().domain(domain).range(range);
 }
 
 /**


### PR DESCRIPTION
Ordinal scales don't support `.rangePoints()` method anymore, this functionality was moved to the new `scalePoint()` scale. This fix returns the previous behavior.

We should consider renaming scale type `ordinal` to something else: currently `ordinal` scale type is not an ordinal scale anymore.