### PR TITLE
Corrected documented default margin to be consistent with source

### DIFF
--- a/docs/xy-plot.md
+++ b/docs/xy-plot.md
@@ -84,7 +84,7 @@ Height of the component. The height should be passed.
 
 #### margin (optional)
 Type: `Object`  
-Default: `{left: 40, right: 40, top: 10, bottom: 10}`
+Default: `{left: 40, right: 10, top: 10, bottom: 40}`
 Margin around the chart.
 
 #### stackBy (optional)


### PR DESCRIPTION
The values in `xy-plot.md` are now consistent with the `defaultProps` of [`xy-plot.js:70`](https://github.com/uber/react-vis/blob/master/src/lib/plot/xy-plot.js#L70).