### PR TITLE
Add labels to radial plot

### DIFF
--- a/showcase/radial-chart/custom-radius-radial-chart.js
+++ b/showcase/radial-chart/custom-radius-radial-chart.js
@@ -33,6 +33,7 @@ export default class SimpleRadialChart extends Component {
     return (
       <RadialChart
         animation
+        showLabels
         radiusDomain={[0, 20]}
         data={[
           {
@@ -43,6 +44,8 @@ export default class SimpleRadialChart extends Component {
           },
           {
             angle: 2,
+            label: 'Super Custom label',
+            subLabel: 'With annotation',
             id: 2,
             radius: 20,
             opacity: (!hoveredSection || hoveredSection === 2) ? 1 : 0.6
@@ -51,7 +54,8 @@ export default class SimpleRadialChart extends Component {
             angle: 5,
             id: 3,
             radius: 5,
-            opacity: (!hoveredSection || hoveredSection === 3) ? 1 : 0.6
+            opacity: (!hoveredSection || hoveredSection === 3) ? 1 : 0.6,
+            label: 'Alt Label'
           },
           {
             angle: 3,
@@ -63,12 +67,13 @@ export default class SimpleRadialChart extends Component {
             angle: 5,
             id: 5,
             radius: 12,
+            subLabel: 'Sub Label only',
             opacity: (!hoveredSection || hoveredSection === 5) ? 1 : 0.6
           }
         ]}
         onSectionMouseOver={row => this.setState({hoveredSection: row.id})}
         onSectionMouseOut={() => this.setState({hoveredSection: false})}
-        width={300}
+        width={600}
         height={300} />
     );
   }

--- a/showcase/radial-chart/simple-radial-chart.js
+++ b/showcase/radial-chart/simple-radial-chart.js
@@ -31,13 +31,14 @@ export default class SimpleRadialChart extends React.Component {
         colorRange={[0, 10]}
         margin={{top: 100}}
         data={[
-          {angle: 1, color: '#0f0'},
-          {angle: 2, color: '#ff0'},
-          {angle: 5, color: '#0ff'},
-          {angle: 3, color: '#f0f'},
-          {angle: 5, color: '#ff0'}
+          {angle: 1, color: '#0f0', label: 'green'},
+          {angle: 2, color: '#ff0', label: 'yellow'},
+          {angle: 5, color: '#0ff', label: 'cyan'},
+          {angle: 3, color: '#f0f', label: 'magenta'},
+          {angle: 5, color: '#ff0', label: 'yellow again'}
         ]}
-        width={300}
+        showLabels
+        width={400}
         height={300} />
     );
   }

--- a/src/radial-chart/index.js
+++ b/src/radial-chart/index.js
@@ -232,9 +232,15 @@ class RadialChart extends React.Component {
       if (!canRenderMainLabel && !canRenderSubLabel) {
         return;
       }
+      // this equation finds the center of the pie wedge and place the label there
+      // there is a quarter circle correction, due to where d3 places it's coord system
       const angle = (pieData[i].startAngle + pieData[i].endAngle) / 2 - Math.PI / 2;
+      // we then translate a g to just outside the location of the wedge
       const xTrans = 1.1 * radiusFunctor(d) * Math.cos(angle);
       const yTrans = 1.1 * radiusFunctor(d) * Math.sin(angle);
+      // finally we select which way we want the text to be oriented
+      // if its on the left half of the circle, the it should be right aligned
+      // and vice versa for the right half
       const textAnchor = (angle > 0.5 * Math.PI) && angle < (1.5 * Math.PI) ? 'end' : 'start';
       return (
         <g transform={`translate(${xTrans},${yTrans})`} key={`${i}-text-wrapper`}>

--- a/src/styles/radial-chart.scss
+++ b/src/styles/radial-chart.scss
@@ -8,3 +8,9 @@
     stroke-width: 1px;
   }
 }
+
+.rv-radial-chart__series--pie__label {
+  fill: #333;
+  font-family: Sintony, Helvetica, sans-serif;
+  font-size: 12px;
+}

--- a/src/styles/radial-chart.scss
+++ b/src/styles/radial-chart.scss
@@ -8,9 +8,3 @@
     stroke-width: 1px;
   }
 }
-
-.rv-radial-chart__series--pie__label {
-  fill: #333;
-  font-family: Sintony, Helvetica, sans-serif;
-  font-size: 12px;
-}


### PR DESCRIPTION
This PR addresses the omnipresent need to add labels to the radial plot (#39). To do so we modify the api of the radial plot in a couple of ways. We add a top level prop called showLabels to engage the labels, and two new data props, label and subLabel (See below screencap)

<img width="1421" alt="screen shot 2017-01-20 at 8 36 49 am" src="https://cloud.githubusercontent.com/assets/6854312/22157357/3e6653ea-deec-11e6-8ad6-06e92d72d7c4.png">

I think the long term solution for labels & radial plots will be to develop a labelSeries that accepts regular coordinates, and then use that in conjunction with the r-theta plot. In the mean time, this solution makes sense to me as a way to make our pie chart more ethical (label-less pie charts aint great). 