### PR TITLE
Disable animation on flexible width when width is zero

### DIFF
--- a/src/make-vis-flexible.js
+++ b/src/make-vis-flexible.js
@@ -135,12 +135,13 @@ export default function makeVisFlexible(Component) {
 
     render() {
       const {width} = this.state;
+      const props = {...this.props, animation: width === 0 ? null : this.props.animation};
       return (
         <div
           ref={CONTAINER_REF}>
           <Component
             width={width}
-            {...this.props}/>
+            {...props}/>
         </div>
       );
     }

--- a/src/make-vis-flexible.js
+++ b/src/make-vis-flexible.js
@@ -136,6 +136,7 @@ export default function makeVisFlexible(Component) {
     render() {
       const {width} = this.state;
       const props = {...this.props, animation: width === 0 ? null : this.props.animation};
+
       return (
         <div
           ref={CONTAINER_REF}>


### PR DESCRIPTION
This addresses part of #147. The logic here is that the flexibility of width shouldn't be animated on first load. Also, At this point #147 is pretty stale, so I'd be willing to drop this pr if others felt it was unnecessary. 