### PR TITLE
Fix the misaligned Y Axis

### DIFF
--- a/src/lib/plot/axis/axis.js
+++ b/src/lib/plot/axis/axis.js
@@ -114,7 +114,7 @@ class Axis extends PureRenderComponent {
     }
     return {
       tickTotal: getTicksTotalFromSize(innerHeight),
-      top: 0,
+      top: marginTop,
       left: marginLeft + innerWidth,
       width: marginRight,
       height: innerHeight


### PR DESCRIPTION
When orientation is set to right, the axis is not aligned properly. This change fixes #143