### PR TITLE
Adding ability to specify d3 curve function name as a line series prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ npm test
 
 ## Change log
 
+### (UNRELEASED)
+
+- Improvement: added line smoothing via d3-shape curve functions ([#185](https://github.com/uber/react-vis/pull/185)).
+
 ### 0.6.4
 
 - Bugfix: Fixed the issue with numeric titles in legends ([#154](https://github.com/uber/react-vis/pull/154)).

--- a/docs/xy-plot.md
+++ b/docs/xy-plot.md
@@ -364,9 +364,18 @@ The way to align the hint inside the chart. When `auto` is set the hint is tryin
 Set the hint to `topleft` if you want to see a "conventional" hint alignment.
 
 #### curve (optional)
-Type: `string`
+Type: `string|function`
 Default: `null`  
-Apply the named curve function from the D3 shape library to smooth the line series plot, see [the D3 documentation](https://github.com/d3/d3-shape#curves) for function names.
+Apply the provided or named curve function from the D3 shape library to smooth the line series plot, see [the D3 documentation](https://github.com/d3/d3-shape#curves) for function names and instructions. Providing the function, not the name, will require importing the d3-shape package in order to configure it:
+
+```javascript
+// Setting up with only a name
+const stringCurveProp = <LineSeries data={data} curve={'curveMonotoneX'} .../>;
+
+const configuredCurve = d3Shape.curveCatmullRom.alpha(0.5);
+const funcCurveProp = <LineSeries data={data} curve={configuredCurve} .../>;
+```
+
 
 ### Crosshair
 

--- a/docs/xy-plot.md
+++ b/docs/xy-plot.md
@@ -363,6 +363,11 @@ Default: `auto`
 The way to align the hint inside the chart. When `auto` is set the hint is trying to stay inside the bounding box of the chart.
 Set the hint to `topleft` if you want to see a "conventional" hint alignment.
 
+#### curve (optional)
+Type: `string`
+Default: `null`__
+Apply the named curve function from the D3 shape library to smooth the line series plot, see [the D3 documentation](https://github.com/d3/d3-shape#curves) for function names.
+
 ### Crosshair
 
 `Crosshair` is a tooltip for multiple values at the same time. Its purpose is to combine several values with the similar X coordinate in one tooltip. Crosshair is automatically aligned by the x coordinate depending on what values are passed.

--- a/docs/xy-plot.md
+++ b/docs/xy-plot.md
@@ -365,7 +365,7 @@ Set the hint to `topleft` if you want to see a "conventional" hint alignment.
 
 #### curve (optional)
 Type: `string`
-Default: `null`__
+Default: `null`  
 Apply the named curve function from the D3 shape library to smooth the line series plot, see [the D3 documentation](https://github.com/d3/d3-shape#curves) for function names.
 
 ### Crosshair

--- a/src/example/plot/complex-chart.js
+++ b/src/example/plot/complex-chart.js
@@ -177,6 +177,7 @@ export default class Example extends React.Component {
               {...(series[0].disabled ? {opacity: 0.2} : null)}/>
             <LineSeries
               data={series[1].data}
+              curve="curveMonotoneX"
               {...(series[1].disabled ? {opacity: 0.2} : null)}/>
             <Crosshair
               itemsFormat={this._formatCrosshairItems}

--- a/src/example/plot/line-chart.js
+++ b/src/example/plot/line-chart.js
@@ -19,6 +19,7 @@
 // THE SOFTWARE.
 
 import React from 'react';
+import {curveCatmullRom} from 'd3-shape';
 
 import {
   XYPlot,
@@ -51,6 +52,7 @@ export default class Example extends React.Component {
           data={null}/>
         <LineSeries
           className="third-series"
+          curve={'curveMonotoneX'}
           data={[
             {x: 1, y: 10},
             {x: 2, y: 4},
@@ -59,7 +61,7 @@ export default class Example extends React.Component {
           ]}/>
         <LineSeries
           className="fourth-series"
-          curve="curveCatmullRom"
+          curve={curveCatmullRom.alpha(0.5)}
           data={[
             {x: 1, y: 7},
             {x: 2, y: 11},

--- a/src/example/plot/line-chart.js
+++ b/src/example/plot/line-chart.js
@@ -57,6 +57,15 @@ export default class Example extends React.Component {
             {x: 3, y: 2},
             {x: 4, y: 15}
           ]}/>
+        <LineSeries
+          className="fourth-series"
+          curve="curveCatmullRom"
+          data={[
+            {x: 1, y: 7},
+            {x: 2, y: 11},
+            {x: 3, y: 9},
+            {x: 4, y: 2}
+          ]}/>
       </XYPlot>
     );
   }

--- a/src/example/plot/linemark-chart.js
+++ b/src/example/plot/linemark-chart.js
@@ -45,6 +45,14 @@ export default class Example extends React.Component {
             {x: 2, y: 5},
             {x: 3, y: 15}
           ]}/>
+        <LineMarkSeries
+          className="linemark-series-example-2"
+          curve={'curveMonotoneX'}
+          data={[
+            {x: 1, y: 11},
+            {x: 1.5, y: 29},
+            {x: 3, y: 7}
+          ]}/>
       </XYPlot>
     );
   }

--- a/src/lib/plot/series/line-series.js
+++ b/src/lib/plot/series/line-series.js
@@ -36,15 +36,27 @@ const STROKE_STYLES = {
 
 const defaultProps = {
   strokeStyle: 'solid',
-  opacity: 1
+  opacity: 1,
+  curve: null
 };
 
 const propTypes = {
   ...AbstractSeries.propTypes,
-  strokeStyle: React.PropTypes.oneOf(Object.keys(STROKE_STYLES))
+  strokeStyle: React.PropTypes.oneOf(Object.keys(STROKE_STYLES)),
+  curve: React.PropTypes.string
 };
 
 class LineSeries extends AbstractSeries {
+
+  _renderLine(data, x, y, curve) {
+    let line = d3Shape.line();
+    if (curve !== null && d3Shape[curve]) {
+      line = line.curve(d3Shape[curve]);
+    }
+    line = line.x(x).y(y);
+    return line(data);
+  }
+
   render() {
     const {animation, className, data} = this.props;
     if (!data) {
@@ -58,15 +70,14 @@ class LineSeries extends AbstractSeries {
       );
     }
 
-    const {strokeStyle, strokeWidth, marginLeft, marginTop} = this.props;
+    const {strokeStyle, strokeWidth, marginLeft, marginTop, curve} = this.props;
 
     const x = this._getAttributeFunctor('x');
     const y = this._getAttributeFunctor('y');
     const stroke = this._getAttributeValue('stroke') ||
       this._getAttributeValue('color');
     const opacity = this._getAttributeValue('opacity') || DEFAULT_OPACITY;
-    const line = d3Shape.line().x(x).y(y);
-    const d = line(data);
+    const d = this._renderLine(data, x, y, curve);
 
     return (
       <path

--- a/src/lib/plot/series/line-series.js
+++ b/src/lib/plot/series/line-series.js
@@ -43,15 +43,22 @@ const defaultProps = {
 const propTypes = {
   ...AbstractSeries.propTypes,
   strokeStyle: React.PropTypes.oneOf(Object.keys(STROKE_STYLES)),
-  curve: React.PropTypes.string
+  curve: React.PropTypes.oneOfType([
+    React.PropTypes.string,
+    React.PropTypes.func
+  ])
 };
 
 class LineSeries extends AbstractSeries {
 
   _renderLine(data, x, y, curve) {
     let line = d3Shape.line();
-    if (curve !== null && d3Shape[curve]) {
-      line = line.curve(d3Shape[curve]);
+    if (curve !== null) {
+      if (typeof curve === 'string' && d3Shape[curve]) {
+        line = line.curve(d3Shape[curve]);
+      } else if (typeof curve === 'function') {
+        line = line.curve(curve);
+      }
     }
     line = line.x(x).y(y);
     return line(data);


### PR DESCRIPTION
In order to make smoothed line series, a user should be able to specify the name of one of the many smoothing functions that d3-shape provides: https://github.com/d3/d3-shape#curves 