### PR TITLE
Modify Default Opacity

### DIFF
--- a/showcase/index.js
+++ b/showcase/index.js
@@ -222,7 +222,6 @@ const App = (
         <VoronoiLineChart />
       </section>
     </article>
-
     <article id="radial-charts">
       <h1>Radial Chart</h1>
       <section>

--- a/showcase/radial-chart/simple-radial-chart.js
+++ b/showcase/radial-chart/simple-radial-chart.js
@@ -31,7 +31,7 @@ export default class SimpleRadialChart extends React.Component {
         colorRange={[0, 10]}
         margin={{top: 100}}
         data={[
-          {angle: 1, color: '#0f0', label: 'green'},
+          {angle: 1, color: '#0f0', label: 'green', opacity: 0.2},
           {angle: 2, color: '#ff0', label: 'yellow'},
           {angle: 5, color: '#0ff', label: 'cyan'},
           {angle: 3, color: '#f0f', label: 'magenta'},

--- a/src/plot/xy-plot.js
+++ b/src/plot/xy-plot.js
@@ -25,7 +25,7 @@ import {extractScalePropsFromProps, getMissingScaleProps} from 'utils/scales-uti
 import {getStackedData, getSeriesChildren, getSeriesPropsFromChildren} from 'utils/series-utils';
 import {getInnerDimensions, MarginPropType} from 'utils/chart-utils';
 import {AnimationPropType} from 'utils/animation-utils';
-import {CONTINUOUS_COLOR_RANGE, SIZE_RANGE, OPACITY_RANGE} from 'theme';
+import {CONTINUOUS_COLOR_RANGE, SIZE_RANGE, OPACITY_TYPE} from 'theme';
 
 const ATTRIBUTES = [
   'x',
@@ -165,7 +165,7 @@ class XYPlot extends React.Component {
       xRange: [0, innerWidth],
       yRange: [innerHeight, 0],
       colorRange: CONTINUOUS_COLOR_RANGE,
-      opacityRange: OPACITY_RANGE,
+      opacityType: OPACITY_TYPE,
       sizeRange: SIZE_RANGE
     };
   }

--- a/src/radial-chart/index.js
+++ b/src/radial-chart/index.js
@@ -24,7 +24,7 @@ import * as d3Shape from 'd3-shape';
 import Animation from 'animation';
 import {getInnerDimensions, MarginPropType} from 'utils/chart-utils';
 import {AnimationPropType} from 'utils/animation-utils';
-import {OPACITY_RANGE, DISCRETE_COLOR_RANGE} from 'theme';
+import {DEFAULT_OPACITY, OPACITY_TYPE, DISCRETE_COLOR_RANGE} from 'theme';
 import {
   getAttributeFunctor,
   extractScalePropsFromProps,
@@ -133,8 +133,8 @@ class RadialChart extends React.Component {
     return {
       radiusRange: [0, radius],
       _radiusValue: radius,
-      opacityRange: OPACITY_RANGE,
-      _opacityValue: 1,
+      opacityType: OPACITY_TYPE,
+      _opacityValue: DEFAULT_OPACITY,
       colorRange: DISCRETE_COLOR_RANGE,
       colorType: 'category'
     };

--- a/src/theme.js
+++ b/src/theme.js
@@ -34,7 +34,7 @@ export const CONTINUOUS_COLOR_RANGE = [
 export const SIZE_RANGE = [1, 10];
 
 export const OPACITY_RANGE = [0.1, 1];
-
+export const OPACITY_TYPE = 'literal';
 export const DEFAULT_OPACITY = 1;
 
 export const DEFAULT_SIZE = 5;

--- a/src/treemap/index.js
+++ b/src/treemap/index.js
@@ -21,7 +21,7 @@
 import React, {PropTypes} from 'react';
 import * as d3Hierarchy from 'd3-hierarchy';
 
-import {CONTINUOUS_COLOR_RANGE, DEFAULT_COLOR, OPACITY_RANGE} from 'theme';
+import {CONTINUOUS_COLOR_RANGE, DEFAULT_COLOR, DEFAULT_OPACITY, OPACITY_TYPE} from 'theme';
 import {AnimationPropType} from 'utils/animation-utils';
 import {getAttributeFunctor, getMissingScaleProps} from 'utils/scales-utils';
 
@@ -93,8 +93,8 @@ class Treemap extends React.Component {
       onLeafClick: NOOP,
       onLeafMouseOver: NOOP,
       onLeafMouseOut: NOOP,
-      opacityRange: OPACITY_RANGE,
-      _opacityValue: 1,
+      opacityType: OPACITY_TYPE,
+      _opacityValue: DEFAULT_OPACITY,
       padding: 1
     };
   }

--- a/src/utils/scales-utils.js
+++ b/src/utils/scales-utils.js
@@ -189,10 +189,22 @@ export function getDomainByAttr(allData, attr, type) {
  * this object, it should return the same value all time.
  * @param {string} attr Attribute.
  * @param {*} value Value.
+ * @param {string} type - the type of scale being used
  * @returns {Object} Custom scale object.
  * @private
  */
-function _createScaleObjectForValue(attr, value) {
+function _createScaleObjectForValue(attr, value, type) {
+  if (type === 'literal') {
+    return {
+      type: 'literal',
+      domain: [],
+      range: [],
+      distance: 0,
+      attr,
+      baseValue: undefined,
+      isValue: true
+    };
+  }
   if (typeof value === 'undefined') {
     return null;
   }
@@ -251,7 +263,7 @@ function _collectScaleObjectFromProps(props, attr) {
 
   // Return value-based scale if the value is assigned.
   if (typeof value !== 'undefined') {
-    return _createScaleObjectForValue(attr, value);
+    return _createScaleObjectForValue(attr, value, props[`${attr}Type`]);
   }
 
   // Pick up the domain from the properties and create a new one if it's not
@@ -263,7 +275,7 @@ function _collectScaleObjectFromProps(props, attr) {
   // Make sure that the minimum necessary properties exist.
   if (!range || !domain || !domain.length) {
     // Try to use the fallback value if it is available.
-    return _createScaleObjectForValue(attr, fallbackValue);
+    return _createScaleObjectForValue(attr, fallbackValue, props[`${attr}Type`]);
   }
 
   return _createScaleObjectForFunction(


### PR DESCRIPTION
Right now the default opacity is really confusing! For some reason it imposes a range [0.1, 1], which would be cool if people weren't familiar with the normal domain of opacity for the browser, but at this point it's pretty clear. The main change in this PR is to remove this range and switch the default opacity scale to be a LITERAL so that opacity behaves closer to what users expect. This is a breaking change, and will be clustered in with the other breaking changes.

This addresses #234, #155 