### PR TITLE
Make literal scales honor the values provided via props

### DIFF
--- a/src/utils/scales-utils.js
+++ b/src/utils/scales-utils.js
@@ -202,7 +202,7 @@ function _createScaleObjectForValue(attr, value, type) {
     return {
       type: 'literal',
       domain: [],
-      range: [],
+      range: [value],
       distance: 0,
       attr,
       baseValue: undefined,

--- a/tests/components/line-series-tests.js
+++ b/tests/components/line-series-tests.js
@@ -62,3 +62,23 @@ test('LineSeries: Showcase Example - LineMarkSeries', t => {
   });
   t.end();
 });
+
+test('LineSeries: Line Styling', t => {
+  const $ = mount(
+    <XYPlot width={300} height={300}>
+      <LineSeries
+        {...LINE_PROPS}
+        opacity={0.5}
+        strokeWidth="3px"
+        stroke="rgb(255, 255, 255)"
+      />
+    </XYPlot>
+  );
+
+  const lineStyle = $.find('.rv-xy-plot__series path').prop('style');
+
+  t.equal(lineStyle.opacity, 0.5, 'should render an opaque line');
+  t.equal(lineStyle.strokeWidth, '3px', 'should honor stroke width');
+  t.equal(lineStyle.stroke, 'rgb(255, 255, 255)', 'should honor stroke');
+  t.end();
+});

--- a/tests/utils/scales-utils-tests.js
+++ b/tests/utils/scales-utils-tests.js
@@ -164,6 +164,9 @@ test('scales-utils #getAttributeValue ', t => {
   // with props
   result = getAttributeValue({x: 10}, 'x');
   t.equal(result, 10, 'The value should be returned');
+  // with props including a scale type
+  result = getAttributeValue({opacity: 0.5, opacityType: 'literal'}, 'opacity');
+  t.equal(result, 0.5, 'The value should be returned');
   t.end();
 });
 


### PR DESCRIPTION
In the case of literal scales, such as opacity, the provided value was being ignored. This fixes that and adds some tests to ensure literal scale values are honored.