### PR TITLE
refine treemap doc

### DIFF
--- a/docs/treemap.md
+++ b/docs/treemap.md
@@ -15,6 +15,7 @@ Add the following code to your render function:
 ```jsx
 <Treemap
   title={'My New Treemap'}
+  width={300}
   height={300}
   data={
     {


### PR DESCRIPTION
Specify Treemap width in the example. Solved "Warning: Failed propType: Required prop `width` was not specified in `Treemap`. Check the render method of `App`".