### PR TITLE
Add additional orientation options in hint.js and provide 3 examples using these orientation options

### DIFF
--- a/src/example/main.js
+++ b/src/example/main.js
@@ -158,7 +158,7 @@ const examples = (
       </section>
       <section>
         <h3>Dynamic Hints</h3>
-        <p >Move mouse over the point to see the hint.</p>
+        <p>Move mouse over the point to see the hint.</p>
         <DynamicHints />
       </section>
       <section>

--- a/src/example/main.js
+++ b/src/example/main.js
@@ -179,8 +179,7 @@ const examples = (
         <p>Mouse over point. <br/>
           Hint uses flex, css to show hint and pole<br/>
           from point to outside plot edge (requires<br/>
-          margin values). Pass in style to Hint (could use<br/>
-          className alternatively)</p>
+          margin values).</p>
         <DynamicComplexEdgeHints />
       </section>
       <section>

--- a/src/example/main.js
+++ b/src/example/main.js
@@ -41,6 +41,9 @@ import AxisWithTurnedLabels from './plot/axis-with-turned-labels';
 import GridLinesChart from './plot/grid';
 import StaticHints from './plot/static-hints';
 import DynamicHints from './plot/dynamic-hints';
+import DynamicComplexEdgeHints from './plot/dynamic-complex-edge-hints';
+import DynamicSimpleEdgeHints from './plot/dynamic-simple-edge-hints';
+import DynamicSimpleTopEdgeHints from './plot/dynamic-simple-topedge-hints';
 import StaticCrosshair from './plot/static-crosshair';
 import DynamicCrosshair from './plot/dynamic-crosshair';
 import SyncedCharts from './plot/synced-charts';
@@ -155,8 +158,30 @@ const examples = (
       </section>
       <section>
         <h3>Dynamic Hints</h3>
-        <p>Move mouse over the point to see the hint.</p>
+        <p >Move mouse over the point to see the hint.</p>
         <DynamicHints />
+      </section>
+      <section>
+        <h3>Dynamic Simple Edge Hints</h3>
+        <p>Mouse over point; hint appears on different edges.<br/>
+          Left margin enables first point to show w/o break.</p>
+        <DynamicSimpleEdgeHints />
+      </section>
+      <section>
+        <h3>Dynamic Simple Top Edge Hints</h3>
+        <p>Mouse over point. <br/>
+          Hint appears at top edge & pole to point.<br/>
+        Left margin enables first point to show w/o break.</p>
+        <DynamicSimpleTopEdgeHints />
+      </section>
+      <section>
+        <h3>Dynamic Complex Edge Hints</h3>
+        <p>Mouse over point. <br/>
+          Hint uses flex, css to show hint and pole<br/>
+          from point to outside plot edge (requires<br/>
+          margin values). Pass in style to Hint (could use<br/>
+          className alternatively)</p>
+        <DynamicComplexEdgeHints />
       </section>
       <section>
         <h3>Static Crosshair</h3>

--- a/src/example/main.js
+++ b/src/example/main.js
@@ -163,15 +163,15 @@ const examples = (
       </section>
       <section>
         <h3>Dynamic Simple Edge Hints</h3>
-        <p>Mouse over point; hint appears on different edges.<br/>
+        <p>Mouse over point. Hint appears on different edges.<br/>
           Left margin enables first point to show w/o break.</p>
         <DynamicSimpleEdgeHints />
       </section>
       <section>
         <h3>Dynamic Simple Top Edge Hints</h3>
-        <p>Mouse over point. <br/>
-          Hint appears at top edge & pole to point.<br/>
-        Left margin enables first point to show w/o break.</p>
+        <p>Mouse over point. Orientation is EDGETOP_LEFT. <br/>
+          Hint pinned to top edge & pole indicates location
+          along edge with hint box on the left side of edge.</p>
         <DynamicSimpleTopEdgeHints />
       </section>
       <section>

--- a/src/example/main.scss
+++ b/src/example/main.scss
@@ -178,3 +178,111 @@ article {
     position: absolute;
   }
 }
+
+.complex-hint {
+  margin-top: 40px;
+  .rv-hint {
+    /* must be positioned in a parent with relative positioning */
+    position: absolute;
+    width: 0;
+    height: 100%;
+
+    $hint-color: black;
+    $margin-left: 30px;
+    $margin-right: 10px;
+    $margin-top: 10px;
+    $margin-bottom: 25px;
+
+    & .hint--text-container {
+      position: absolute;
+      /*
+       * set to 0,0 so that its content (including children)
+       * can overflow out in vertical and horizontal
+       */
+      width: 0;
+      height: 0;
+
+      /*
+       * use flex to place its children (centered) and aligned (bottom).
+       * As its height is 0, align-items flex-end paints its items from cross-axis
+       * up.  flex-start, its items would paint from cross-axis down.
+       */
+      display: flex;
+      justify-content: center;
+
+      &.topEdgeright {
+        flex-direction: column-reverse;
+        align-items: flex-start;
+      }
+      &.edgetopLeft {
+        flex-direction: row;
+        align-items: flex-end;
+      }
+      &.edgebottomLeft {
+        flex-direction: row;
+        align-items: flex-start;
+      }
+      &.topEdgeleft {
+        flex-direction: column;
+        align-items: flex-end;
+      }
+
+      & .hint--text {
+        /* text content uses -micro padding */
+        padding: 4px;
+        border: 2px solid $hint-color;
+        color: $hint-color;
+        white-space: nowrap;
+      }
+    }
+
+    & .hint--pole {
+      position: absolute;
+
+      &.topEdgeright {
+        top: -1px;
+        left: -$margin-right;
+        border-top: 2px solid $hint-color;
+        width: $margin-right;
+        height: 0;
+      }
+      &.edgetopLeft {
+        border-left: 2px solid $hint-color;
+        left: -1px;
+        height: $margin-top;
+        width: 0;
+        top: 0;
+      }
+      &.edgebottomLeft {
+        border-left: 2px solid $hint-color;
+        left: -1px;
+        height: $margin-bottom;
+        width: 0;
+        top: -$margin-bottom;
+      }
+      &.topEdgeleft {
+        top: -1px;
+        border-top: 2px solid $hint-color;
+        width: $margin-left;
+        height: 0;
+      }
+    }
+  }
+
+  .rv-hint--orientation-topEdgeright {
+    width: 0;
+    height: 0;
+  }
+  .rv-hint--orientation-edgetopLeft {
+    width: 0;
+    height: 100%;
+  }
+  .rv-hint--orientation-edgebottomLeft {
+    width: 0;
+    height: 0;
+  }
+  .rv-hint--orientation-topEdgeleft {
+    width: 100%;
+    height: 0;
+  }
+}

--- a/src/example/plot/dynamic-complex-edge-hints.js
+++ b/src/example/plot/dynamic-complex-edge-hints.js
@@ -1,0 +1,112 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import React from 'react';
+
+import {
+  XYPlot,
+  XAxis,
+  YAxis,
+  VerticalGridLines,
+  HorizontalGridLines,
+  LineSeries,
+  MarkSeries,
+  Hint} from '../../';
+
+const {EDGEBOTTOM_LEFT, EDGETOP_LEFT, TOP_EDGERIGHT, TOP_EDGELEFT} =
+  Hint.ORIENTATION;
+
+const CHART_MARGINS = {left: 30, right: 10, top: 10, bottom: 25};
+const XMIN = 1;
+const XMAX = 4;
+const YMIN = 5;
+const YMAX = 15;
+const DATA = [
+  {x: 1, y: 5},
+  {x: 2, y: 8},
+  {x: 3, y: 12},
+  {x: 4, y: 15}
+];
+const POLE = [
+  [{x: XMIN, y: DATA[0].y}, {x: XMAX, y: DATA[0].y}],
+  [{x: DATA[1].x, y: DATA[1].y}, {x: DATA[1].x, y: YMAX}],
+  [{x: DATA[2].x, y: YMIN}, {x: DATA[2].x, y: DATA[2].y}],
+  [{x: XMIN, y: DATA[3].y}, {x: DATA[3].x, y: DATA[3].y}]
+];
+const DATA_HINT_ORIENTATION = [
+  TOP_EDGERIGHT,
+  EDGETOP_LEFT,
+  EDGEBOTTOM_LEFT,
+  TOP_EDGELEFT
+];
+
+export default class Example extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      value: null
+    };
+    this._rememberValue = this._rememberValue.bind(this);
+  }
+
+  _rememberValue(value) {
+    this.setState({value});
+  }
+
+  render() {
+    const {value} = this.state;
+    return (
+      <div className="complex-hint">
+        <XYPlot
+          width={300}
+          height={300}
+          margin={CHART_MARGINS}>
+          <VerticalGridLines />
+          <HorizontalGridLines />
+          <XAxis />
+          <YAxis />
+          <MarkSeries
+            onNearestX={ this._rememberValue}
+            data={DATA}/>
+          {value ?
+            <LineSeries
+              data={ POLE[value.x - 1] }
+              stroke="black"
+            /> : null
+          }
+          {value ?
+            <Hint
+              value={value}
+              orientation={ DATA_HINT_ORIENTATION[value.x - 1] }>
+              <div className={ `hint--text-container ${
+                DATA_HINT_ORIENTATION[value.x - 1]}`}>
+                <div className="hint--text">
+                  { `(${value.x}, ${value.y})` }
+                </div>
+              </div>
+              <div className={`hint--pole ${
+                DATA_HINT_ORIENTATION[value.x - 1]}`}/>
+            </Hint> : null
+          }
+        </XYPlot>
+      </div>
+  );
+  }
+}

--- a/src/example/plot/dynamic-simple-edge-hints.js
+++ b/src/example/plot/dynamic-simple-edge-hints.js
@@ -26,35 +26,62 @@ import {
   YAxis,
   VerticalGridLines,
   HorizontalGridLines,
-  LineSeries,
+  MarkSeries,
   Hint} from '../../';
 
+const {EDGEBOTTOM_LEFT, EDGEBOTTOM_RIGHT, EDGETOP_LEFT, TOP_EDGERIGHT} =
+  Hint.ORIENTATION;
+const CHART_MARGINS = {left: 50, right: 50, top: 10, bottom: 25};
+const DATA = [
+  {x: 1, y: 5},
+  {x: 2, y: 10},
+  {x: 3, y: 10},
+  {x: 4, y: 15}
+];
+const DATA_HINT_ORIENTATION = [
+  TOP_EDGERIGHT,
+  EDGEBOTTOM_RIGHT,
+  EDGETOP_LEFT,
+  EDGEBOTTOM_LEFT
+];
+
 export default class Example extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      value: null
+    };
+    this._rememberValue = this._rememberValue.bind(this);
+  }
+
+  _rememberValue(value) {
+    this.setState({value});
+  }
+
   render() {
+    const {value} = this.state;
     return (
       <XYPlot
         width={300}
-        height={300}>
+        height={300}
+        margin={CHART_MARGINS}>
         <VerticalGridLines />
         <HorizontalGridLines />
         <XAxis />
         <YAxis />
-        <LineSeries
-          data={[
-            {x: 0, y: 1},
-            {x: 1, y: 10},
-            {x: 2, y: 5},
-            {x: 3, y: 15}
-          ]}/>
-        <Hint value={{x: 1, y: 10}}/>
-        <Hint
-          value={{x: 0.4, y: 14}}
-          orientation={ Hint.ORIENTATION.BOTTOMRIGHT }>
-          <div className="custom-hint">
-            This is a custom hint<br />
-            for a non-existent value
-          </div>
-        </Hint>
+        <MarkSeries
+          onNearestX={ this._rememberValue}
+          data={DATA}/>
+        {value ?
+          <Hint
+            value={value}
+            orientation={ DATA_HINT_ORIENTATION[value.x - 1] }
+          >
+            <div className="rv-hint__content">
+              { `(${value.x}, ${value.y})` }
+            </div>
+          </Hint> : null
+        }
       </XYPlot>
     );
   }

--- a/src/example/plot/dynamic-simple-edge-hints.js
+++ b/src/example/plot/dynamic-simple-edge-hints.js
@@ -79,6 +79,8 @@ export default class Example extends React.Component {
           >
             <div className="rv-hint__content">
               { `(${value.x}, ${value.y})` }
+              <br/>
+              { DATA_HINT_ORIENTATION[value.x - 1] }
             </div>
           </Hint> : null
         }

--- a/src/example/plot/dynamic-simple-topedge-hints.js
+++ b/src/example/plot/dynamic-simple-topedge-hints.js
@@ -27,34 +27,61 @@ import {
   VerticalGridLines,
   HorizontalGridLines,
   LineSeries,
+  MarkSeries,
   Hint} from '../../';
 
+const CHART_MARGINS = {left: 50, right: 10, top: 10, bottom: 25};
+const DATA = [
+  {x: 1, y: 5},
+  {x: 2, y: 10},
+  {x: 3, y: 10},
+  {x: 4, y: 15}
+];
+const YMAX = 15;
+
 export default class Example extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      value: null
+    };
+    this._rememberValue = this._rememberValue.bind(this);
+  }
+
+  _rememberValue(value) {
+    this.setState({value});
+  }
+
   render() {
+    const {value} = this.state;
     return (
       <XYPlot
         width={300}
-        height={300}>
+        height={300}
+        margin={CHART_MARGINS}>
         <VerticalGridLines />
         <HorizontalGridLines />
         <XAxis />
         <YAxis />
-        <LineSeries
-          data={[
-            {x: 0, y: 1},
-            {x: 1, y: 10},
-            {x: 2, y: 5},
-            {x: 3, y: 15}
-          ]}/>
-        <Hint value={{x: 1, y: 10}}/>
-        <Hint
-          value={{x: 0.4, y: 14}}
-          orientation={ Hint.ORIENTATION.BOTTOMRIGHT }>
-          <div className="custom-hint">
-            This is a custom hint<br />
-            for a non-existent value
-          </div>
-        </Hint>
+        <MarkSeries
+          onNearestX={ this._rememberValue}
+          data={DATA}/>
+        {value ?
+          <LineSeries
+            data={[{x: value.x, y: value.y}, {x: value.x, y: YMAX}]}
+            stroke="black"
+          /> : null
+        }
+        {value ?
+          <Hint
+            value={value}
+            orientation={ Hint.ORIENTATION.EDGETOP_LEFT }
+          >
+            <div className="rv-hint__content">
+              { `(${value.x}, ${value.y})` }
+            </div>
+          </Hint> : null
+        }
       </XYPlot>
     );
   }

--- a/src/lib/plot/hint.js
+++ b/src/lib/plot/hint.js
@@ -23,6 +23,25 @@ import React from 'react';
 import PureRenderComponent from '../pure-render-component';
 import {getAttributeFunctor} from '../utils/scales-utils';
 
+/*
+ * Hint is placed in one of four quadrants around a data point (imagine the
+ * point bisected by two axes -vertical, horizontal- creating 4 quadrants around
+ * a data point).
+ *
+ * A new extension to Hint introduced the edges of chart/plot area as a valid
+ * place to pin one dimension (edge) of a data point where a hint is placed.
+ * The data point's other dimension determines the location along the pinned
+ * edge as well as which side of the edge. Thus, the data point's
+ * x (if top/bottom edge is pinned) or y (if left/right edge is pinned) value
+ * determines the location of the edge plus descriptor of which side (top/bottom
+ * if left/right edge is pinned or left/righ if top/bottom edge is pinned).
+ *
+ * The constants identify positioning the Hint in either a quadrant or
+ * combination of an edge and an axis.
+ *
+ * The constants use the following naming format:
+ *   <edgetop | edgebottom | top | bottom>_<edgeleft | edgeright | left | right>
+ */
 const ORIENTATION = {
   AUTO: 'auto',
   TOPLEFT: 'topleft',
@@ -94,12 +113,18 @@ class Hint extends PureRenderComponent {
    * @private
    */
   _getCSSRight(x) {
+    if (x === undefined || x === null) {
+      return {
+        right: 0
+      };
+    }
+
     const {
       innerWidth,
       marginRight
     } = this.props;
     return {
-      right: x === undefined || x === null ? 0 : marginRight + innerWidth - x
+      right: marginRight + innerWidth - x
     };
   }
 
@@ -111,9 +136,15 @@ class Hint extends PureRenderComponent {
    * @private
    */
   _getCSSLeft(x) {
+    if (x === undefined || x === null) {
+      return {
+        left:  0
+      };
+    }
+
     const {marginLeft} = this.props;
     return {
-      left: x === undefined || x === null ? 0 : marginLeft + x
+      left:  marginLeft + x
     };
   }
 
@@ -125,12 +156,18 @@ class Hint extends PureRenderComponent {
    * @private
    */
   _getCSSBottom(y) {
+    if (y === undefined || y === null) {
+      return {
+        bottom: 0
+      };
+    }
+
     const {
       innerHeight,
       marginBottom
     } = this.props;
     return {
-      bottom: y === undefined || y === null ? 0 : marginBottom + innerHeight - y
+      bottom: marginBottom + innerHeight - y
     };
   }
 
@@ -142,9 +179,15 @@ class Hint extends PureRenderComponent {
    * @private
    */
   _getCSSTop(y) {
+    if (y === undefined || y === null) {
+      return {
+        top: 0
+      };
+    }
+
     const {marginTop} = this.props;
     return {
-      top: y === undefined || y === null ? 0 : marginTop + y
+      top: marginTop + y
     };
   }
 

--- a/src/lib/plot/hint.js
+++ b/src/lib/plot/hint.js
@@ -50,7 +50,7 @@ function defaultFormat(value) {
   });
 }
 
-const Hint = class Hint extends PureRenderComponent {
+class Hint extends PureRenderComponent {
 
   static get propTypes() {
     return {
@@ -88,7 +88,7 @@ const Hint = class Hint extends PureRenderComponent {
 
   /**
    * Get the right coordinate of the hint.
-   * When x undefined, edge case, pin right.
+   * When x undefined or null, edge case, pin right.
    * @param {number} x X.
    * @returns {{right: *}} Mixin.
    * @private
@@ -99,13 +99,13 @@ const Hint = class Hint extends PureRenderComponent {
       marginRight
     } = this.props;
     return {
-      right: typeof x === 'number' ? marginRight + innerWidth - x : 0
+      right: x === undefined || x === null ? 0 : marginRight + innerWidth - x
     };
   }
 
   /**
    * Get the left coordinate of the hint.
-   * When x undefined, edge case, pin left.
+   * When x undefined or null, edge case, pin left.
    * @param {number} x X.
    * @returns {{left: *}} Mixin.
    * @private
@@ -113,13 +113,13 @@ const Hint = class Hint extends PureRenderComponent {
   _getCSSLeft(x) {
     const {marginLeft} = this.props;
     return {
-      left: typeof x === 'number' ? marginLeft + x : 0
+      left: x === undefined || x === null ? 0 : marginLeft + x
     };
   }
 
   /**
    * Get the bottom coordinate of the hint.
-   * When y undefined, edge case, pin bottom.
+   * When y undefined or null, edge case, pin bottom.
    * @param {number} y Y.
    * @returns {{bottom: *}} Mixin.
    * @private
@@ -130,13 +130,13 @@ const Hint = class Hint extends PureRenderComponent {
       marginBottom
     } = this.props;
     return {
-      bottom: typeof y === 'number' ? marginBottom + innerHeight - y : 0
+      bottom: y === undefined || y === null ? 0 : marginBottom + innerHeight - y
     };
   }
 
   /**
    * Get the top coordinate of the hint.
-   * When y undefined, edge case, pin top.
+   * When y undefined or null, edge case, pin top.
    * @param {number} y Y.
    * @returns {{top: *}} Mixin.
    * @private
@@ -144,7 +144,7 @@ const Hint = class Hint extends PureRenderComponent {
   _getCSSTop(y) {
     const {marginTop} = this.props;
     return {
-      top: typeof y === 'number' ? marginTop + y : 0
+      top: y === undefined || y === null ? 0 : marginTop + y
     };
   }
 
@@ -194,11 +194,11 @@ const Hint = class Hint extends PureRenderComponent {
     case ORIENTATION.EDGETOP_LEFT:
     case ORIENTATION.EDGETOP_RIGHT:
       // this pins x to top edge
-      return this._getCSSTop();
+      return this._getCSSTop(null);
     case ORIENTATION.EDGEBOTTOM_LEFT:
     case ORIENTATION.EDGEBOTTOM_RIGHT:
       // this pins x to bottom edge
-      return this._getCSSBottom();
+      return this._getCSSBottom(null);
     case ORIENTATION.BOTTOMLEFT:
     case ORIENTATION.BOTTOMRIGHT:
     case ORIENTATION.BOTTOM_EDGELEFT:
@@ -217,11 +217,11 @@ const Hint = class Hint extends PureRenderComponent {
     case ORIENTATION.TOP_EDGELEFT:
     case ORIENTATION.BOTTOM_EDGELEFT:
       // this pins x to left edge
-      return this._getCSSLeft();
+      return this._getCSSLeft(null);
     case ORIENTATION.TOP_EDGERIGHT:
     case ORIENTATION.BOTTOM_EDGERIGHT:
       // this pins x to left edge
-      return this._getCSSRight();
+      return this._getCSSRight(null);
     case ORIENTATION.TOPLEFT:
     case ORIENTATION.BOTTOMLEFT:
     case ORIENTATION.EDGETOP_LEFT:
@@ -269,18 +269,15 @@ const Hint = class Hint extends PureRenderComponent {
 
   render() {
     const {
-      className,
-      style,
       value,
       format,
       children} = this.props;
 
-    const posInfo = this._getPositionInfo();
+    const {style, className} = this._getPositionInfo();
     return (
       <div
-        className={`rv-hint ${posInfo.className} ${className}`}
+        className={`rv-hint ${className}`}
         style={{
-          ... posInfo.style,
           ... style,
           position: 'absolute'
         }}>
@@ -299,7 +296,7 @@ const Hint = class Hint extends PureRenderComponent {
       </div>
     );
   }
-};
+}
 
 Hint.displayName = 'Hint';
 Hint.ORIENTATION = ORIENTATION;

--- a/src/lib/utils/scales-utils.js
+++ b/src/lib/utils/scales-utils.js
@@ -657,4 +657,4 @@ export default {
   getScaleObjectFromProps,
   getScalePropTypesByAttribute,
   literalScale
-}
+};


### PR DESCRIPTION
Add 8 more orientation options all related to edges:
-   'edgetopLeft',
-   'edgebottomLeft',
-   'edgetopRight',
-   'edgebottomRight',
-   'topEdgeleft',
-   'bottomEdgeleft',
-   'topEdgeright',
-   'bottomEdgeright'

Add 3 examples (dynamic-simple-edge-hints, dynamic-simple-topedge-hints, dynamic-complex-edge-hints) illustrating these new orientation options. 

![2016-12-05-2](https://cloud.githubusercontent.com/assets/2983206/21125735/a8137502-c09c-11e6-9e2d-eb6b420c53c1.gif)

Export ORIENTATION object with all the orientation constants and use them instead of the strings.
Convert examples to use these constants rather than the strings (for backwards compatibility, the original orientation strings are unchanged).

dynamic-complex-hints.js shows the power of using these edge orientation which also uses:
- divs to draw the hint-text box and the hint-pole; they are provided as children to the Hint component.  The hint-pole cannot be done with LineSeries as shown in (dynamic-simple-topedge-hints.js) because it needs to extend from bottom to top edge of plot and not from bottom of innerplot to top of plot (see image).
- flex to draw the text box beyond the top of the plot (using align-items: flex-end) and a few other flex tricks.  This demonstrates a pure div approach that could not be done with subclassing GridLines or using LineSeries for the pole because of the need to go from edge to edge of the plot. 
- exploits existing support by Hint to set margins and to use them to create short hint-pole-stem that connects with LineSeries (if you want to see what I mean, comment out the LineSeries in dynamic-complex-hints.js.
