### PR TITLE
Add modes to treemap

### DIFF
--- a/showcase/treemap/simple-treemap.js
+++ b/showcase/treemap/simple-treemap.js
@@ -32,6 +32,7 @@ export default class SimpleTreemapExample extends React.Component {
         className="nested-tree-example"
         colorType="literal"
         data={D3FlareData}
+        mode="slicedice"
         height={300}
         width={350}/>
     );

--- a/src/treemap/index.js
+++ b/src/treemap/index.js
@@ -28,9 +28,11 @@ import {getAttributeFunctor, getFontColorFromBackground, getMissingScaleProps} f
 
 const TREEMAP_TILE_MODES = {
   squarify: d3Hierarchy.treemapSquarify,
+  resquarify: d3Hierarchy.treemapResquarify,
   slice: d3Hierarchy.treemapSlice,
   dice: d3Hierarchy.treemapDice,
-  slicedice: d3Hierarchy.treemapSliceDice
+  slicedice: d3Hierarchy.treemapSliceDice,
+  binary: d3Hierarchy.treemapBinary
 };
 
 const NOOP = d => d;

--- a/src/treemap/index.js
+++ b/src/treemap/index.js
@@ -121,7 +121,7 @@ class Treemap extends React.Component {
     if (data) {
       const tileFn = TREEMAP_TILE_MODES[mode];
       return d3Hierarchy.treemap(tileFn)
-        .tile(d3Hierarchy.treemapSquarify)
+        .tile(tileFn)
         .size([width, height])
         .padding(padding)(
           d3Hierarchy.hierarchy(data)


### PR DESCRIPTION
The treemap currently has a prop exposed for accepting a tiling strategy, but unfortunately it was not hooked up right. This fixes that and adds some more tiling strategies. 