### PR TITLE
Added clustered stacked bar chart

### DIFF
--- a/docs/markdown/series.md
+++ b/docs/markdown/series.md
@@ -36,6 +36,10 @@ Exact size for all series points in pixels or a series object.
 Type: `number|Object`  
 Exact opacity for all series points in pixels or a series object.
 
+### cluster (optional, `BarSeries` only)
+Supply a clustering key for this series.
+When used with the `stackBy` attribute, creates a clustered stacked bar chart.
+
 #### onNearestX (optional)
 Type: `function(value, info)`  
 A callback function which is triggered each time when the mouse pointer gets close to some X value.

--- a/showcase/index.js
+++ b/showcase/index.js
@@ -24,6 +24,7 @@ import LineMarkChart from './plot/linemark-chart';
 import BarChart from './plot/bar-chart';
 import StackedVerticalBarChart from './plot/stacked-vertical-bar-chart';
 import StackedHorizontalBarChart from './plot/stacked-horizontal-bar-chart';
+import ClusteredStackedVerticalBarChart from './plot/clustered-stacked-bar-chart';
 import StackedHistogram from './plot/stacked-histogram';
 import AreaChart from './plot/area-chart';
 import AreaChartElevated from './plot/area-chart-elevated';
@@ -70,6 +71,7 @@ export const showCase = {
   BarChart,
   StackedVerticalBarChart,
   StackedHorizontalBarChart,
+  ClusteredStackedVerticalBarChart,
   StackedHistogram,
   AreaChart,
   AreaChartElevated,

--- a/showcase/plot/clustered-stacked-bar-chart.js
+++ b/showcase/plot/clustered-stacked-bar-chart.js
@@ -1,0 +1,98 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import React from 'react';
+
+import {
+  XYPlot,
+  XAxis,
+  YAxis,
+  VerticalGridLines,
+  HorizontalGridLines,
+  VerticalBarSeries,
+  DiscreteColorLegend
+} from 'index';
+
+export default class Example extends React.Component {
+  render() {
+    return (
+      <XYPlot
+        className="clustered-stacked-bar-chart-example"
+        xType="ordinal"
+        stackBy="y"
+        width={300}
+        height={300}>
+        <DiscreteColorLegend
+          style={{position: 'absolute', left: '40px', top: '0px'}}
+          orientation="horizontal" items={[
+            {
+              title: 'Apples',
+              color: '#12939A'
+            },
+            {
+              title: 'Oranges',
+              color: '#79C7E3'
+            }
+          ]}
+        />
+        <VerticalGridLines />
+        <HorizontalGridLines />
+        <XAxis />
+        <YAxis />
+        <VerticalBarSeries
+          cluster="2015"
+          color="#12939A"
+          data={[
+            {x: 'Q1', y: 10},
+            {x: 'Q2', y: 5},
+            {x: 'Q3', y: 15},
+            {x: 'Q4', y: 20}
+          ]}/>
+        <VerticalBarSeries
+          cluster="2015"
+          color="#79C7E3"
+          data={[
+            {x: 'Q1', y: 3},
+            {x: 'Q2', y: 7},
+            {x: 'Q3', y: 2},
+            {x: 'Q4', y: 1}
+          ]}/>
+        <VerticalBarSeries
+          cluster="2016"
+          color="#12939A"
+          data={[
+            {x: 'Q1', y: 3},
+            {x: 'Q2', y: 8},
+            {x: 'Q3', y: 11},
+            {x: 'Q4', y: 19}
+          ]}/>
+        <VerticalBarSeries
+          cluster="2016"
+          color="#79C7E3"
+          data={[
+            {x: 'Q1', y: 22},
+            {x: 'Q2', y: 2},
+            {x: 'Q3', y: 22},
+            {x: 'Q4', y: 18}
+          ]}/>
+      </XYPlot>
+    );
+  }
+}

--- a/showcase/showcase-app.js
+++ b/showcase/showcase-app.js
@@ -8,6 +8,7 @@ const {
   BarChart,
   StackedVerticalBarChart,
   StackedHorizontalBarChart,
+  ClusteredStackedVerticalBarChart,
   StackedHistogram,
   AreaChart,
   AreaChartElevated,
@@ -104,6 +105,10 @@ class App extends Component {
           <section>
             <h3>Stacked Vertical Bar Series</h3>
             <StackedVerticalBarChart />
+          </section>
+          <section>
+            <h3>Clustered Stacked Vertical Bar Series</h3>
+            <ClusteredStackedVerticalBarChart />
           </section>
           <section>
             <h3>Stacked Vertical Rect Series (histogram)</h3>

--- a/src/plot/series/bar-series.js
+++ b/src/plot/series/bar-series.js
@@ -35,17 +35,21 @@ class BarSeries extends AbstractSeries {
       linePosAttr: React.PropTypes.string,
       valuePosAttr: React.PropTypes.string,
       lineSizeAttr: React.PropTypes.string,
-      valueSizeAttr: React.PropTypes.string
+      valueSizeAttr: React.PropTypes.string,
+      cluster: React.PropTypes.string
     };
   }
 
-  _getScackParams() {
-    const {_stackBy, valuePosAttr} = this.props;
+  _getStackParams() {
+    const {_stackBy, valuePosAttr, cluster} = this.props;
     let {
       sameTypeTotal = 1,
       sameTypeIndex = 0
     } = this.props;
-    if (_stackBy === valuePosAttr) {
+
+    // If bars are stacked, but not clustering, override `sameTypeTotal` and
+    // `sameTypeIndex` such that bars are stacked and not staggered.
+    if (_stackBy === valuePosAttr && !cluster) {
       sameTypeTotal = 1;
       sameTypeIndex = 0;
     }
@@ -77,7 +81,7 @@ class BarSeries extends AbstractSeries {
       );
     }
 
-    const {sameTypeTotal, sameTypeIndex} = this._getScackParams();
+    const {sameTypeTotal, sameTypeIndex} = this._getStackParams();
 
     const distance = this._getScaleDistance(linePosAttr);
     const lineFunctor = this._getAttributeFunctor(linePosAttr);

--- a/src/styles/examples.scss
+++ b/src/styles/examples.scss
@@ -347,3 +347,11 @@ article {
     border: thin solid white;
   }
 }
+
+.clustered-stacked-bar-chart-example {
+  .rv-discrete-color-legend {
+    position: absolute;
+    top: 0px;
+    left: 40px;
+  }
+}

--- a/tests/components/bar-series-tests.js
+++ b/tests/components/bar-series-tests.js
@@ -8,6 +8,7 @@ import {testRenderWithProps, GENERIC_XYPLOT_SERIES_PROPS} from '../test-utils';
 import StackedHorizontalBarChart from '../../showcase/plot/stacked-horizontal-bar-chart';
 import StackedVerticalBarChart from '../../showcase/plot/stacked-vertical-bar-chart';
 import BarChart from '../../showcase/plot/bar-chart';
+import ClusteredStackedVerticalBarChart from '../../showcase/plot/clustered-stacked-bar-chart';
 
 testRenderWithProps(HorizontalBarSeries, GENERIC_XYPLOT_SERIES_PROPS);
 testRenderWithProps(VerticalBarSeries, GENERIC_XYPLOT_SERIES_PROPS);
@@ -46,5 +47,13 @@ test('BarSeries: Ordinal Y-Axis HorizontalBarSeries', t => {
   </XYPlot>);
   t.equal($.find('.rv-xy-plot__series--bar rect').length, 3, 'should find the right number of bars');
   t.equal($.find('.rv-xy-plot__series--bar rect').at(0).prop('height') > 0, true, 'should not have negative bar height');
+  t.end();
+});
+
+test('BarSeries: Showcase Example - ClusteredStackedVerticalBarChart', t => {
+  const $ = mount(<ClusteredStackedVerticalBarChart />);
+  t.equal($.text(), 'Q1Q2Q3Q40102030ApplesOranges', 'should fine the right text content');
+  t.equal($.find('.rv-xy-plot__series--bar rect').length, 16, 'should find the right number of bars');
+  t.equal($.find('.rv-xy-plot__series').length, 4, 'should find the right number of series');
   t.end();
 });

--- a/tests/utils/series-utils-tests.js
+++ b/tests/utils/series-utils-tests.js
@@ -83,21 +83,46 @@ test('series-utils #collectSeriesTypesInfo', t => {
   t.end();
 });
 
+test('series-utils #seriesClusterProps', t => {
+  const result = getSeriesPropsFromChildren([
+    React.createElement(HorizontalBarSeries, {cluster: 'alpha', data: []}),
+    React.createElement(HorizontalBarSeries, {cluster: 'beta', data: []}),
+    React.createElement(HorizontalBarSeries, {cluster: 'alpha', data: []}),
+    React.createElement(HorizontalBarSeries, {cluster: 'gamma', data: []})
+  ]);
+  const expectedClusters = ['alpha', 'beta', 'gamma'];
+  t.ok(result.length === 4, 'Returns array of proper size');
+  result.forEach((props, i) => {
+    t.ok(props.sameTypeIndex === expectedClusters.indexOf(props.cluster));
+    t.ok(props.sameTypeTotal === props.clusters.length, 'SameTypeTotal is set correctly');
+    t.ok(props.clusters.length === 3, 'Returns correct number of unique clusters');
+  });
+  t.end();
+});
+
 test('series-utils #getStackedData', t => {
+  const yData = [
+    [
+      {y: 2, x: 10},
+      {y: 4, x: 5},
+      {y: 5, x: 15}
+    ],
+    [
+      {y: 2, x: 12},
+      {y: 4, x: 2},
+      {y: 5, x: 11}
+    ]
+  ];
+
+  // Transpose data to flip stacking
+  const xData = yData.map(arr => arr.map(d => ({x: d.y, y: d.x})));
+
   let children = [
     (<HorizontalBarSeries
-      data={[
-        {y: 2, x: 10},
-        {y: 4, x: 5},
-        {y: 5, x: 15}
-      ]}
+      data={yData[0]}
     />),
     (<HorizontalBarSeries
-      data={[
-        {y: 2, x: 12},
-        {y: 4, x: 2},
-        {y: 5, x: 11}
-      ]}/>),
+      data={yData[1]}/>),
     (<div> i think i will by that lamp </div>)
   ];
   let results = getStackedData(children, 'y');
@@ -114,18 +139,10 @@ test('series-utils #getStackedData', t => {
 
   children = [
     (<HorizontalBarSeries
-      data={[
-        {x: 2, y: 10},
-        {x: 4, y: 5},
-        {x: 5, y: 15}
-      ]}
+      data={xData[0]}
     />),
     (<HorizontalBarSeries
-      data={[
-        {x: 2, y: 12},
-        {x: 4, y: 2},
-        {x: 5, y: 11}
-      ]}/>),
+      data={xData[1]}/>),
     null
   ];
   results = getStackedData(children, 'x');
@@ -138,6 +155,93 @@ test('series-utils #getStackedData', t => {
     {x: 8, x0: 4, y: 2},
     {x: 10, x0: 5, y: 11}
   ], null];
+
   t.deepEqual(results, expectedResults, 'should find the correct results for stacking by x');
+
+  children = [
+    <HorizontalBarSeries
+      cluster="alpha"
+      data={yData[0]}
+    />,
+    <HorizontalBarSeries
+      cluster="alpha"
+      data={yData[1]}
+    />,
+    <HorizontalBarSeries
+      cluster="beta"
+      data={yData[0]}
+    />,
+    <HorizontalBarSeries
+      cluster="beta"
+      data={yData[1]}
+    />
+  ];
+  results = getStackedData(children, 'y');
+  expectedResults = [
+    [
+      {x: 10, y: 2},
+      {x: 5, y: 4},
+      {x: 15, y: 5}
+    ],
+    [
+      {x: 12, y: 4, y0: 2},
+      {x: 2, y: 8, y0: 4},
+      {x: 11, y: 10, y0: 5}
+    ],
+    [
+      {x: 10, y: 2},
+      {x: 5, y: 4},
+      {x: 15, y: 5}
+    ],
+    [
+      {x: 12, y: 4, y0: 2},
+      {x: 2, y: 8, y0: 4},
+      {x: 11, y: 10, y0: 5}
+    ]
+  ];
+  t.deepEqual(results, expectedResults, 'should find the correct results for stacking bar clusters by y');
+
+  children = [
+    <HorizontalBarSeries
+      cluster="alpha"
+      data={xData[0]}
+    />,
+    <HorizontalBarSeries
+      cluster="alpha"
+      data={xData[1]}
+    />,
+    <HorizontalBarSeries
+      cluster="beta"
+      data={xData[0]}
+    />,
+    <HorizontalBarSeries
+      cluster="beta"
+      data={xData[1]}
+    />
+  ];
+  results = getStackedData(children, 'x');
+  expectedResults = [
+    [
+      {x: 2, y: 10},
+      {x: 4, y: 5},
+      {x: 5, y: 15}
+    ],
+    [
+      {x: 4, x0: 2, y: 12},
+      {x: 8, x0: 4, y: 2},
+      {x: 10, x0: 5, y: 11}
+    ],
+    [
+      {x: 2, y: 10},
+      {x: 4, y: 5},
+      {x: 5, y: 15}
+    ],
+    [
+      {x: 4, x0: 2, y: 12},
+      {x: 8, x0: 4, y: 2},
+      {x: 10, x0: 5, y: 11}
+    ]
+  ];
+  t.deepEqual(results, expectedResults, 'should find the correct results for stacking bar clusters by x');
   t.end();
 });


### PR DESCRIPTION
Fixes #292 

This is an initial proof of concept - I haven't added docs or tests yet as I wanted to validate my approach first. I also haven't added axis labels, although I'm not sure if that should be within the scope of this.

This PR adds an optional prop to `BarSeries` - `cluster` - that in the case of a vertical series a stacked bar chart into multiple stacks, keyed by that prop.

I've added an example, and attached a screenshot - would appreciate any help in getting this functionality merged in!

![screen shot 2017-03-20 at 4 56 42 pm](https://cloud.githubusercontent.com/assets/1896836/24126961/5df8bf6a-0d8e-11e7-9bcf-25fb6df0a021.png)
