### PR TITLE
Inject examples into markdown

### DIFF
--- a/docs/docs-app/components/documentation-page.js
+++ b/docs/docs-app/components/documentation-page.js
@@ -2,6 +2,28 @@ import React, {Component} from 'react';
 import marked from 'marked';
 
 import {docsRouting} from '../constants/pages';
+import {showCase} from '../../../showcase/index';
+
+const INJECTION_REG = /<!-- INJECT:"(.+)\" -->/g;
+
+function injectExamplesIntoHtml(content) {
+  return content.split(INJECTION_REG).map((__html, index) => {
+    const Example = showCase[__html];
+    if (!Example) {
+      /* eslint-disable react/no-danger */
+      return (<div
+        className="markdown-body"
+        key={`body-${index}`}
+        dangerouslySetInnerHTML={{__html}} />);
+      /* eslint-enable react/no-danger */
+    }
+    return (
+      <div className="markdown-example" key={`example-${index}`}>
+        <Example />
+      </div>
+    );
+  });
+}
 
 class DocumentationPage extends Component {
   componentWillReceiveProps(nextProps) {
@@ -24,15 +46,14 @@ class DocumentationPage extends Component {
 
     const content = markdownPages.get(route.content.markdown, '');
     const __html = marked(content, {renderer});
-    /* eslint-disable react/no-danger */
+
     return (
       <div className="documentation-page f fg">
         <div className="markdown" ref="documentionContainer">
-          <div className="markdown-body" dangerouslySetInnerHTML={{__html}} />
+          {injectExamplesIntoHtml(__html)}
         </div>
       </div>
     );
-    /* eslint-enable react/no-danger */
   }
 }
 

--- a/docs/docs-app/demo.scss
+++ b/docs/docs-app/demo.scss
@@ -133,6 +133,15 @@ a:visited {
   width: 100%;
 }
 
+.markdown-example {
+  align-items: center;
+  display: flex;
+  height: auto;
+  justify-content: center;
+  padding: 20px;
+  width: 100%;
+}
+
 .documentation-page {
   background-color: $pure-white;
   padding: 2rem;

--- a/docs/markdown/axes.md
+++ b/docs/markdown/axes.md
@@ -1,5 +1,7 @@
 ## Axes
 
+<!-- INJECT:"CustomAxesOrientation" -->
+
 **Note**: Axes API was changed in 0.5.
 
 `XAxis` and `YAxis` shows are responsible for the axis in the chart. Both of them have following properties:

--- a/docs/markdown/crosshair.md
+++ b/docs/markdown/crosshair.md
@@ -1,5 +1,7 @@
 ## Crosshair
 
+<!-- INJECT:"DynamicCrosshair" -->
+
 `Crosshair` is a tooltip for multiple values at the same time. Its purpose is to combine several values with the similar X coordinate in one tooltip. Crosshair is automatically aligned by the x coordinate depending on what values are passed.
 In case if custom representation of crosshair is needed, the component is able to wrap the user's JSX. In this case no CSS is applied to that. Here's a short example:
 

--- a/docs/markdown/grids.md
+++ b/docs/markdown/grids.md
@@ -1,5 +1,7 @@
 ## Grids
 
+<!-- INJECT:"CustomAxisChart" -->
+
 `VerticalGridLines` and `HorizontalGridLines` show a grid inside the chart. Here is a short example:
 
 ```jsx

--- a/docs/markdown/heatmap-series.md
+++ b/docs/markdown/heatmap-series.md
@@ -2,33 +2,37 @@
 
 The HeatmapSeries allows users to create a segment their chart domain and create beautiful fast charts.
 Imagine you have a scatterplot will millions of points, this will be pretty hard to render in the browser.
+
+<!-- INJECT:"HeatmapChart" -->
+
 One solution is to to bin your data, and so arises HeatmapSeries!
 
 ```javascript
-
-(
-  <XYPlot
-    width={300}
-    height={300}>
-    <XAxis />
-    <YAxis />
-    <HeatmapSeries
-      className="heatmap-series-example"
-      data={[
-        {x: 1, y: 0, color: 10},
-        {x: 1, y: 5, color: 10},
-        {x: 1, y: 10, color: 6},
-        {x: 1, y: 15, color: 7},
-        {x: 2, y: 0, color: 12},
-        {x: 2, y: 5, color: 2},
-        {x: 2, y: 10, color: 1},
-        {x: 2, y: 15, color: 12},
-        {x: 3, y: 0, color: 9},
-        {x: 3, y: 5, color: 2},
-        {x: 3, y: 10, color: 6},
-        {x: 3, y: 15, color: 12}
-      ]}/>
-  </XYPlot>
-)
+<XYPlot
+  width={300}
+  height={300}>
+  <XAxis />
+  <YAxis />
+  <HeatmapSeries
+    className="heatmap-series-example"
+    data={myData}/>
+</XYPlot>
 ```
 Like other series it expects it's data to be formatted as a list of objects, as above.
+
+```javascript
+const myData = [
+  {x: 1, y: 0, color: 10},
+  {x: 1, y: 5, color: 10},
+  {x: 1, y: 10, color: 6},
+  {x: 1, y: 15, color: 7},
+  {x: 2, y: 0, color: 12},
+  {x: 2, y: 5, color: 2},
+  {x: 2, y: 10, color: 1},
+  {x: 2, y: 15, color: 12},
+  {x: 3, y: 0, color: 9},
+  {x: 3, y: 5, color: 2},
+  {x: 3, y: 10, color: 6},
+  {x: 3, y: 15, color: 12}
+]
+```

--- a/docs/markdown/legends.md
+++ b/docs/markdown/legends.md
@@ -1,5 +1,7 @@
 ## Legends
 
+<!-- INJECT:"HorizontalDiscreteColorLegendExample" -->
+
 Currently following types of legends are supported:
 
 - for colors:
@@ -12,6 +14,8 @@ Currently following types of legends are supported:
 ## Color legends
 
 ### DiscreteColorLegend
+
+<!-- INJECT:"VerticalDiscreteColorLegendExample" -->
 
 #### items (required)
 Type: `Array<string|{title: string, color: String, disabled: boolean}>`  
@@ -32,6 +36,9 @@ Outer height of the component. Default is not set, the component stretches with 
 ### SearchableDiscreteColorLegend
 
 `SearchableDiscreteColorLegend` allows the user to perform search among the items.
+
+<!-- INJECT:"SearchableDiscreteColorLegendExample" -->
+
 Its API includes the API of `DiscreteColorLegend`, but adds several search-related items:
 
 #### searchText (optional)
@@ -52,6 +59,8 @@ Type: `function(string):void`
 Event handler for the change of the input field. The handler is triggered with the search field value as a parameter.
 
 ### ContinuousColorLegend
+
+<!-- INJECT:"ContinuousColorLegendExample" -->
 
 #### startTitle
 Type: `string|number`  
@@ -88,6 +97,8 @@ Outer height of the component.
 ## Size Legends
 
 ### ContinuousSizeLegend
+
+<!-- INJECT:"ContinuousSizeLegendExample" -->
 
 #### startTitle
 Type: `string|number`  

--- a/docs/markdown/radial-chart.md
+++ b/docs/markdown/radial-chart.md
@@ -3,6 +3,8 @@
 `RadialChart` is responsible for creating pie and donut charts.
 Note: currently radial chart _does not_ support series and it is not planned in the nearest future.
 
+<!-- INJECT:"DonutChartExample" -->
+
 ## Usage
 
 ```jsx
@@ -19,6 +21,8 @@ const data = [
   width={300}
   height={300} />
 ```
+
+<!-- INJECT:"CustomRadiusRadialChart" -->
 
 ## Api
 

--- a/docs/markdown/sankey.md
+++ b/docs/markdown/sankey.md
@@ -2,6 +2,8 @@
 
 Note: This component is in alpha.
 
+<!-- INJECT:"BasicSankeyExample" -->
+
 ### Usage
 
 ```jsx

--- a/docs/markdown/treemap.md
+++ b/docs/markdown/treemap.md
@@ -3,6 +3,8 @@
 Treemaps are a splendid way to represent data that has a nested aspect to it. They allow for the easy display of complicated
 relative information, such as nested-part-to-whole relationships in a easy to grock fashion. Checkout [the wikipedia page](https://en.wikipedia.org/wiki/Treemapping) or Ben Shneiderman's excellent [History of treemaps](http://www.cs.umd.edu/hcil/treemap-history/index.shtml) for more information.
 
+<!-- INJECT:"SimpleTreemap" -->
+
 The `treemap` in react-vis builds a series of nested divs (allow for easy and highly restyleable trees). We offer ten different layout
 strategies, enabling the construction of standard treemaps, circle packed treemaps, and partition trees (also called icicle diagrams).
 


### PR DESCRIPTION
This PR provides a method for injecting the predefined examples from the showcase into the documentation. I think this is a stronger method than writing individual examples, because it allows us to write our testing suite against the things we are injecting. It also makes the process of adding js to markdown super smooth.
![example](https://cloud.githubusercontent.com/assets/6854312/24275795/4f6620f6-0fef-11e7-8d9d-5226db35fc56.gif)
