### PR TITLE
Add `strokeDasharray` support for LineSeries component

### DIFF
--- a/docs/markdown/line-series.md
+++ b/docs/markdown/line-series.md
@@ -1,4 +1,8 @@
-## LineSeries/LineMarkSeries:
+# LineSeries/LineMarkSeries
+
+<!-- INJECT:"LineChart" -->
+
+## API Reference
 
 ##### strokeDasharray (optional)
 Type: `string`

--- a/docs/markdown/line-series.md
+++ b/docs/markdown/line-series.md
@@ -1,31 +1,35 @@
 ## LineSeries/LineMarkSeries:
 
+##### strokeDasharray (optional)
+Type: `string`
+Specify a custom `stroke-dasharray` attribute which controls the pattern of dashes and gaps used to stroke paths.
+
 ##### strokeStyle (optional)
 Type: `string`
-If set to `dashed`, your series will use dashed lines. If set to `solid` or unspecified, your series will use solid lines.
+If set to `dashed`, your series will use dashed lines. If set to `solid` or unspecified, your series will use solid lines. See `strokeDasharray` for specifying a custom stroke dash-array value.
 
 ##### strokeWidth (optional)
 Type: `string|number`
 Specifies the width of the line for the series. By default, this is determined by react-vis css (2px).
 
 #### value
-Type: `Object`  
+Type: `Object`
 The data point to show the value at. Hint component will automatically find the place where the data point is and put the hint there.
 
 #### format (optional)
-Type: `function`  
-Format function for a tooltip. Receives the data point, should return an array of objects containing `title` and `value` properties. Each item of an array is shown on a separate line by default.  
+Type: `function`
+Format function for a tooltip. Receives the data point, should return an array of objects containing `title` and `value` properties. Each item of an array is shown on a separate line by default.
 _Note: please pass custom contents in case if you need different look for the hint._
 
 #### orientation (optional)
-Type: `(auto|topleft|topright|bottomleft|bottomright)`  
-Default: `auto`  
+Type: `(auto|topleft|topright|bottomleft|bottomright)`
+Default: `auto`
 The way to align the hint inside the chart. When `auto` is set the hint is trying to stay inside the bounding box of the chart.
 Set the hint to `topleft` if you want to see a "conventional" hint alignment.
 
 #### curve (optional)
 Type: `string|function`
-Default: `null`  
+Default: `null`
 Apply the provided or named curve function from the D3 shape library to smooth the line series plot, see [the D3 documentation](https://github.com/d3/d3-shape#curves) for function names and instructions. Providing the function, not the name, will require importing the d3-shape package in order to configure it:
 
 ```javascript

--- a/showcase/plot/line-chart.js
+++ b/showcase/plot/line-chart.js
@@ -59,7 +59,9 @@ export default class Example extends React.Component {
             {x: 2, y: 4},
             {x: 3, y: 2},
             {x: 4, y: 15}
-          ]}/>
+          ]}
+          strokeDasharray="7, 3"
+          />
         <LineSeries
           className="fourth-series"
           curve={curveCatmullRom.alpha(0.5)}

--- a/src/plot/series/line-series.js
+++ b/src/plot/series/line-series.js
@@ -77,7 +77,7 @@ class LineSeries extends AbstractSeries {
       );
     }
 
-    const {strokeStyle, strokeWidth, marginLeft, marginTop, curve} = this.props;
+    const {strokeDasharray, strokeStyle, strokeWidth, marginLeft, marginTop, curve} = this.props;
 
     const x = this._getAttributeFunctor('x');
     const y = this._getAttributeFunctor('y');
@@ -97,7 +97,7 @@ class LineSeries extends AbstractSeries {
         onClick={this._seriesClickHandler}
         style={{
           opacity,
-          strokeDasharray: STROKE_STYLES[strokeStyle],
+          strokeDasharray: STROKE_STYLES[strokeStyle] || strokeDasharray,
           strokeWidth,
           stroke
         }}/>

--- a/tests/components/line-series-tests.js
+++ b/tests/components/line-series-tests.js
@@ -71,6 +71,7 @@ test('LineSeries: Line Styling', t => {
         opacity={0.5}
         strokeWidth="3px"
         stroke="rgb(255, 255, 255)"
+        strokeDasharray="3, 1"
       />
     </XYPlot>
   );
@@ -80,5 +81,6 @@ test('LineSeries: Line Styling', t => {
   t.equal(lineStyle.opacity, 0.5, 'should render an opaque line');
   t.equal(lineStyle.strokeWidth, '3px', 'should honor stroke width');
   t.equal(lineStyle.stroke, 'rgb(255, 255, 255)', 'should honor stroke');
+  t.equal(lineStyle.strokeDasharray, '3, 1', 'should honor stroke dash-array');
   t.end();
 });


### PR DESCRIPTION
This enhancement (https://github.com/uber/react-vis/issues/319) allows a user to specify a custom `stroke-dasharray` attribute for the line path in a given series. This is passed down to the `LineSeries` component though the `strokeDasharray` React prop.

- Add test for enhancement
- Update documentation for enhancement
- Pass a strokeDasharray prop to a line in the `LineChart` showcase example
<img width="405" alt="screen shot 2017-03-27 at 1 33 51 pm" src="https://cloud.githubusercontent.com/assets/6504944/24377000/b0464ed6-12f2-11e7-8f0c-5ecafe9b4eb3.png">
- Remove trailing whitespaces in `docs/markdown/line-series.md`

