### PR TITLE
Donut chart example

### DIFF
--- a/src/example/main.js
+++ b/src/example/main.js
@@ -47,9 +47,12 @@ import DynamicTable from './table/dynamic-table';
 import SimpleRadialChart from './radial-chart/simple-radial-chart';
 import DonutChartExample from './radial-chart/donut-chart';
 import CustomRadiusRadialChart from './radial-chart/custom-radius-radial-chart';
-import VerticalDiscreteColorLegendExample from './legends/vertical-discrete-color';
-import HorizontalDiscreteColorLegendExample from './legends/horizontal-discrete-color';
-import SearchableDiscreteColorLegendExample from './legends/searchable-discrete-color';
+import VerticalDiscreteColorLegendExample
+  from './legends/vertical-discrete-color';
+import HorizontalDiscreteColorLegendExample
+  from './legends/horizontal-discrete-color';
+import SearchableDiscreteColorLegendExample
+  from './legends/searchable-discrete-color';
 import ContinuousColorLegendExample from './legends/continuous-color';
 import ContinuousSizeLegendExample from './legends/continuous-size';
 import {isReactDOMSupported} from '../lib/utils/react-utils';

--- a/src/example/main.js
+++ b/src/example/main.js
@@ -45,6 +45,7 @@ import TreemapExample from './treemap/dynamic-treemap';
 import StaticTable from './table/static-table';
 import DynamicTable from './table/dynamic-table';
 import SimpleRadialChart from './radial-chart/simple-radial-chart';
+import DonutChartExample from './radial-chart/donut-chart';
 import CustomRadiusRadialChart from './radial-chart/custom-radius-radial-chart';
 import VerticalDiscreteColorLegendExample from './legends/vertical-discrete-color';
 import HorizontalDiscreteColorLegendExample from './legends/horizontal-discrete-color';
@@ -153,7 +154,10 @@ const examples = (
         <h3>Simple Radial Chart</h3>
         <SimpleRadialChart />
       </section>
-
+      <section>
+        <h3>Simple Donut Chart</h3>
+        <DonutChartExample />
+      </section>
       <section>
         <h3>Custom Radius</h3>
         <CustomRadiusRadialChart />

--- a/src/example/plot/dynamic-crosshair.js
+++ b/src/example/plot/dynamic-crosshair.js
@@ -55,8 +55,8 @@ export default class DynamicCrosshair extends React.Component {
 
   /**
    * Event handler for onNearestX.
-   * @param {number} seriesIndex Index of the series.
    * @param {Object} value Selected value.
+   * @param {index} index Index of the value in the data array.
    * @private
    */
   _onNearestX(value, {index}) {

--- a/src/example/radial-chart/donut-chart.js
+++ b/src/example/radial-chart/donut-chart.js
@@ -1,0 +1,39 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import React from 'react';
+import {RadialChart} from '../../';
+
+export default function DonutChartExample() {
+  return (
+    <RadialChart
+      innerRadius={100}
+      radius={140}
+      data={[
+          {angle: 2},
+          {angle: 6},
+          {angle: 2},
+          {angle: 3},
+          {angle: 1}
+        ]}
+      width={300}
+      height={300}/>
+  );
+}

--- a/src/example/radial-chart/donut-chart.js
+++ b/src/example/radial-chart/donut-chart.js
@@ -27,12 +27,12 @@ export default function DonutChartExample() {
       innerRadius={100}
       radius={140}
       data={[
-          {angle: 2},
-          {angle: 6},
-          {angle: 2},
-          {angle: 3},
-          {angle: 1}
-        ]}
+        {angle: 2},
+        {angle: 6},
+        {angle: 2},
+        {angle: 3},
+        {angle: 1}
+      ]}
       width={300}
       height={300}/>
   );

--- a/src/lib/legends/discrete-color-legend-item.js
+++ b/src/lib/legends/discrete-color-legend-item.js
@@ -32,7 +32,8 @@ const defaultProps = {
   disabled: false
 };
 
-function DiscreteColorLegendItem({onClick, title, color, disabled, orientation}) {
+function DiscreteColorLegendItem({onClick, title, color, disabled,
+  orientation}) {
   let className = `rv-discrete-color-legend-item ${orientation}`;
   if (disabled) {
     className += ' disabled';

--- a/src/lib/legends/discrete-color-legend.js
+++ b/src/lib/legends/discrete-color-legend.js
@@ -60,7 +60,9 @@ function DiscreteColorLegend({items: initialItems, width, height,
   onItemClick, orientation}) {
   const updatedItems = fillItemsWithDefaults(initialItems);
   return (
-    <div className={`rv-discrete-color-legend ${orientation}`} style={{width, height}}>
+    <div
+      className={`rv-discrete-color-legend ${orientation}`}
+      style={{width, height}}>
       {updatedItems.map((item, i) =>
         <DiscreteColorLegendItem
           {...item}


### PR DESCRIPTION
- Added the missing donut chart example.
- Fixed the excessive `arc` generation for radial chart.

This PR fixes #83