### PR TITLE
Allow the user to apply margin as a single value or as a partial object

### DIFF
--- a/src/example/plot/width-height-margin.js
+++ b/src/example/plot/width-height-margin.js
@@ -26,7 +26,7 @@ export default class Example extends React.Component {
   render() {
     return (
       <XYPlot
-        margin={{left: 40, top: 40, right: 40, bottom: 40}}
+        margin={50}
         width={200}
         height={200}>
         <VerticalGridLines />

--- a/src/lib/plot/xy-plot.js
+++ b/src/lib/plot/xy-plot.js
@@ -26,7 +26,9 @@ import {
   getSeriesChildren,
   getSeriesPropsFromChildren} from '../utils/series-utils';
 
-import {getInnerDimensions} from '../utils/chart-utils';
+import {getInnerDimensions, MarginPropType} from '../utils/chart-utils';
+
+import {AnimationPropType} from '../utils/animation-utils';
 
 import {
   CONTINUOUS_COLOR_RANGE,
@@ -43,7 +45,12 @@ const ATTRIBUTES = [
   'size'
 ];
 
-import {AnimationPropType} from '../utils/animation-utils';
+const DEFAULT_MARGINS = {
+  left: 40,
+  right: 10,
+  top: 10,
+  bottom: 40
+};
 
 class XYPlot extends React.Component {
 
@@ -51,28 +58,12 @@ class XYPlot extends React.Component {
     return {
       width: React.PropTypes.number.isRequired,
       height: React.PropTypes.number.isRequired,
-      margin: React.PropTypes.oneOfType([React.PropTypes.shape({
-        left: React.PropTypes.number,
-        top: React.PropTypes.number,
-        right: React.PropTypes.number,
-        bottom: React.PropTypes.number
-      }), React.PropTypes.number]),
+      margin: MarginPropType,
       onMouseLeave: React.PropTypes.func,
       onMouseMove: React.PropTypes.func,
       onMouseEnter: React.PropTypes.func,
       animation: AnimationPropType,
       stackBy: React.PropTypes.oneOf(ATTRIBUTES)
-    };
-  }
-
-  static get defaultProps() {
-    return {
-      margin: {
-        left: 40,
-        right: 10,
-        top: 10,
-        bottom: 40
-      }
     };
   }
 
@@ -153,7 +144,10 @@ class XYPlot extends React.Component {
    * @private
    */
   _getScaleDefaults(props) {
-    const {innerWidth, innerHeight} = getInnerDimensions(props);
+    const {innerWidth, innerHeight} = getInnerDimensions(
+      props,
+      DEFAULT_MARGINS
+    );
     return {
       xRange: [0, innerWidth],
       yRange: [innerHeight, 0],
@@ -239,7 +233,7 @@ class XYPlot extends React.Component {
   _getClonedChildComponents() {
     const {animation} = this.props;
     const {scaleMixins, data} = this.state;
-    const dimensions = getInnerDimensions(this.props);
+    const dimensions = getInnerDimensions(this.props, DEFAULT_MARGINS);
     const children = React.Children.toArray(this.props.children);
     const seriesProps = getSeriesPropsFromChildren(children);
     return children.map((child, index) => {

--- a/src/lib/radial-chart/radial-chart.js
+++ b/src/lib/radial-chart/radial-chart.js
@@ -25,7 +25,7 @@ import * as d3Shape from 'd3-shape';
 
 import {getAttributeFunctor} from '../utils/scales-utils';
 
-import {getInnerDimensions} from '../utils/chart-utils';
+import {getInnerDimensions, MarginPropType} from '../utils/chart-utils';
 
 import {AnimationPropType, applyTransition} from '../utils/animation-utils';
 
@@ -45,6 +45,13 @@ const ATTRIBUTES = [
   'stroke'
 ];
 
+const DEFAULT_MARGINS = {
+  left: 10,
+  right: 10,
+  top: 10,
+  bottom: 10
+};
+
 /**
  * Walk through the data and assign color property to the data points if it
  * doesn't exist.
@@ -62,27 +69,11 @@ export default class RadialChart extends React.Component {
     return {
       width: React.PropTypes.number.isRequired,
       height: React.PropTypes.number.isRequired,
-      margin: React.PropTypes.shape({
-        left: React.PropTypes.number,
-        top: React.PropTypes.number,
-        right: React.PropTypes.number,
-        bottom: React.PropTypes.number
-      }),
+      margin: MarginPropType,
       animation: AnimationPropType,
       onSectionMouseOver: React.PropTypes.func,
       onSectionMouseOut: React.PropTypes.func,
       onSectionClick: React.PropTypes.func
-    };
-  }
-
-  static get defaultProps() {
-    return {
-      margin: {
-        left: 10,
-        right: 10,
-        top: 10,
-        bottom: 10
-      }
     };
   }
 
@@ -169,7 +160,10 @@ export default class RadialChart extends React.Component {
    * @private
    */
   _getScaleDefaults(props) {
-    const {innerWidth, innerHeight} = getInnerDimensions(props);
+    const {innerWidth, innerHeight} = getInnerDimensions(
+      props,
+      DEFAULT_MARGINS
+    );
     const radius = Math.min(innerWidth / 2, innerHeight / 2);
     return {
       radiusRange: [0, radius],
@@ -261,7 +255,10 @@ export default class RadialChart extends React.Component {
 
   render() {
     const {data, width, height} = this.props;
-    const {innerWidth, innerHeight} = getInnerDimensions(this.props);
+    const {innerWidth, innerHeight} = getInnerDimensions(
+      this.props,
+      DEFAULT_MARGINS
+    );
     return (
       <div
         style={{

--- a/src/lib/utils/chart-utils.js
+++ b/src/lib/utils/chart-utils.js
@@ -18,23 +18,35 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {getSeriesChildren} from './series-utils';
+import React from 'react';
 
 /**
  * Get the dimensions of the component for the future use.
  * @param {Object} props Props.
+ * @param {Object} defaultMargins Object with default margins.
  * @returns {Object} Dimensions of the component.
  */
-export function getInnerDimensions(props) {
+export function getInnerDimensions(props, defaultMargins) {
+  const {margin, width, height} = props;
+  const marginProps = {
+    ...defaultMargins,
+    ...(
+      typeof margin === 'number' ?
+        {
+          left: margin,
+          right: margin,
+          top: margin,
+          bottom: margin
+        } :
+        margin
+    )
+  };
   const {
-    height,
-    width,
-    margin: {
-      left: marginLeft = 0,
-      top: marginTop = 0,
-      right: marginRight = 0,
-      bottom: marginBottom = 0}
-    } = props;
+    left: marginLeft = 0,
+    top: marginTop = 0,
+    right: marginRight = 0,
+    bottom: marginBottom = 0
+  } = marginProps;
   return {
     marginLeft,
     marginTop,
@@ -45,12 +57,12 @@ export function getInnerDimensions(props) {
   };
 }
 
-/**
- * Collect data from the list of children.
- * @param {Object} props Props for the plot.
- * @returns {Array} Array of arrays with data.
- */
-export function getDataFromChildren(props) {
-  const {children} = props;
-  return getSeriesChildren(children).map(child => child.props.data);
-}
+export const MarginPropType = React.PropTypes.oneOfType([
+  React.PropTypes.shape({
+    left: React.PropTypes.number,
+    top: React.PropTypes.number,
+    right: React.PropTypes.number,
+    bottom: React.PropTypes.number
+  }),
+  React.PropTypes.number
+]);


### PR DESCRIPTION
- Now you no longer need to pass an object with all sides (e.g. `left`, `right`, `top` and `bottom`): partial objects such as `{left: 1000}` are accepted.
- The defaults are applied on top of the margins.
- The user is allowed to pass a number for all margins instead of an object (will be applied to all sides).