### PR TITLE
Updates for DiscreteColorLegend: default colors, slight API changes, etc

### DIFF
--- a/docs/legends.md
+++ b/docs/legends.md
@@ -14,8 +14,8 @@ Currently following types of legends are supported:
 ### DiscreteColorLegend
 
 #### items (required)
-Type: `Array<{title: string, color: String}>`  
-Array of items that should be shown on the legend.
+Type: `Array<string|{title: string, color: String, disabled: boolean}>`  
+Array of items that should be shown on the legend. The array should consist from either objects (`title`, optional `color` and optional `disabled` flag) or strings (treated as titles). 
 
 #### onItemClick
 Type: `function(Object, number): void`  

--- a/docs/xy-plot.md
+++ b/docs/xy-plot.md
@@ -281,7 +281,10 @@ Exact opacity for all series points in pixels or a series object.
 #### onNearestX (optional)
 Type: `function(value, info)`  
 A callback function which is triggered each time when the mouse pointer gets close to some X value.
-Callback is triggered with two arguments. `value` is the data point, `info` consists of `innerX` (the left position of the value) and `event` (the React event).
+Callback is triggered with two arguments. `value` is the data point, `info` object has following properties:
+- `innerX` is the left position of the value;
+- `index` is the index of the data point in the array of data;
+- `event` is the event object.
 
 #### onValueMouseOver (optional)
 Type: `function(d, info)`  

--- a/src/example/legends/discrete-color.js
+++ b/src/example/legends/discrete-color.js
@@ -19,42 +19,24 @@
 // THE SOFTWARE.
 
 import React from 'react';
+import {DiscreteColorLegend} from '../../';
 
-import {
-  DiscreteColorLegend} from '../../';
+const ITEMS = [
+  'Options',
+  'Buttons',
+  'Select boxes',
+  'Date inputs',
+  'Password inputs',
+  'Forms',
+  'Other'
+];
 
-export default class Example extends React.Component {
-
-  constructor(props) {
-    super(props);
-    this.state = {
-      items: [
-        {title: 'Apples', color: '#3a3'},
-        {title: 'Bananas', color: '#fc0'},
-        {title: 'Blueberries', color: '#337'},
-        {title: 'Carrots', color: '#f93'},
-        {title: 'Eggplants', color: '#337'},
-        {title: 'Limes', color: '#cf3'},
-        {title: 'Potatoes', color: '#766'}
-      ]
-    };
-    this._clickHandler = this._clickHandler.bind(this);
-  }
-
-  _clickHandler(item, i) {
-    const {items} = this.state;
-    items[i].disabled = !items[i].disabled;
-    this.setState({items});
-  }
-
-  render() {
-    return (
-      <DiscreteColorLegend
-        height={200}
-        width={300}
-        onItemClick={this._clickHandler}
-        items={this.state.items}
-      />
-    );
-  }
+export default function DiscreteColorExample() {
+  return (
+    <DiscreteColorLegend
+      height={200}
+      width={300}
+      items={ITEMS}
+    />
+  );
 }

--- a/src/example/legends/searchable-discrete-color.js
+++ b/src/example/legends/searchable-discrete-color.js
@@ -46,7 +46,7 @@ export default class Example extends React.Component {
   _clickHandler(item) {
     const {items} = this.state;
     item.disabled = !item.disabled;
-    this.setState({items: [...items]});
+    this.setState({items});
   }
 
   _searchChangeHandler(searchText) {

--- a/src/example/main.scss
+++ b/src/example/main.scss
@@ -89,11 +89,22 @@ article {
 }
 
 .example-with-click-me {
+  position: relative;
   text-align: center;
   &:hover {
     .click-me {
       animation: none;
     }
+  }
+
+  .chart {
+    margin-right: 200px;
+  }
+
+  .legend {
+    position: absolute;
+    text-align: left;
+    right: 0;
   }
 }
 

--- a/src/lib/legends/discrete-color-legend.js
+++ b/src/lib/legends/discrete-color-legend.js
@@ -50,11 +50,12 @@ function fillItemsWithDefaults(items) {
         item.color :
         DISCRETE_COLOR_RANGE[i % DISCRETE_COLOR_RANGE.length],
       disabled: Boolean(item.disabled)
-    }
+    };
   });
 }
 
-function DiscreteColorLegend({items: initialItems, width, height, onItemClick}) {
+function DiscreteColorLegend({items: initialItems, width, height,
+  onItemClick}) {
   const updatedItems = fillItemsWithDefaults(initialItems);
   return (
     <div className="rv-discrete-color-legend" style={{width, height}}>

--- a/src/lib/legends/discrete-color-legend.js
+++ b/src/lib/legends/discrete-color-legend.js
@@ -19,26 +19,52 @@
 // THE SOFTWARE.
 
 import React from 'react';
-
 import DiscreteColorLegendItem from './discrete-color-legend-item';
+import {DISCRETE_COLOR_RANGE} from '../theme';
 
 const propTypes = {
   items: React.PropTypes.arrayOf(
-    React.PropTypes.shape(DiscreteColorLegendItem.propTypes)
-  ),
+    React.PropTypes.oneOfType([
+      React.PropTypes.shape({
+        title: React.PropTypes.string.isRequired,
+        color: React.PropTypes.string,
+        disabled: React.PropTypes.bool
+      }),
+      React.PropTypes.string.isRequired
+    ])
+  ).isRequired,
   onItemClick: React.PropTypes.func,
   height: React.PropTypes.number,
   width: React.PropTypes.number
 };
 
-function DiscreteColorLegend({items, width, height, onItemClick}) {
+const defaultProps = {
+  colors: DISCRETE_COLOR_RANGE
+};
+
+function fillItemsWithDefaults(items) {
+  return items.map((item, i) => {
+    return {
+      title: item.title ? item.title : item,
+      color: item.color ?
+        item.color :
+        DISCRETE_COLOR_RANGE[i % DISCRETE_COLOR_RANGE.length],
+      disabled: Boolean(item.disabled)
+    }
+  });
+}
+
+function DiscreteColorLegend({items: initialItems, width, height, onItemClick}) {
+  const updatedItems = fillItemsWithDefaults(initialItems);
   return (
     <div className="rv-discrete-color-legend" style={{width, height}}>
-      {items.map((item, i) =>
-        <DiscreteColorLegendItem key={i}
+      {updatedItems.map((item, i) =>
+        <DiscreteColorLegendItem
           {...item}
-          onClick={onItemClick ? () => onItemClick(item, i) : null}
-        />
+          key={i}
+          onClick={onItemClick ?
+            () => onItemClick(initialItems[i], i) :
+            null} />
       )}
     </div>
   );
@@ -46,5 +72,6 @@ function DiscreteColorLegend({items, width, height, onItemClick}) {
 
 DiscreteColorLegend.displayName = 'DiscreteColorLegendItem';
 DiscreteColorLegend.propTypes = propTypes;
+DiscreteColorLegend.defaultProps = defaultProps;
 
 export default DiscreteColorLegend;

--- a/src/lib/legends/searchable-discrete-color-legend.js
+++ b/src/lib/legends/searchable-discrete-color-legend.js
@@ -26,13 +26,13 @@ const propTypes = {
   searchText: React.PropTypes.string,
   onSearchChange: React.PropTypes.func,
   searchPlaceholder: React.PropTypes.string,
-  searchFn: React.PropTypes.function
+  searchFn: React.PropTypes.func
 };
 
 const defaultProps = {
   searchText: '',
   searchFn: (items, s) => items.filter(
-    ({title}) => title.toLowerCase().indexOf(s) !== -1
+    item => (item.title || item).toLowerCase().indexOf(s) !== -1
   )
 };
 

--- a/src/lib/plot/series/abstract-series.js
+++ b/src/lib/plot/series/abstract-series.js
@@ -223,18 +223,20 @@ export default class AbstractSeries extends PureRenderComponent {
     }
     let minDistance = Number.POSITIVE_INFINITY;
     let value = null;
+    let valueIndex = null;
 
     // TODO(antonb): WAT?
     d3Selection.event = event.nativeEvent;
     const coordinate = d3Selection.mouse(event.currentTarget)[0] - marginLeft;
     const xScaleFn = this._getAttributeFunctor('x');
 
-    data.forEach(item => {
+    data.forEach((item, i) => {
       const currentCoordinate = xScaleFn(item);
       const newDistance = Math.abs(coordinate - currentCoordinate);
       if (newDistance < minDistance) {
         minDistance = newDistance;
         value = item;
+        valueIndex = i;
       }
     });
     if (!value) {
@@ -242,6 +244,7 @@ export default class AbstractSeries extends PureRenderComponent {
     }
     onNearestX(value, {
       innerX: xScaleFn(value),
+      index: valueIndex,
       event: event.nativeEvent
     });
   }


### PR DESCRIPTION
This PR makes following changes:

- Simplified the way how elements are passed into `DiscreteColorLegend`: now either objects (`title`, `color` and `disabled`) or strings (treated as titles) can be used.
- The default colors of the library are assigned as to the legends in case if no color is passed.
- The complex chart example is updated: the legend is added, the `onNearestX` is very simplified.
- A new `index` property was added into `info` object of `onNearestX(value, info)` callback (easier for the use).

Docs were updated according to these changes.

This pull request fixes #32 