### PR TITLE
Improve Radial Chart Functionality

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,6 +9,7 @@
   ],
   "rules": {
     "consistent-return": 0,
+    "max-len": [1, 110, 4],
     "max-params": ["error", 6],
     "object-curly-spacing": 0,
     "babel/object-curly-spacing": 2

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ node_modules/
 .nyc_output/
 coverage/
 dist/
-showcase/node_modules/
 
 # To be removed in next major
 main.css

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules/
 .nyc_output/
 coverage/
 dist/
+showcase/node_modules/
 
 # To be removed in next major
 main.css

--- a/showcase/radial-chart/custom-radius-radial-chart.js
+++ b/showcase/radial-chart/custom-radius-radial-chart.js
@@ -18,24 +18,21 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import React from 'react';
+import React, {Component} from 'react';
 
 import RadialChart from 'radial-chart';
 
-export default class SimpleRadialChart extends React.Component {
-  constructor(props) {
-    super(props);
+export default class SimpleRadialChart extends Component {
 
-    this.state = {
-      hoveredSection: false
-    };
+  state = {
+    hoveredSection: false
   }
 
   render() {
     const {hoveredSection} = this.state;
     return (
       <RadialChart
-        animation={true}
+        animation
         radiusDomain={[0, 20]}
         data={[
           {

--- a/showcase/radial-chart/custom-radius-radial-chart.js
+++ b/showcase/radial-chart/custom-radius-radial-chart.js
@@ -23,17 +23,54 @@ import React from 'react';
 import RadialChart from 'radial-chart';
 
 export default class SimpleRadialChart extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      hoveredSection: false
+    };
+  }
+
   render() {
+    const {hoveredSection} = this.state;
     return (
       <RadialChart
+        animation={true}
         radiusDomain={[0, 20]}
         data={[
-          {angle: 1, radius: 10},
-          {angle: 2, radius: 20},
-          {angle: 5, radius: 5},
-          {angle: 3, radius: 14},
-          {angle: 5, radius: 12}
+          {
+            angle: 1,
+            id: 1,
+            radius: 10,
+            opacity: (!hoveredSection || hoveredSection === 1) ? 1 : 0.6
+          },
+          {
+            angle: 2,
+            id: 2,
+            radius: 20,
+            opacity: (!hoveredSection || hoveredSection === 2) ? 1 : 0.6
+          },
+          {
+            angle: 5,
+            id: 3,
+            radius: 5,
+            opacity: (!hoveredSection || hoveredSection === 3) ? 1 : 0.6
+          },
+          {
+            angle: 3,
+            id: 4,
+            radius: 14,
+            opacity: (!hoveredSection || hoveredSection === 4) ? 1 : 0.6
+          },
+          {
+            angle: 5,
+            id: 5,
+            radius: 12,
+            opacity: (!hoveredSection || hoveredSection === 5) ? 1 : 0.6
+          }
         ]}
+        onSectionMouseOver={row => this.setState({hoveredSection: row.id})}
+        onSectionMouseOut={() => this.setState({hoveredSection: false})}
         width={300}
         height={300} />
     );

--- a/src/radial-chart/index.js
+++ b/src/radial-chart/index.js
@@ -31,6 +31,8 @@ import {
   getMissingScaleProps
 } from 'utils/scales-utils';
 
+const NOOP = d => d;
+
 const ATTRIBUTES = [
   'angle',
   'radius',
@@ -109,12 +111,10 @@ class RadialChart extends React.Component {
    * @param {Object} event Event.
    * @private
    */
-  _sectionHandler(handler, d, event) {
-    if (handler) {
-      const {arc} = this.state;
-      const [x, y] = arc.centroid(d);
-      handler(d.data, {event, x, y});
-    }
+  _sectionHandler(handler = NOOP, d, event) {
+    const {arc} = this.state;
+    const [x, y] = arc.centroid(d);
+    handler(d.data, {event, x, y});
   }
 
   /**
@@ -215,10 +215,8 @@ class RadialChart extends React.Component {
     }
 
     const opacityFunctor = this._getAttributeFunctor('opacity');
-    const fillFunctor = this._getAttributeFunctor('fill') ||
-      this._getAttributeFunctor('color');
-    const strokeFunctor = this._getAttributeFunctor('stroke') ||
-      this._getAttributeFunctor('color');
+    const fillFunctor = this._getAttributeFunctor('fill') || this._getAttributeFunctor('color');
+    const strokeFunctor = this._getAttributeFunctor('stroke') || this._getAttributeFunctor('color');
 
     const pie = d3Shape.pie().sort(null).value(d => d.angle);
     const pieData = pie(data);
@@ -237,28 +235,19 @@ class RadialChart extends React.Component {
             className="rv-radial-chart__series--pie"
             transform={`translate(${width / 2},${height / 2})`}
             ref="container">
-            {data.map((d, i) => {
-              return (
-                <path {...{
-                  d: arc(pieData[i]),
-                  style: {
-                    opacity: opacityFunctor && opacityFunctor(d),
-                    stroke: strokeFunctor && strokeFunctor(d),
-                    fill: fillFunctor && fillFunctor(d)
-                  },
-                  onMouseEnter: e => {
-                    this._sectionHandler(onSectionMouseOver, pieData[i], e);
-                  },
-                  onMouseLeave: e => {
-                    this._sectionHandler(onSectionMouseOut, pieData[i], e);
-                  },
-                  onClick: e => {
-                    this._sectionHandler(onSectionClick, pieData[i], e);
-                  },
-                  key: i
-                }}/>
-              );
-            })}
+            {data.map((d, i) =>
+              <path {...{
+                d: arc(pieData[i]),
+                style: {
+                  opacity: opacityFunctor && opacityFunctor(d),
+                  stroke: strokeFunctor && strokeFunctor(d),
+                  fill: fillFunctor && fillFunctor(d)
+                },
+                onMouseEnter: e => this._sectionHandler(onSectionMouseOver, pieData[i], e),
+                onMouseLeave: e => this._sectionHandler(onSectionMouseOut, pieData[i], e),
+                onClick: e => this._sectionHandler(onSectionClick, pieData[i], e),
+                key: i
+              }}/>)}
           </g>
         </svg>
       </div>

--- a/src/radial-chart/index.js
+++ b/src/radial-chart/index.js
@@ -19,7 +19,6 @@
 // THE SOFTWARE.
 
 import React from 'react';
-import equal from 'deep-equal';
 import * as d3Shape from 'd3-shape';
 
 import Animation from 'animation';
@@ -91,22 +90,16 @@ class RadialChart extends React.Component {
     const scaleProps = this._getAllScaleProps(props, data);
     const arc = this._getArcFromProps(scaleProps);
     this.state = {scaleProps, data, arc};
-    this._sectionMouseOut = this._sectionMouseOut.bind(this);
-    this._sectionMouseOver = this._sectionMouseOver.bind(this);
-    this._sectionClick = this._sectionClick.bind(this);
   }
 
   componentWillReceiveProps(nextProps) {
     const nextData = assignColorsToData(nextProps.data);
-    const {scaleProps} = this.state;
-    const nextscaleProps = this._getAllScaleProps(nextProps, nextData);
-    if (!equal(nextscaleProps, scaleProps)) {
-      this.setState({
-        scaleProps: nextscaleProps,
-        data: nextData,
-        arc: this._getArcFromProps(scaleProps)
-      });
-    }
+    const nextScaleProps = this._getAllScaleProps(nextProps, nextData);
+    this.setState({
+      scaleProps: this._getAllScaleProps(nextProps, nextData),
+      data: nextData,
+      arc: this._getArcFromProps(nextScaleProps)
+    });
   }
 
   /**
@@ -116,45 +109,12 @@ class RadialChart extends React.Component {
    * @param {Object} event Event.
    * @private
    */
-  _triggerSectionHandler(handler, d, event) {
+  _sectionHandler(handler, d, event) {
     if (handler) {
       const {arc} = this.state;
       const [x, y] = arc.centroid(d);
       handler(d.data, {event, x, y});
     }
-  }
-
-  /**
-   * `mouseover` handler for the section.
-   * @param {Object} d Data point.
-   * @param {Object} event Event.
-   * @private
-   */
-  _sectionMouseOver(d, event) {
-    const {onSectionMouseOver} = this.props;
-    this._triggerSectionHandler(onSectionMouseOver, d, event);
-  }
-
-  /**
-   * `mouseout` handler for the section.
-   * @param {Object} d Data point.
-   * @param {Object} event Event.
-   * @private
-   */
-  _sectionMouseOut(d, event) {
-    const {onSectionMouseOut} = this.props;
-    this._triggerSectionHandler(onSectionMouseOut, d, event);
-  }
-
-  /**
-   * `click` handler for the section.
-   * @param {Object} d Data point.
-   * @param {Object} event Event.
-   * @private
-   */
-  _sectionClick(d, event) {
-    const {onSectionClick} = this.props;
-    this._triggerSectionHandler(onSectionClick, d, event);
   }
 
   /**
@@ -232,7 +192,15 @@ class RadialChart extends React.Component {
   }
 
   render() {
-    const {width, height, animation} = this.props;
+    const {
+      animation,
+      height,
+      onSectionMouseOver,
+      onSectionMouseOut,
+      onSectionClick,
+      width
+    } = this.props;
+
     if (animation) {
       return (
         <Animation {...this.props} animatedProps={ANIMATED_PROPS}>
@@ -254,7 +222,6 @@ class RadialChart extends React.Component {
 
     const pie = d3Shape.pie().sort(null).value(d => d.angle);
     const pieData = pie(data);
-
     return (
       <div
         style={{
@@ -270,18 +237,28 @@ class RadialChart extends React.Component {
             className="rv-radial-chart__series--pie"
             transform={`translate(${width / 2},${height / 2})`}
             ref="container">
-            {data.map((d, i) => <path {...{
-              d: arc(pieData[i]),
-              style: {
-                opacity: opacityFunctor && opacityFunctor(d),
-                stroke: strokeFunctor && strokeFunctor(d),
-                fill: fillFunctor && fillFunctor(d)
-              },
-              onMouseOver: e => this._sectionMouseOver(pieData[i], e),
-              onMouseOut: e => this._sectionMouseOut(pieData[i], e),
-              onClick: e => this._sectionClick(pieData[i], e),
-              key: i
-            }}/>)}
+            {data.map((d, i) => {
+              return (
+                <path {...{
+                  d: arc(pieData[i]),
+                  style: {
+                    opacity: opacityFunctor && opacityFunctor(d),
+                    stroke: strokeFunctor && strokeFunctor(d),
+                    fill: fillFunctor && fillFunctor(d)
+                  },
+                  onMouseEnter: e => {
+                    this._sectionHandler(onSectionMouseOver, pieData[i], e);
+                  },
+                  onMouseLeave: e => {
+                    this._sectionHandler(onSectionMouseOut, pieData[i], e);
+                  },
+                  onClick: e => {
+                    this._sectionHandler(onSectionClick, pieData[i], e);
+                  },
+                  key: i
+                }}/>
+              );
+            })}
           </g>
         </svg>
       </div>

--- a/src/styles/radial-chart.scss
+++ b/src/styles/radial-chart.scss
@@ -1,6 +1,3 @@
-.rv-radial-chart {
-}
-
 .rv-radial-chart__svg {
   display: block;
 }

--- a/src/utils/scales-utils.js
+++ b/src/utils/scales-utils.js
@@ -135,7 +135,10 @@ function _getScaleFnFromScaleObject(scaleObject) {
     return null;
   }
   const {type, domain, range} = scaleObject;
-  const scale = SCALE_FUNCTIONS[type]().domain(domain).range(range);
+  const modDomain = domain[0] === domain[1] ?
+    (domain[0] === 0 ? [-1, 0] : [-domain[0], domain[0]]) :
+    domain;
+  const scale = SCALE_FUNCTIONS[type]().domain(modDomain).range(range);
   if (type === ORDINAL_SCALE_TYPE) {
     scale.padding(0.5);
   }


### PR DESCRIPTION
This PR addresses a number of bugs that have been present in the radial chart for a while. Chief among them are: 

- When specify a variable such as opacity that happen to all have the same value, the value default to a small value. This problem is documented in #234 

- Radial chart not updating when new props are passed. This issue was briefly referenced in #161 but didn't have a direct gh-issue about it, so I added a example that demonstrates how to build a hover, as well demonstrates the bug. 

- Untangling the mouse events in radial (#157)

