### PR TITLE
Add a circle packing mode to treemap

### DIFF
--- a/showcase/index.js
+++ b/showcase/index.js
@@ -53,6 +53,7 @@ import VoronoiLineChart from './plot/voronoi-line-chart';
 
 import SimpleTreemap from './treemap/simple-treemap';
 import TreemapExample from './treemap/dynamic-treemap';
+import CirclePacking from './treemap/circle-packed-treemap';
 
 import SimpleRadialChart from './radial-chart/simple-radial-chart';
 import DonutChartExample from './radial-chart/donut-chart';
@@ -248,6 +249,10 @@ const App = (
       <section>
         <h3>Animated Treemap</h3>
         <TreemapExample />
+      </section>
+      <section>
+        <h3>Circle Packing</h3>
+        <CirclePacking />
       </section>
     </article>
 

--- a/showcase/treemap/circle-packed-treemap.js
+++ b/showcase/treemap/circle-packed-treemap.js
@@ -29,9 +29,9 @@ export default class CirclePackedTreemap extends React.Component {
       <Treemap
         colorType="literal"
         className="circle-packed-treemap-example"
-        useCirclePacking={true}
         data={D3FlareData}
         height={300}
+        mode="circlePack"
         width={500}/>
     );
   }

--- a/showcase/treemap/circle-packed-treemap.js
+++ b/showcase/treemap/circle-packed-treemap.js
@@ -1,0 +1,38 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the 'Software'), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import React from 'react';
+
+import Treemap from 'treemap';
+import D3FlareData from './d3-flare-example.json';
+
+export default class CirclePackedTreemap extends React.Component {
+  render() {
+    return (
+      <Treemap
+        colorType="literal"
+        className="circle-packed-treemap-example"
+        useCirclePacking={true}
+        data={D3FlareData}
+        height={300}
+        width={500}/>
+    );
+  }
+}

--- a/showcase/treemap/dynamic-treemap.js
+++ b/showcase/treemap/dynamic-treemap.js
@@ -27,7 +27,8 @@ export default class DynamicTreemapExample extends React.Component {
 
   state = {
     hoveredNode: false,
-    treemapData: this._getRandomData()
+    treemapData: this._getRandomData(),
+    useCirclePacking: false
   }
 
   componentDidMount() {
@@ -62,16 +63,20 @@ export default class DynamicTreemapExample extends React.Component {
   }
 
   render() {
+    const treeProps = {
+      animation: true,
+      data: this.state.treemapData,
+      onLeafMouseOver: x => this.setState({hoveredNode: x}),
+      onLeafMouseOut: () => this.setState({hoveredNode: false}),
+      onLeafClick: () => this.setState({useCirclePacking: !this.state.useCirclePacking}),
+      height: 300,
+      useCirclePacking: this.state.useCirclePacking,
+      width: 350
+    };
     return (
-      <div>
-        <Treemap
-          animation
-          data={this.state.treemapData}
-          onLeafMouseOver={x => this.setState({hoveredNode: x})}
-          onLeafMouseOut={() => this.setState({hoveredNode: false})}
-          onLeafClick={() => this.setState({treemapData: this._getRandomData()})}
-          height={300}
-          width={350}/>
+      <div className="dynamic-treemap-example">
+        click below!
+        <Treemap {...treeProps}/>
         {this.state.hoveredNode && this.state.hoveredNode.value}
       </div>
     );

--- a/showcase/treemap/dynamic-treemap.js
+++ b/showcase/treemap/dynamic-treemap.js
@@ -70,7 +70,7 @@ export default class DynamicTreemapExample extends React.Component {
       onLeafMouseOut: () => this.setState({hoveredNode: false}),
       onLeafClick: () => this.setState({useCirclePacking: !this.state.useCirclePacking}),
       height: 300,
-      useCirclePacking: this.state.useCirclePacking,
+      mode: this.state.useCirclePacking ? 'circlePack' : 'squarify',
       width: 350
     };
     return (

--- a/src/styles/examples.scss
+++ b/src/styles/examples.scss
@@ -308,3 +308,15 @@ article {
     height: 0;
   }
 }
+
+.circle-packed-treemap-example {
+  .rv-treemap__leaf--circle {
+    border: thin solid #ddd;
+  }
+}
+
+.dynamic-treemap-example {
+  .rv-treemap__leaf--circle {
+    border: thin solid white;
+  }
+}

--- a/src/styles/treemap.scss
+++ b/src/styles/treemap.scss
@@ -8,6 +8,13 @@
   position: absolute;
 }
 
+.rv-treemap__leaf--circle {
+  align-items: center;
+  border-radius: 100%;
+  display: flex;
+  justify-content: center;
+}
+
 .rv-treemap__leaf__content {
   overflow: hidden;
   padding: 10px;

--- a/src/treemap/index.js
+++ b/src/treemap/index.js
@@ -46,6 +46,10 @@ const TREEMAP_TILE_MODES = {
   binary: treemapBinary
 };
 
+const TREEMAP_LAYOUT_MODES = [
+  'circlePack'
+];
+
 const NOOP = d => d;
 
 const ATTRIBUTES = ['opacity', 'color'];
@@ -81,7 +85,7 @@ class Treemap extends React.Component {
       data: PropTypes.object.isRequired,
       height: PropTypes.number.isRequired,
       mode: PropTypes.oneOf(
-        Object.keys(TREEMAP_TILE_MODES)
+        Object.keys(TREEMAP_TILE_MODES).concat(TREEMAP_LAYOUT_MODES)
       ),
       onLeafClick: PropTypes.func,
       onLeafMouseOver: PropTypes.func,
@@ -125,8 +129,8 @@ class Treemap extends React.Component {
    * @private
    */
   _getNodesToRender() {
-    const {data, height, width, mode, padding, useCirclePacking} = this.props;
-    if (data && useCirclePacking) {
+    const {data, height, width, mode, padding} = this.props;
+    if (data && mode === 'circlePack') {
       const packingFunction = pack()
           .size([width, height])
           .padding(padding);
@@ -151,9 +155,9 @@ class Treemap extends React.Component {
   }
 
   render() {
-    const {animation, className, height, useCirclePacking, width} = this.props;
+    const {animation, className, height, mode, width} = this.props;
     const nodes = this._getNodesToRender();
-
+    const useCirclePacking = mode === 'circlePack';
     return (
       <div
         className={`rv-treemap ${useCirclePacking ? 'rv-treemap-circle-packed' : ''} ${className}`}

--- a/src/treemap/index.js
+++ b/src/treemap/index.js
@@ -19,7 +19,17 @@
 // THE SOFTWARE.
 
 import React, {PropTypes} from 'react';
-import * as d3Hierarchy from 'd3-hierarchy';
+import {
+  hierarchy,
+  pack,
+  treemapSquarify,
+  treemapResquarify,
+  treemapSlice,
+  treemapDice,
+  treemapSliceDice,
+  treemapBinary,
+  treemap
+} from 'd3-hierarchy';
 
 import {CONTINUOUS_COLOR_RANGE, DEFAULT_COLOR, OPACITY_RANGE} from 'theme';
 import {AnimationPropType} from 'utils/animation-utils';
@@ -28,12 +38,12 @@ import {getAttributeFunctor, getMissingScaleProps} from 'utils/scales-utils';
 import TreemapLeaf from './treemap-leaf';
 
 const TREEMAP_TILE_MODES = {
-  squarify: d3Hierarchy.treemapSquarify,
-  resquarify: d3Hierarchy.treemapResquarify,
-  slice: d3Hierarchy.treemapSlice,
-  dice: d3Hierarchy.treemapDice,
-  slicedice: d3Hierarchy.treemapSliceDice,
-  binary: d3Hierarchy.treemapBinary
+  squarify: treemapSquarify,
+  resquarify: treemapResquarify,
+  slice: treemapSlice,
+  dice: treemapDice,
+  slicedice: treemapSliceDice,
+  binary: treemapBinary
 };
 
 const NOOP = d => d;
@@ -76,6 +86,7 @@ class Treemap extends React.Component {
       onLeafClick: PropTypes.func,
       onLeafMouseOver: PropTypes.func,
       onLeafMouseOut: PropTypes.func,
+      useCirclePacking: PropTypes.bool,
       padding: PropTypes.number.isRequired,
       width: PropTypes.number.isRequired
     };
@@ -114,36 +125,45 @@ class Treemap extends React.Component {
    * @private
    */
   _getNodesToRender() {
-    const {data, height, width, mode, padding} = this.props;
-
+    const {data, height, width, mode, padding, useCirclePacking} = this.props;
+    if (data && useCirclePacking) {
+      const packingFunction = pack()
+          .size([width, height])
+          .padding(padding);
+      const structuredInput = hierarchy(data)
+        .sort((a, b) => a.size - b.size)
+        .sum(d => d.size);
+      return packingFunction(structuredInput).descendants();
+    }
     if (data) {
       const tileFn = TREEMAP_TILE_MODES[mode];
-      return d3Hierarchy.treemap(tileFn)
+      const treemapingFunction = treemap(tileFn)
         .tile(tileFn)
         .size([width, height])
-        .padding(padding)(
-          d3Hierarchy.hierarchy(data)
-            .sort((a, b) => a.size - b.size)
-            .sum(d => d.size)
-        ).descendants();
+        .padding(padding);
+      const structuredInput = hierarchy(data)
+        .sort((a, b) => a.size - b.size)
+        .sum(d => d.size);
+
+      return treemapingFunction(structuredInput).descendants();
     }
     return [];
   }
 
   render() {
-    const {animation, className, height, width} = this.props;
+    const {animation, className, height, useCirclePacking, width} = this.props;
     const nodes = this._getNodesToRender();
 
     return (
       <div
-        className={`rv-treemap ${className}`}
+        className={`rv-treemap ${useCirclePacking ? 'rv-treemap-circle-packed' : ''} ${className}`}
         style={{
           width: `${width}px`,
           height: `${height}px`
         }}>
         {nodes.map((node, index) => {
           // throw out the rootest node
-          if (!index) {
+          if (!useCirclePacking && !index) {
             return null;
           }
 
@@ -151,10 +171,11 @@ class Treemap extends React.Component {
             animation,
             node,
             ...this.props,
-            x0: node.x0,
-            x1: node.x1,
-            y0: node.y0,
-            y1: node.y1,
+            x0: useCirclePacking ? node.x : node.x0,
+            x1: useCirclePacking ? node.x : node.x1,
+            y0: useCirclePacking ? node.y : node.y0,
+            y1: useCirclePacking ? node.y : node.y1,
+            r: useCirclePacking ? node.r : 1,
             scales: this.state.scales
           };
           return (<TreemapLeaf {...nodeProps} key={`leaf-${index}`} />);

--- a/src/treemap/treemap-leaf.js
+++ b/src/treemap/treemap-leaf.js
@@ -27,7 +27,7 @@ import {getFontColorFromBackground} from 'utils/scales-utils';
 const ANIMATED_PROPS = [
   'colorRange', 'colorDomain', 'color',
   'opacityRange', 'opacityDomain', 'opacity',
-  'x0', 'x1', 'y0', 'y1'
+  'x0', 'x1', 'y0', 'y1', 'r'
 ];
 
 class TreemapLeaf extends React.Component {
@@ -42,6 +42,8 @@ class TreemapLeaf extends React.Component {
       onLeafMouseOut: PropTypes.func,
       scales: PropTypes.object.isRequired,
       width: PropTypes.number.isRequired,
+      useCirclePacking: PropTypes.bool,
+      r: PropTypes.number.isRequired,
       x0: PropTypes.number.isRequired,
       x1: PropTypes.number.isRequired,
       y0: PropTypes.number.isRequired,
@@ -56,7 +58,9 @@ class TreemapLeaf extends React.Component {
       onLeafClick,
       onLeafMouseOver,
       onLeafMouseOut,
+      r,
       scales,
+      useCirclePacking,
       x0,
       x1,
       y0,
@@ -76,15 +80,15 @@ class TreemapLeaf extends React.Component {
     const {data: {title}} = node;
     return (
       <div
-        className="rv-treemap__leaf"
+        className={`rv-treemap__leaf ${useCirclePacking ? 'rv-treemap__leaf--circle' : ''}`}
         onMouseEnter={event => onLeafMouseOver(node, event)}
         onMouseLeave={event => onLeafMouseOut(node, event)}
         onClick={event => onLeafClick(node, event)}
         style={{
-          top: y0,
-          left: x0,
-          width: x1 - x0,
-          height: y1 - y0,
+          top: useCirclePacking ? (y0 - r) : y0,
+          left: useCirclePacking ? (x0 - r) : x0,
+          width: useCirclePacking ? r * 2 : x1 - x0,
+          height: useCirclePacking ? r * 2 : y1 - y0,
           background,
           opacity,
           color

--- a/src/treemap/treemap-leaf.js
+++ b/src/treemap/treemap-leaf.js
@@ -36,13 +36,13 @@ class TreemapLeaf extends React.Component {
     return {
       animation: AnimationPropType,
       height: PropTypes.number.isRequired,
+      mode: PropTypes.string,
       node: PropTypes.object.isRequired,
       onLeafClick: PropTypes.func,
       onLeafMouseOver: PropTypes.func,
       onLeafMouseOut: PropTypes.func,
       scales: PropTypes.object.isRequired,
       width: PropTypes.number.isRequired,
-      useCirclePacking: PropTypes.bool,
       r: PropTypes.number.isRequired,
       x0: PropTypes.number.isRequired,
       x1: PropTypes.number.isRequired,
@@ -54,13 +54,13 @@ class TreemapLeaf extends React.Component {
   render() {
     const {
       animation,
+      mode,
       node,
       onLeafClick,
       onLeafMouseOver,
       onLeafMouseOut,
       r,
       scales,
-      useCirclePacking,
       x0,
       x1,
       y0,
@@ -73,7 +73,7 @@ class TreemapLeaf extends React.Component {
         </Animation>
       );
     }
-
+    const useCirclePacking = mode === 'circlePack';
     const background = scales.color(node);
     const opacity = scales.opacity(node);
     const color = getFontColorFromBackground(background);


### PR DESCRIPTION
This PR adds a circle packing mode to the treemap (#153)

![treemap-animation-circle](https://cloud.githubusercontent.com/assets/6854312/23113488/4fbfd35a-f6ed-11e6-9aa6-e02ddbea893f.gif)
