### PR TITLE
Add missing 3 public functions in scales-utils.js that were not included in the original PR 181.

### DIFF
--- a/src/lib/utils/scales-utils.js
+++ b/src/lib/utils/scales-utils.js
@@ -649,6 +649,9 @@ export function literalScale() {
 export default {
   extractScalePropsFromProps,
   getAttributeScale,
+  getAttributeFunctor,
+  getAttr0Functor,
+  getAttributeValue,
   getDomainByAttr,
   getMissingScaleProps,
   getScaleObjectFromProps,


### PR DESCRIPTION
They are:
  getAttributeFunctor,
  getAttr0Functor,
  getAttributeValue