### PR TITLE
Fix the duplicate axis values

### DIFF
--- a/src/lib/plot/axis/axis-ticks.js
+++ b/src/lib/plot/axis/axis-ticks.js
@@ -45,9 +45,9 @@ function _getTickTextAttributes(orientation) {
   };
 }
 
-function _getTickFormatFn(scale, tickFormat) {
+function _getTickFormatFn(scale, tickTotal, tickFormat) {
   return !tickFormat ?
-    (scale.tickFormat ? scale.tickFormat() : v => v) :
+    (scale.tickFormat ? scale.tickFormat(tickTotal) : v => v) :
     tickFormat;
 }
 
@@ -81,7 +81,7 @@ function AxisTicks(props) {
   const wrap = (orientation === LEFT || orientation === TOP) ? -1 : 1;
 
   const values = _getTickValues(scale, tickTotal, tickValues);
-  const tickFormatFn = _getTickFormatFn(scale, tickFormat);
+  const tickFormatFn = _getTickFormatFn(scale, tickTotal, tickFormat);
 
   const tickXAttr = isVertical ? 'y' : 'x';
   const tickYAttr = isVertical ? 'x' : 'y';


### PR DESCRIPTION
Previously the axis values were duplicated due to the bad formatting of the labels ('1, 1, 2, 2' were shown instead of '1, 1.5, 2, 2.5'). This change adds a missing parameter to the format funciton and fixes this issue