### PR TITLE
tickSizeInner should be tickSizeOuter and vice versa.  

### DIFF
--- a/docs/xy-plot.md
+++ b/docs/xy-plot.md
@@ -210,10 +210,14 @@ Type: `number`
 Default: `null`
 Tick size for the axis. Sets the outer size of the tick line. Similar to the `tickSizeOuter()` method of d3-axis.
 
+NOTE: 1.0.0 and onwards now properly draws outer tick using this value. Previously, this value affected the drawing of inner tick.
+
 #### tickSizeInner (optional)
 Type: `number`  
 Default: `null`
 Tick size for the axis. Sets the inner size of the tick line. Similar to the `tickSizeInner()` method of d3-axis.
+
+NOTE: v1.0.0+ properly draws inner tick using this value. Previously, this value affected the drawing of outer tick.
 
 #### tickPadding (optional)
 Type: `number`  

--- a/showcase/plot/complex-chart.js
+++ b/showcase/plot/complex-chart.js
@@ -173,8 +173,16 @@ export default class Example extends React.Component {
             onMouseLeave={this._mouseLeaveHandler}
             height={300}>
             <HorizontalGridLines />
-            <YAxis className="cool-custom-name"/>
-            <XAxis className="even-cooler-custom-name"/>
+            <YAxis
+              className="cool-custom-name"
+              tickSizeInner={ 0 }
+              tickSizeOuter={ 8 }
+            />
+            <XAxis
+              className="even-cooler-custom-name"
+              tickSizeInner={ 0 }
+              tickSizeOuter={ 8 }
+            />
             <VerticalBarSeries
               data={series[0].data}
               onNearestX={this._nearestXHandler}

--- a/src/plot/axis/axis-ticks.js
+++ b/src/plot/axis/axis-ticks.js
@@ -73,7 +73,7 @@ class AxisTicks extends React.Component {
   }
 
   /**
-   * Get hte props of the tick line.
+   * Get the props of the tick line.
    * @returns {Object} Props.
    * @private
    */
@@ -89,8 +89,8 @@ class AxisTicks extends React.Component {
     return {
       [`${tickXAttr}1`]: 0,
       [`${tickXAttr}2`]: 0,
-      [`${tickYAttr}1`]: -wrap * tickSizeOuter,
-      [`${tickYAttr}2`]: wrap * tickSizeInner
+      [`${tickYAttr}1`]: -wrap * tickSizeInner,
+      [`${tickYAttr}2`]: wrap * tickSizeOuter
     };
   }
 

--- a/src/styles/examples.scss
+++ b/src/styles/examples.scss
@@ -158,8 +158,8 @@ article {
 
   .chart {
     margin-right: 200px;
-    & .rv-xy-plot__axis__tick__line {
-      stroke: #6b6b76;
+    .rv-xy-plot__axis__tick__line {
+      stroke: $rv-xy-plot-axis-font-color;
     }
   }
 

--- a/src/styles/examples.scss
+++ b/src/styles/examples.scss
@@ -158,6 +158,9 @@ article {
 
   .chart {
     margin-right: 200px;
+    & .rv-xy-plot__axis__tick__line {
+      stroke: #6b6b76;
+    }
   }
 
   .legend {


### PR DESCRIPTION
The plot is the reference point. The old version had it inverted. 
Updated the complex-chart example to show that the changes work.
Attached image shows the example with outTicks of size 8.
![pr179](https://cloud.githubusercontent.com/assets/2983206/23133950/d4c753e8-f747-11e6-98d2-2680edcc5640.png)
