### PR TITLE
[Issue 221] Add default props class name for Axis

### DIFF
--- a/src/lib/plot/axis/axis.js
+++ b/src/lib/plot/axis/axis.js
@@ -67,6 +67,7 @@ const propTypes = {
 };
 
 const defaultProps = {
+  className: '',
   tickSize: 6,
   tickPadding: 8,
   orientation: BOTTOM


### PR DESCRIPTION
Address #221 
I am adding `defaultProps` to match the pattern of `abstract-series`
https://github.com/uber/react-vis/blob/master/src/lib/plot/series/abstract-series.js#L51-L53