### PR TITLE
Examples only for PR204 to Deprecate orientation prop in favor of two new props (horizontalAlign, verticalAlign)

### DIFF
--- a/src/example/main.js
+++ b/src/example/main.js
@@ -44,6 +44,7 @@ import DynamicHints from './plot/dynamic-hints';
 import DynamicComplexEdgeHints from './plot/dynamic-complex-edge-hints';
 import DynamicSimpleEdgeHints from './plot/dynamic-simple-edge-hints';
 import DynamicSimpleTopEdgeHints from './plot/dynamic-simple-topedge-hints';
+import DynamicProgrammaticRightEdgeHints from './plot/dynamic-programmatic-rightedge-hints';
 import StaticCrosshair from './plot/static-crosshair';
 import DynamicCrosshair from './plot/dynamic-crosshair';
 import SyncedCharts from './plot/synced-charts';
@@ -176,6 +177,14 @@ const examples = (
           along edge, hint box on right of pole<br/>
           for first 2 data points and left otherwise.</p>
         <DynamicSimpleTopEdgeHints />
+      </section>
+      <section>
+        <h3>Dynamic Programmatic Right Edge Hints</h3>
+        <p>Mouse over point.<br/>
+          getAlignStyle method returns style object<br/>
+          with right and top CSS props set (pinned<br/>
+          right edge and at y position) </p>
+        <DynamicProgrammaticRightEdgeHints />
       </section>
       <section>
         <h3>Dynamic Complex Edge Hints</h3>

--- a/src/example/main.js
+++ b/src/example/main.js
@@ -41,6 +41,9 @@ import AxisWithTurnedLabels from './plot/axis-with-turned-labels';
 import GridLinesChart from './plot/grid';
 import StaticHints from './plot/static-hints';
 import DynamicHints from './plot/dynamic-hints';
+import DynamicComplexEdgeHints from './plot/dynamic-complex-edge-hints';
+import DynamicSimpleEdgeHints from './plot/dynamic-simple-edge-hints';
+import DynamicSimpleTopEdgeHints from './plot/dynamic-simple-topedge-hints';
 import StaticCrosshair from './plot/static-crosshair';
 import DynamicCrosshair from './plot/dynamic-crosshair';
 import SyncedCharts from './plot/synced-charts';
@@ -157,6 +160,30 @@ const examples = (
         <h3>Dynamic Hints</h3>
         <p>Move mouse over the point to see the hint.</p>
         <DynamicHints />
+      </section>
+      <section>
+        <h3>Dynamic Simple Edge Hints</h3>
+        <p>Mouse over point. Hint appears on different edges.<br/>
+          Left margin enables first point to show w/o break.</p>
+        <DynamicSimpleEdgeHints />
+      </section>
+      <section>
+        <h3>Dynamic Simple Top Edge Hints</h3>
+        <p>Mouse over point.<br/>
+          horizontalAlign=ALIGN.AUTO,<br/>
+          verticalAlign=ALIGN.TOP_EDGE <br/>
+          Hint pinned to top edge, pole moves<br/>
+          along edge, hint box on right of pole<br/>
+          for first 2 data points and left otherwise.</p>
+        <DynamicSimpleTopEdgeHints />
+      </section>
+      <section>
+        <h3>Dynamic Complex Edge Hints</h3>
+        <p>Mouse over point. <br/>
+          Hint uses flex, css to show hint and pole<br/>
+          from point to outside plot edge (css for<br/>
+          margin values).</p>
+        <DynamicComplexEdgeHints />
       </section>
       <section>
         <h3>Static Crosshair</h3>

--- a/src/example/main.scss
+++ b/src/example/main.scss
@@ -178,3 +178,111 @@ article {
     position: absolute;
   }
 }
+
+.complex-hint {
+  margin-top: 40px;
+  .rv-hint {
+    /* must be positioned in a parent with relative positioning */
+    position: absolute;
+    width: 0;
+    height: 100%;
+
+    $hint-color: black;
+    $margin-left: 30px;
+    $margin-right: 10px;
+    $margin-top: 10px;
+    $margin-bottom: 25px;
+
+    & .hint--text-container {
+      position: absolute;
+      /*
+       * set to 0,0 so that its content (including children)
+       * can overflow out in vertical and horizontal
+       */
+      width: 0;
+      height: 0;
+
+      /*
+       * use flex to place its children (centered) and aligned (bottom).
+       * As its height is 0, align-items flex-end paints its items from cross-axis
+       * up.  flex-start, its items would paint from cross-axis down.
+       */
+      display: flex;
+      justify-content: center;
+
+      &.rightEdge-top {
+        flex-direction: column-reverse;
+        align-items: flex-start;
+      }
+      &.left-topEdge {
+        flex-direction: row;
+        align-items: flex-end;
+      }
+      &.left-bottomEdge {
+        flex-direction: row;
+        align-items: flex-start;
+      }
+      &.leftEdge-top {
+        flex-direction: column;
+        align-items: flex-end;
+      }
+
+      & .hint--text {
+        /* text content uses -micro padding */
+        padding: 4px;
+        border: 2px solid $hint-color;
+        color: $hint-color;
+        white-space: nowrap;
+      }
+    }
+
+    & .hint--pole {
+      position: absolute;
+
+      &.rightEdge-top {
+        top: -1px;
+        left: -$margin-right;
+        border-top: 2px solid $hint-color;
+        width: $margin-right;
+        height: 0;
+      }
+      &.left-topEdge {
+        border-left: 2px solid $hint-color;
+        left: -1px;
+        height: $margin-top;
+        width: 0;
+        top: 0;
+      }
+      &.left-bottomEdge {
+        border-left: 2px solid $hint-color;
+        left: -1px;
+        height: $margin-bottom;
+        width: 0;
+        top: -$margin-bottom;
+      }
+      &.leftEdge-top {
+        top: -1px;
+        border-top: 2px solid $hint-color;
+        width: $margin-left;
+        height: 0;
+      }
+    }
+  }
+
+  .rv-hint--horizontalAlign-rightEdge.rv-hint--verticalAlign-top {
+    width: 0;
+    height: 0;
+  }
+  .rv-hint--horizontalAlign-left.rv-hint--verticalAlign-topEdge {
+    width: 0;
+    height: 100%;
+  }
+  .rv-hint--horizontalAlign-left.rv-hint--verticalAlign-bottomEdge {
+    width: 0;
+    height: 0;
+  }
+  .rv-hint--horizontalAlign-leftEdge.rv-hint--verticalAlign-top {
+    width: 100%;
+    height: 0;
+  }
+}

--- a/src/example/plot/dynamic-complex-edge-hints.js
+++ b/src/example/plot/dynamic-complex-edge-hints.js
@@ -51,17 +51,17 @@ const POLE = [
   [{x: XMIN, y: DATA[3].y}, {x: DATA[3].x, y: DATA[3].y}]
 ];
 const DATA_HINT_ALIGN = [{
-  horizontalAlign: RIGHT_EDGE,
-  verticalAlign: TOP
+  horizontal: RIGHT_EDGE,
+  vertical: TOP
 }, {
-  horizontalAlign: LEFT,
-  verticalAlign: TOP_EDGE
+  horizontal: LEFT,
+  vertical: TOP_EDGE
 }, {
-  horizontalAlign: LEFT,
-  verticalAlign: BOTTOM_EDGE
+  horizontal: LEFT,
+  vertical: BOTTOM_EDGE
 }, {
-  horizontalAlign: LEFT_EDGE,
-  verticalAlign: TOP
+  horizontal: LEFT_EDGE,
+  vertical: TOP
 }];
 
 export default class Example extends React.Component {
@@ -101,19 +101,18 @@ export default class Example extends React.Component {
           {value ?
             <Hint
               value={value}
-              horizontalAlign={ DATA_HINT_ALIGN[value.x - 1].horizontalAlign }
-              verticalAlign={ DATA_HINT_ALIGN[value.x - 1].verticalAlign }
+              align={ DATA_HINT_ALIGN[value.x - 1] }
             >
               <div className={ `hint--text-container ${
-                DATA_HINT_ALIGN[value.x - 1].horizontalAlign}-${
-                DATA_HINT_ALIGN[value.x - 1].verticalAlign}`}>
+                DATA_HINT_ALIGN[value.x - 1].horizontal}-${
+                DATA_HINT_ALIGN[value.x - 1].vertical}`}>
                 <div className="hint--text">
                   { `(${value.x}, ${value.y})` }
                 </div>
               </div>
               <div className={`hint--pole ${
-                DATA_HINT_ALIGN[value.x - 1].horizontalAlign}-${
-                DATA_HINT_ALIGN[value.x - 1].verticalAlign}`}/>
+                DATA_HINT_ALIGN[value.x - 1].horizontal}-${
+                DATA_HINT_ALIGN[value.x - 1].vertical}`}/>
             </Hint> : null
           }
         </XYPlot>

--- a/src/example/plot/dynamic-complex-edge-hints.js
+++ b/src/example/plot/dynamic-complex-edge-hints.js
@@ -1,0 +1,123 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import React from 'react';
+
+import {
+  XYPlot,
+  XAxis,
+  YAxis,
+  VerticalGridLines,
+  HorizontalGridLines,
+  LineSeries,
+  MarkSeries,
+  Hint} from '../../';
+
+const {LEFT, TOP, BOTTOM_EDGE, LEFT_EDGE, RIGHT_EDGE, TOP_EDGE} =
+  Hint.ALIGN;
+
+const CHART_MARGINS = {left: 30, right: 10, top: 10, bottom: 25};
+const XMIN = 1;
+const XMAX = 4;
+const YMIN = 5;
+const YMAX = 15;
+const DATA = [
+  {x: 1, y: 5},
+  {x: 2, y: 8},
+  {x: 3, y: 12},
+  {x: 4, y: 15}
+];
+const POLE = [
+  [{x: XMIN, y: DATA[0].y}, {x: XMAX, y: DATA[0].y}],
+  [{x: DATA[1].x, y: DATA[1].y}, {x: DATA[1].x, y: YMAX}],
+  [{x: DATA[2].x, y: YMIN}, {x: DATA[2].x, y: DATA[2].y}],
+  [{x: XMIN, y: DATA[3].y}, {x: DATA[3].x, y: DATA[3].y}]
+];
+const DATA_HINT_ALIGN = [{
+  horizontalAlign: RIGHT_EDGE,
+  verticalAlign: TOP
+}, {
+  horizontalAlign: LEFT,
+  verticalAlign: TOP_EDGE
+}, {
+  horizontalAlign: LEFT,
+  verticalAlign: BOTTOM_EDGE
+}, {
+  horizontalAlign: LEFT_EDGE,
+  verticalAlign: TOP
+}];
+
+export default class Example extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      value: null
+    };
+    this._rememberValue = this._rememberValue.bind(this);
+  }
+
+  _rememberValue(value) {
+    this.setState({value});
+  }
+
+  render() {
+    const {value} = this.state;
+    return (
+      <div className="complex-hint">
+        <XYPlot
+          width={300}
+          height={300}
+          margin={CHART_MARGINS}>
+          <VerticalGridLines />
+          <HorizontalGridLines />
+          <XAxis />
+          <YAxis />
+          <MarkSeries
+            onNearestX={ this._rememberValue}
+            data={DATA}/>
+          {value ?
+            <LineSeries
+              data={ POLE[value.x - 1] }
+              stroke="black"
+            /> : null
+          }
+          {value ?
+            <Hint
+              value={value}
+              horizontalAlign={ DATA_HINT_ALIGN[value.x - 1].horizontalAlign }
+              verticalAlign={ DATA_HINT_ALIGN[value.x - 1].verticalAlign }
+            >
+              <div className={ `hint--text-container ${
+                DATA_HINT_ALIGN[value.x - 1].horizontalAlign}-${
+                DATA_HINT_ALIGN[value.x - 1].verticalAlign}`}>
+                <div className="hint--text">
+                  { `(${value.x}, ${value.y})` }
+                </div>
+              </div>
+              <div className={`hint--pole ${
+                DATA_HINT_ALIGN[value.x - 1].horizontalAlign}-${
+                DATA_HINT_ALIGN[value.x - 1].verticalAlign}`}/>
+            </Hint> : null
+          }
+        </XYPlot>
+      </div>
+  );
+  }
+}

--- a/src/example/plot/dynamic-programmatic-rightedge-hints.js
+++ b/src/example/plot/dynamic-programmatic-rightedge-hints.js
@@ -26,31 +26,25 @@ import {
   YAxis,
   VerticalGridLines,
   HorizontalGridLines,
+  LineSeries,
   MarkSeries,
   Hint} from '../../';
 
-const {LEFT, RIGHT, TOP, BOTTOM_EDGE, RIGHT_EDGE, TOP_EDGE} =
-  Hint.ALIGN;
 const CHART_MARGINS = {left: 50, right: 10, top: 10, bottom: 25};
 const DATA = [
   {x: 1, y: 5},
-  {x: 2, y: 10},
-  {x: 3, y: 10},
+  {x: 2, y: 12},
+  {x: 3, y: 8},
   {x: 4, y: 15}
 ];
-const DATA_HINT_ALIGN = [{
-  horizontal: RIGHT_EDGE,
-  vertical: TOP
-}, {
-  horizontal: RIGHT,
-  vertical: BOTTOM_EDGE
-}, {
-  horizontal: LEFT,
-  vertical: TOP_EDGE
-}, {
-  horizontal: LEFT,
-  vertical: BOTTOM_EDGE
-}];
+const XMAX = 4;
+
+function getAlignStyle(align, x, y) {
+  return {
+    right: 0,
+    top: CHART_MARGINS.top + y
+  }
+}
 
 export default class Example extends React.Component {
   constructor(props) {
@@ -80,15 +74,18 @@ export default class Example extends React.Component {
           onNearestX={ this._rememberValue}
           data={DATA}/>
         {value ?
+          <LineSeries
+            data={[{x: value.x, y: value.y}, {x: XMAX, y: value.y}]}
+            stroke="black"
+          /> : null
+        }
+        {value ?
           <Hint
             value={value}
-            align={ DATA_HINT_ALIGN[value.x - 1] }
+            getAlignStyle={ getAlignStyle }
           >
             <div className="rv-hint__content">
               { `(${value.x}, ${value.y})` }
-              <br/>
-              { `${DATA_HINT_ALIGN[value.x - 1].horizontal}-${
-                DATA_HINT_ALIGN[value.x - 1].vertical}` }
             </div>
           </Hint> : null
         }

--- a/src/example/plot/dynamic-simple-edge-hints.js
+++ b/src/example/plot/dynamic-simple-edge-hints.js
@@ -26,37 +26,73 @@ import {
   YAxis,
   VerticalGridLines,
   HorizontalGridLines,
-  LineSeries,
+  MarkSeries,
   Hint} from '../../';
 
+const {LEFT, RIGHT, TOP, BOTTOM_EDGE, RIGHT_EDGE, TOP_EDGE} =
+  Hint.ALIGN;
+const CHART_MARGINS = {left: 50, right: 10, top: 10, bottom: 25};
+const DATA = [
+  {x: 1, y: 5},
+  {x: 2, y: 10},
+  {x: 3, y: 10},
+  {x: 4, y: 15}
+];
+const DATA_HINT_ALIGN = [{
+  horizontalAlign: RIGHT_EDGE,
+  verticalAlign: TOP
+}, {
+  horizontalAlign: RIGHT,
+  verticalAlign: BOTTOM_EDGE
+}, {
+  horizontalAlign: LEFT,
+  verticalAlign: TOP_EDGE
+}, {
+  horizontalAlign: LEFT,
+  verticalAlign: BOTTOM_EDGE
+}];
+
 export default class Example extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      value: null
+    };
+    this._rememberValue = this._rememberValue.bind(this);
+  }
+
+  _rememberValue(value) {
+    this.setState({value});
+  }
+
   render() {
+    const {value} = this.state;
     return (
       <XYPlot
         width={300}
-        height={300}>
+        height={300}
+        margin={CHART_MARGINS}>
         <VerticalGridLines />
         <HorizontalGridLines />
         <XAxis />
         <YAxis />
-        <LineSeries
-          data={[
-            {x: 0, y: 1},
-            {x: 1, y: 10},
-            {x: 2, y: 5},
-            {x: 3, y: 15}
-          ]}/>
-        <Hint value={{x: 1, y: 10}}/>
-        <Hint
-          value={{x: 0.4, y: 14}}
-          horizontalAlign={ Hint.ALIGN.RIGHT }
-          verticalAlign={Hint.ALIGN.BOTTOM }
+        <MarkSeries
+          onNearestX={ this._rememberValue}
+          data={DATA}/>
+        {value ?
+          <Hint
+            value={value}
+            horizontalAlign={ DATA_HINT_ALIGN[value.x - 1].horizontalAlign }
+            verticalAlign={ DATA_HINT_ALIGN[value.x - 1].verticalAlign }
           >
-          <div className="custom-hint">
-            This is a custom hint<br />
-            for a non-existent value
-          </div>
-        </Hint>
+            <div className="rv-hint__content">
+              { `(${value.x}, ${value.y})` }
+              <br/>
+              { `${DATA_HINT_ALIGN[value.x - 1].horizontalAlign}-${
+                DATA_HINT_ALIGN[value.x - 1].verticalAlign}` }
+            </div>
+          </Hint> : null
+        }
       </XYPlot>
     );
   }

--- a/src/example/plot/dynamic-simple-topedge-hints.js
+++ b/src/example/plot/dynamic-simple-topedge-hints.js
@@ -75,8 +75,7 @@ export default class Example extends React.Component {
         {value ?
           <Hint
             value={value}
-            horizontalAlign={ Hint.AUTO }
-            verticalAlign={ Hint.ALIGN.TOP_EDGE }
+            align={ {horizontal: Hint.AUTO, vertical: Hint.ALIGN.TOP_EDGE} }
           >
             <div className="rv-hint__content">
               { `(${value.x}, ${value.y})` }

--- a/src/example/plot/dynamic-simple-topedge-hints.js
+++ b/src/example/plot/dynamic-simple-topedge-hints.js
@@ -27,36 +27,62 @@ import {
   VerticalGridLines,
   HorizontalGridLines,
   LineSeries,
+  MarkSeries,
   Hint} from '../../';
 
+const CHART_MARGINS = {left: 50, right: 10, top: 10, bottom: 25};
+const DATA = [
+  {x: 1, y: 5},
+  {x: 2, y: 10},
+  {x: 3, y: 10},
+  {x: 4, y: 15}
+];
+const YMAX = 15;
+
 export default class Example extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      value: null
+    };
+    this._rememberValue = this._rememberValue.bind(this);
+  }
+
+  _rememberValue(value) {
+    this.setState({value});
+  }
+
   render() {
+    const {value} = this.state;
     return (
       <XYPlot
         width={300}
-        height={300}>
+        height={300}
+        margin={CHART_MARGINS}>
         <VerticalGridLines />
         <HorizontalGridLines />
         <XAxis />
         <YAxis />
-        <LineSeries
-          data={[
-            {x: 0, y: 1},
-            {x: 1, y: 10},
-            {x: 2, y: 5},
-            {x: 3, y: 15}
-          ]}/>
-        <Hint value={{x: 1, y: 10}}/>
-        <Hint
-          value={{x: 0.4, y: 14}}
-          horizontalAlign={ Hint.ALIGN.RIGHT }
-          verticalAlign={Hint.ALIGN.BOTTOM }
+        <MarkSeries
+          onNearestX={ this._rememberValue}
+          data={DATA}/>
+        {value ?
+          <LineSeries
+            data={[{x: value.x, y: value.y}, {x: value.x, y: YMAX}]}
+            stroke="black"
+          /> : null
+        }
+        {value ?
+          <Hint
+            value={value}
+            horizontalAlign={ Hint.AUTO }
+            verticalAlign={ Hint.ALIGN.TOP_EDGE }
           >
-          <div className="custom-hint">
-            This is a custom hint<br />
-            for a non-existent value
-          </div>
-        </Hint>
+            <div className="rv-hint__content">
+              { `(${value.x}, ${value.y})` }
+            </div>
+          </Hint> : null
+        }
       </XYPlot>
     );
   }


### PR DESCRIPTION
This is the examples only portion that uses the new proposed Hint props - horizontalAlign, verticalAlign - ([PR#204](https://github.com/uber/react-vis/pull/204)) .  PR#204 contained only the change to hint.js  So, this PR is only useful if [PR#204](https://github.com/uber/react-vis/pull/204) is accepted.

Added 3 new examples to illustrate the new Hint props (see attached figure) and to serve as test of the new Hint props:
1. Dynamic Simple Edge Hints - Illustrates each point using different horizontalAlign, verticalAlign options.  The hint box includes text on which option is used.  There is no additional CSS styling. So, the example illustrates edge and quadrant placement clearly before any CSS treatment.
2. Dynamic Simple Top Edge Hints - illustrates pinning hint to top edge but using AUTO for placement of hint box along the top edge.  The Hint's AUTO algorithm uses horizontalAlign=RIGHT for the first 2 points as they are on the left side of the plot and horizontalAlign=LEFT for the last 2 points as they are on the right side of the plot.  The pole in the hint is created using additional combination of MarkSeries and Line Series to create the pole line.
3. Dynamic Complex Edge Hints - illustrates the 4 edge placement represented by the 4 data points.  More importantly, it shows how the provided children contain divs with CSS classes that allow creation of pole line (using CSS) and how the hint box with a short stem (extending from the plot edge) can be offset (using flex layout). It supports the argument that offsets can be handled with CSS.

![hint-align](https://cloud.githubusercontent.com/assets/2983206/21443972/e58028ae-c85d-11e6-8062-2f3950e49e32.gif)
