### PR TITLE
A case is wrong in HInt.js

### DIFF
--- a/src/plot/hint.js
+++ b/src/plot/hint.js
@@ -225,7 +225,7 @@ class Hint extends PureRenderComponent {
         horizontal: ALIGN.LEFT,
         vertical: ALIGN.TOP
       };
-    case ALIGN.TOP_RIGHT:
+    case ORIENTATION.TOP_RIGHT:
       return {
         horizontal: ALIGN.RIGHT,
         vertical: ALIGN.TOP


### PR DESCRIPTION
A case in Hint.js on `_mapOrientationToAlign` is wrong. 