### PR TITLE
Allow the user to pass undefined and nulls as scale props

### DIFF
--- a/src/lib/plot/xy-plot.js
+++ b/src/lib/plot/xy-plot.js
@@ -201,8 +201,8 @@ class XYPlot extends React.Component {
     return {
       ...defaultScaleProps,
       ...zeroBaseProps,
-      ...missingScaleProps,
       ...userScaleProps,
+      ...missingScaleProps,
       _allData: data,
       _adjustBy: Array.from(adjustBy),
       _adjustWhat: Array.from(adjustWhat),


### PR DESCRIPTION
This change fixes the problem introduced in 0.5, when the empty scale props were treated as existing values (worked well with undefined/null before).

This PR fixes #149