### PR TITLE
Remove duplicated style

### DIFF
--- a/src/styles/legends.scss
+++ b/src/styles/legends.scss
@@ -113,15 +113,12 @@ $rv-legend-disabled-color: #B8B8B8;
   white-space: nowrap;
   overflow: hidden;
 }
-.rv-legend-titles__left {
-  position: absolute;
-}
+
 .rv-legend-titles__center {
   display: block;
   text-align: center;
   width: 100%;
 }
 .rv-legend-titles__right {
-  position: absolute;
   right: 0;
 }

--- a/src/styles/legends.scss
+++ b/src/styles/legends.scss
@@ -106,6 +106,7 @@ $rv-legend-disabled-color: #B8B8B8;
   height: 16px;
   position: relative;
 }
+
 .rv-legend-titles__left,
 .rv-legend-titles__right,
 .rv-legend-titles__center {
@@ -119,6 +120,7 @@ $rv-legend-disabled-color: #B8B8B8;
   text-align: center;
   width: 100%;
 }
+
 .rv-legend-titles__right {
   right: 0;
 }


### PR DESCRIPTION
Position absolute already being declared.
```css
.rv-legend-titles__left,
.rv-legend-titles__right,
.rv-legend-titles__center {
   position: absolute;
   white-space: nowrap;
   overflow: hidden;
 }
```