### PR TITLE
Fix capitalisation in docs

### DIFF
--- a/docs/xy-plot.md
+++ b/docs/xy-plot.md
@@ -61,7 +61,7 @@ Not all properties can be visualized in each series. Here's a short comparison o
 |----------------------|-----|-----|---------|-----------|--------|
 | `LineSeries`         |  +  |  +  | +       |           |        |
 | `AreaSeries`         |  +  |  +  | +       |           |        |
-| `LinemarkSeries`     |  +  |  +  | +       |     +     | +      |
+| `LineMarkSeries`     |  +  |  +  | +       |     +     | +      |
 | `MarkSeries`         |  +  |  +  | +       |     +     | +      |
 | `VerticalBarSeries`  |  +  |  +  | +       |     +     |        |
 | `HorizontalBarSeries`|  +  |  +  | +       |     +     |        |


### PR DESCRIPTION
When trying to import ´LinemarkSeries` instead of `LineMarkSeries`, it will give you an error.