### PR TITLE
Do not recreate the domain each time when the scale is passed

### DIFF
--- a/src/example/radial-chart/simple-radial-chart.js
+++ b/src/example/radial-chart/simple-radial-chart.js
@@ -33,6 +33,7 @@ export default class SimpleRadialChart extends React.Component {
           {angle: 3},
           {angle: 5}
         ]}
+        onSectionClick={(d, i) => console.log(d, i)}
         width={300}
         height={300} />
     );

--- a/src/example/radial-chart/simple-radial-chart.js
+++ b/src/example/radial-chart/simple-radial-chart.js
@@ -33,7 +33,6 @@ export default class SimpleRadialChart extends React.Component {
           {angle: 3},
           {angle: 5}
         ]}
-        onSectionClick={(d, i) => console.log(d, i)}
         width={300}
         height={300} />
     );

--- a/src/lib/plot/xy-plot.js
+++ b/src/lib/plot/xy-plot.js
@@ -182,9 +182,6 @@ class XYPlot extends React.Component {
 
     // Make sure that the domain is set and pass the domain as well.
     ATTRIBUTES.forEach(attr => {
-      if (!attrProps[`${attr}Type`]) {
-        attrProps[`${attr}Type`] = 'linear';
-      }
       if (!attrProps[`${attr}Domain`]) {
         attrProps[`${attr}Domain`] = getDomainByAttr(
           allData,

--- a/src/lib/treemap/treemap.js
+++ b/src/lib/treemap/treemap.js
@@ -22,7 +22,7 @@ import React from 'react';
 import * as d3Hierarchy from 'd3-hierarchy';
 import * as d3Color from 'd3-color';
 import {getCSSAnimation, AnimationPropType} from '../utils/animation-utils';
-import {getAttributeFunctor} from '../utils/scales-utils';
+import {getAttributeFunctor, getMissingScaleProps} from '../utils/scales-utils';
 import {CONTINUOUS_COLOR_RANGE, DEFAULT_COLOR, OPACITY_RANGE} from '../theme';
 
 const TREEMAP_TILE_MODES = {
@@ -38,6 +38,8 @@ function getFontColorFromBackground(background) {
   }
   return null;
 }
+
+const ATTRIBUTES = ['opacity', 'color'];
 
 class Treemap extends React.Component {
 
@@ -86,12 +88,14 @@ class Treemap extends React.Component {
    */
   _getScaleFns(props) {
     const {data} = props;
+    const allData = data.children || [];
 
     // Adding _allData property to the object to reuse the existing
     // getAttributeFunctor function.
     const compatibleProps = {
       ...props,
-      _allData: data.children || []
+      ...getMissingScaleProps(props, allData, ATTRIBUTES),
+      _allData: allData
     };
     return {
       opacity: getAttributeFunctor(compatibleProps, 'opacity'),

--- a/src/lib/utils/scales-utils.js
+++ b/src/lib/utils/scales-utils.js
@@ -571,3 +571,47 @@ export function getScalePropTypesByAttribute(attr) {
     [`${attr}BaseValue`]: React.PropTypes.any
   };
 }
+
+/**
+ * Extract the list of scale properties from the entire props object.
+ * @param {Object} props Props.
+ * @param {Array<String>} attributes Array of attributes for the given
+ * components (for instance, `['x', 'y', 'color']`).
+ * @returns {Object} Collected props.
+ */
+export function extractScalePropsFromProps(props, attributes) {
+  const result = {};
+  Object.keys(props).forEach(key => {
+    const attr = attributes.find(
+      a => key.indexOf(a) === 0 || key.indexOf(`_${a}`) === 0);
+    if (!attr) {
+      return;
+    }
+    result[key] = props[key];
+  });
+  return result;
+}
+
+/**
+ * Extract the missing scale props from the given data and return them as
+ * an object.
+ * @param {Object} props Props.
+ * @param {Array} data Array of all data.
+ * @param {Array<String>} attributes Array of attributes for the given
+ * components (for instance, `['x', 'y', 'color']`).
+ * @returns {Object} Collected props.
+ */
+export function getMissingScaleProps(props, data, attributes) {
+  const result = {};
+  // Make sure that the domain is set and pass the domain as well.
+  attributes.forEach(attr => {
+    if (!props[`${attr}Domain`]) {
+      result[`${attr}Domain`] = getDomainByAttr(
+        data,
+        attr,
+        props[`${attr}Type`]
+      );
+    }
+  });
+  return result;
+}

--- a/src/lib/utils/scales-utils.js
+++ b/src/lib/utils/scales-utils.js
@@ -143,7 +143,7 @@ function _getScaleFnFromScaleObject(scaleObject) {
  * @returns {Array} Domain.
  * @private
  */
-function _getDomainByAttr(allData, attr, type) {
+export function getDomainByAttr(allData, attr, type) {
   let domain;
   const attr0 = `${attr}0`;
 
@@ -230,25 +230,22 @@ function _createScaleObjectForFunction(
  */
 function _collectScaleObjectFromProps(props, attr) {
   const {
-    _allData: data = [],
     [attr]: value,
     [`_${attr}Value`]: fallbackValue,
-    [`${attr}Domain`]: initialDomain,
     [`${attr}Range`]: range,
     [`${attr}Distance`]: distance = 0,
     [`${attr}BaseValue`]: baseValue,
-    [`${attr}Type`]: type = LINEAR_SCALE_TYPE} = props;
+    [`${attr}Type`]: type} = props;
+
+  let {[`${attr}Domain`]: domain} = props;
 
   // Return value-based scale if the value is assigned.
   if (typeof value !== 'undefined') {
     return _createScaleObjectForValue(attr, value);
   }
-  const filteredData = data.filter(d => d);
-  const allData = [].concat(...filteredData);
 
   // Pick up the domain from the properties and create a new one if it's not
   // available.
-  let domain = initialDomain || _getDomainByAttr(allData, attr, type);
   if (typeof baseValue !== 'undefined') {
     domain = addValueToArray(domain, baseValue);
   }

--- a/src/lib/utils/scales-utils.js
+++ b/src/lib/utils/scales-utils.js
@@ -235,7 +235,7 @@ function _collectScaleObjectFromProps(props, attr) {
     [`${attr}Range`]: range,
     [`${attr}Distance`]: distance = 0,
     [`${attr}BaseValue`]: baseValue,
-    [`${attr}Type`]: type} = props;
+    [`${attr}Type`]: type = LINEAR_SCALE_TYPE} = props;
 
   let {[`${attr}Domain`]: domain} = props;
 
@@ -251,7 +251,7 @@ function _collectScaleObjectFromProps(props, attr) {
   }
 
   // Make sure that the minimum necessary properties exist.
-  if (!range || !domain.length) {
+  if (!range || !domain || !domain.length) {
     // Try to use the fallback value if it is available.
     return _createScaleObjectForValue(attr, fallbackValue);
   }

--- a/src/test/components.js
+++ b/src/test/components.js
@@ -92,13 +92,21 @@ const XYPLOT_SERIES_PROPS = {
 const XYPLOT_XAXIS_PROPS = {
   xRange: [0, 1],
   xDomain: [0, 1],
-  xType: 'linear'
+  xType: 'linear',
+  width: 100,
+  height: 100,
+  top: 0,
+  left: 0
 };
 
 const XYPLOT_YAXIS_PROPS = {
   yRange: [0, 1],
   yDomain: [0, 1],
-  yType: 'linear'
+  yType: 'linear',
+  width: 100,
+  height: 100,
+  top: 0,
+  left: 0
 };
 
 const XYPLOT_PROPS = {width: 10, height: 10};

--- a/src/test/scales-utils.js
+++ b/src/test/scales-utils.js
@@ -187,7 +187,7 @@ test('scales-utils/extractScalePropsFromProps', function t(assert) {
     bDomain: [1, 2, 3]
   };
   const result = extractScalePropsFromProps(props, ['a', 'b']);
-  assert.ok(Object.keys(result).length == 4 && result.aType === props.aType &&
+  assert.ok(Object.keys(result).length === 4 && result.aType === props.aType &&
     result.aRange === props.aRange && result._aValue === props._aValue &&
     result.bDomain === props.bDomain,
     'Should return valid object');

--- a/src/test/scales-utils.js
+++ b/src/test/scales-utils.js
@@ -49,19 +49,17 @@ test('scales-utils/getScaleObjectFromProps with empty props', function t(
   assert.end();
 });
 
-test('scales-utils/getScaleObjectFromProps with empty range', function t(
+test('scales-utils/getScaleObjectFromProps with empty domain', function t(
   assert) {
-  const noRangeResult = getScaleObjectFromProps({_allData}, 'x');
-  assert.ok(noRangeResult === null, 'Should be null if no range is passed');
+  const noRangeResult = getScaleObjectFromProps({xDomain}, 'x');
+  assert.ok(noRangeResult === null, 'Should be null if no domain is passed');
   assert.end();
 });
 
-test('scales-utils/getScaleObjectFromProps with incomplete props', function t(
+test('scales-utils/getScaleObjectFromProps with empty range', function t(
   assert) {
-  const incompleteResult = getScaleObjectFromProps({xRange, _allData}, 'x');
-  assert.ok(isScaleConsistent(incompleteResult, 'x'),
-    'Should be a consistent scale');
-  assert.ok(incompleteResult.type === 'linear', 'Should be linear by detault');
+  const noDomainResult = getScaleObjectFromProps({xRange}, 'x');
+  assert.ok(noDomainResult === null, 'Should be null if no range is passed');
   assert.end();
 });
 
@@ -117,7 +115,7 @@ test('scales-utils/getAttributeFunctor without props', function t(assert) {
 });
 
 test('scales-utils/getAttributeFunctor with props', function t(assert) {
-  const result = getAttributeFunctor({xRange, _allData}, 'x');
+  const result = getAttributeFunctor({xRange, xDomain}, 'x');
   const isFunction = typeof result === 'function';
   assert.ok(isFunction, 'Result should be a function');
   if (isFunction) {
@@ -134,7 +132,7 @@ test('scales-utils/getAttributeScale without props', function t(assert) {
 });
 
 test('scales-utils/getAttributeScale with props', function t(assert) {
-  const result = getAttributeScale({xRange, _allData}, 'x');
+  const result = getAttributeScale({xRange, xDomain}, 'x');
   const isFunction = typeof result === 'function';
   assert.ok(isFunction, 'Result should be a function');
   if (isFunction) {

--- a/src/test/scales-utils.js
+++ b/src/test/scales-utils.js
@@ -20,14 +20,15 @@
 
 import test from 'tape';
 import 'babel-polyfill';
-
 import {
   getScaleObjectFromProps,
   getScalePropTypesByAttribute,
   getAttributeFunctor,
   getAttributeScale,
   getAttributeValue,
-  _getSmallestDistanceIndex
+  _getSmallestDistanceIndex,
+  extractScalePropsFromProps,
+  getMissingScaleProps
 } from '../lib/utils/scales-utils';
 
 function isScaleConsistent(scaleObject, attr) {
@@ -171,4 +172,34 @@ test('scales-utils/_getSmallestDistanceIndex', function t(assert) {
   function runTest(arg) {
     return _getSmallestDistanceIndex(arg, scaleObj);
   }
+});
+
+test('scales-utils/extractScalePropsFromProps', function t(assert) {
+  assert.ok(
+    Object.keys(extractScalePropsFromProps({}, [])).length === 0,
+    'Should return empty object on empty values'
+  );
+  const props = {
+    aType: 'linear',
+    aRange: [1, 2],
+    _aValue: 10,
+    somethingElse: [],
+    bDomain: [1, 2, 3]
+  };
+  const result = extractScalePropsFromProps(props, ['a', 'b']);
+  assert.ok(Object.keys(result).length == 4 && result.aType === props.aType &&
+    result.aRange === props.aRange && result._aValue === props._aValue &&
+    result.bDomain === props.bDomain,
+    'Should return valid object');
+  assert.end();
+});
+
+test('scales-utils/getMissingScaleProps', function t(assert) {
+  assert.ok(Object.keys(getMissingScaleProps({}, [], [])).length === 0,
+    'Should return empty result on empty arguments');
+  const result = getMissingScaleProps({}, _allData[0], ['x']);
+  assert.ok(Boolean(result.xDomain) && result.xDomain.length === 2 &&
+    result.xDomain[0] === 1 && result.xDomain[1] === 3,
+    'Should return a valid object');
+  assert.end();
 });

--- a/src/test/series-utils.js
+++ b/src/test/series-utils.js
@@ -35,7 +35,11 @@ test('series-utils/isSeriesChild', function t(assert) {
   const axis = React.createElement(XAxis, {
     xRange: [0, 1],
     xDomain: [0, 1],
-    xType: 'linear'
+    xType: 'linear',
+    width: 100,
+    height: 100,
+    top: 0,
+    left: 0
   });
   assert.notOk(isSeriesChild(axis), 'Should return false for non-series');
   assert.end();


### PR DESCRIPTION
The parent picks up the domain from all values that are being passed **and** passes this domain for the children. It helps to reduce the excessive computation of the values, eliminates the use of `_allData` array and helps to run the components separately from the parent.