### PR TITLE
Implement onNearestXY for MarkSeries and add documentation

### DIFF
--- a/docs/docs-app/constants/pages.js
+++ b/docs/docs-app/constants/pages.js
@@ -160,6 +160,13 @@ export const docPages = generatePath([
           filename: 'heatmap-series.md',
           pageType: 'documentation'
         }
+      }, {
+        name: 'Mark Series',
+        content: {
+          markdown: getDocUrl('mark-series.md'),
+          filename: 'mark-series.md',
+          pageType: 'documentation'
+        }
       }
     ]
   },

--- a/docs/markdown/mark-series.md
+++ b/docs/markdown/mark-series.md
@@ -1,6 +1,6 @@
 # MarkSeries
 
-<!-- INJECT:"ScatteplotChart" -->
+<!-- INJECT:"ScatterplotChart" -->
 
 ## API Reference
 

--- a/docs/markdown/mark-series.md
+++ b/docs/markdown/mark-series.md
@@ -1,0 +1,12 @@
+# MarkSeries
+
+## API Reference
+
+#### onNearestXY (optional)
+Type: `function(value, info)`
+A callback function which is triggered on mousemove and returns the closest point vased on the voronoi layout.
+Callback is triggered with two arguments. `value` is the data point, `info` object has following properties:
+- `innerX` is the horizontal position of the value;
+- `innerY` is the vertical position of the value;
+- `index` is the index of the data point in the array of data;
+- `event` is the event object.

--- a/docs/markdown/mark-series.md
+++ b/docs/markdown/mark-series.md
@@ -1,5 +1,7 @@
 # MarkSeries
 
+<!-- INJECT:"ScatteplotChart" -->
+
 ## API Reference
 
 #### onNearestXY (optional)

--- a/docs/markdown/series.md
+++ b/docs/markdown/series.md
@@ -4,7 +4,7 @@ The library supports several types of series:
 
 * [LineSeries](line-series.md) for lines;
 * `AreaSeries` for area charts;
-* `MarkSeries` for scatterplots;
+* [MarkSeries](mark-series.md) for scatterplots;
 * [LineMarkSeries](line-series.md) is a shorthand to place marks (e.g. circles) on lines;
 * `VerticalBarSeries` for vertical bar charts;
 * `HorizontalBarSeries` for horizontal bar charts;
@@ -17,11 +17,11 @@ Type: `Array<Object>`
 Array of data for the series.
 
 #### x
-Type: `number|Object`  
+Type: `number|Object`
 Exact X position of all series points in pixels or a series object.
 
-#### y (optional)  
-Type: `number|Object`  
+#### y (optional)
+Type: `number|Object`
 Exact Y position of all series points in pixels or a series object.
 
 #### color (optional)
@@ -29,11 +29,11 @@ Type: `string|Object`
 Exact color for all series points or a series object.
 
 #### size (optional)
-Type: `number|Object`  
+Type: `number|Object`
 Exact size for all series points in pixels or a series object.
 
 #### opacity (optional)
-Type: `number|Object`  
+Type: `number|Object`
 Exact opacity for all series points in pixels or a series object.
 
 #### className (optional)
@@ -41,7 +41,7 @@ Type: `string`
 Provide an additional class name for the series.
 
 #### onNearestX (optional)
-Type: `function(value, info)`  
+Type: `function(value, info)`
 A callback function which is triggered each time when the mouse pointer gets close to some X value.
 Callback is triggered with two arguments. `value` is the data point, `info` object has following properties:
 - `innerX` is the left position of the value;
@@ -49,31 +49,31 @@ Callback is triggered with two arguments. `value` is the data point, `info` obje
 - `event` is the event object.
 
 #### onValueMouseOver (optional)
-Type: `function(d, info)`  
-`mouseover` event handler for the elements corresponding separate data points `d` is a data point, `info` is an object with the only `event` property.  
+Type: `function(d, info)`
+`mouseover` event handler for the elements corresponding separate data points `d` is a data point, `info` is an object with the only `event` property.
 **NOTE**: This event handler is *not* triggered for AreaSeries and LineSeries.
 
 #### onValueMouseOut (optional)
-Type: `function(d, info)`  
-`mouseout` event handler for the elements corresponding separate data points. `d` is a data point, `info` is an object with the only `event` property.  
+Type: `function(d, info)`
+`mouseout` event handler for the elements corresponding separate data points. `d` is a data point, `info` is an object with the only `event` property.
 **NOTE**: This event handler is *not* triggered for AreaSeries and LineSeries.
 
 #### onValueClick (optional)
-Type: `function(d, info)`  
-`click` event handler for the elements corresponding separate data points. `d` is a data point, `info` is an object with the only `event` property.  
+Type: `function(d, info)`
+`click` event handler for the elements corresponding separate data points. `d` is a data point, `info` is an object with the only `event` property.
 **NOTE**: This event handler is *not* triggered for AreaSeries and LineSeries.
 
 #### onSeriesMouseOver (optional)
-Type: `function(info)`  
+Type: `function(info)`
 `mouseover` event handler for the entire series. Received `info` object as argument with the only `event` property.
 
 #### onSeriesMouseOut (optional)
-Type: `function(info)`  
+Type: `function(info)`
 `mouseout` event handler for the entire series. Received `info` object as argument with the only `event` property.
 
 #### onSeriesClick (optional)
-Type: `function(info)`  
+Type: `function(info)`
 `click` event handler for the entire series. Received `info` object as argument with the only `event` property.
 
-#### animation (optional)  
+#### animation (optional)
 See the [XYPlot](xy-plot.md)'s `animation` section for more information.

--- a/showcase/index.js
+++ b/showcase/index.js
@@ -28,7 +28,7 @@ import ClusteredStackedVerticalBarChart from './plot/clustered-stacked-bar-chart
 import StackedHistogram from './plot/stacked-histogram';
 import AreaChart from './plot/area-chart';
 import AreaChartElevated from './plot/area-chart-elevated';
-import ScatteplotChart from './plot/scatterplot';
+import ScatterplotChart from './plot/scatterplot';
 import HeatmapChart from './plot/heatmap-chart';
 import WidthHeightMarginChart from './plot/width-height-margin';
 import CustomScales from './plot/custom-scales';
@@ -76,7 +76,7 @@ export const showCase = {
   StackedHistogram,
   AreaChart,
   AreaChartElevated,
-  ScatteplotChart,
+  ScatterplotChart,
   HeatmapChart,
   WidthHeightMarginChart,
   CustomScales,

--- a/showcase/index.js
+++ b/showcase/index.js
@@ -44,7 +44,7 @@ import DynamicSimpleTopEdgeHints from './plot/dynamic-simple-topedge-hints';
 import DynamicProgrammaticRightEdgeHints from './plot/dynamic-programmatic-rightedge-hints';
 import StaticCrosshair from './plot/static-crosshair';
 import DynamicCrosshair from './plot/dynamic-crosshair';
-import DynamicCrosshairMarkseries from './plot/dynamic-crosshair-markseries';
+import DynamicCrosshairScatterplot from './plot/dynamic-crosshair-scatterplot';
 import SyncedCharts from './plot/synced-charts';
 import TimeChart from './plot/time-chart';
 import VoronoiLineChart from './plot/voronoi-line-chart';
@@ -92,7 +92,7 @@ export const showCase = {
   DynamicProgrammaticRightEdgeHints,
   StaticCrosshair,
   DynamicCrosshair,
-  DynamicCrosshairMarkseries,
+  DynamicCrosshairScatterplot,
   SyncedCharts,
   TimeChart,
   VoronoiLineChart,

--- a/showcase/index.js
+++ b/showcase/index.js
@@ -44,6 +44,7 @@ import DynamicSimpleTopEdgeHints from './plot/dynamic-simple-topedge-hints';
 import DynamicProgrammaticRightEdgeHints from './plot/dynamic-programmatic-rightedge-hints';
 import StaticCrosshair from './plot/static-crosshair';
 import DynamicCrosshair from './plot/dynamic-crosshair';
+import DynamicCrosshairMarkseries from './plot/dynamic-crosshair-markseries';
 import SyncedCharts from './plot/synced-charts';
 import TimeChart from './plot/time-chart';
 import VoronoiLineChart from './plot/voronoi-line-chart';
@@ -91,6 +92,7 @@ export const showCase = {
   DynamicProgrammaticRightEdgeHints,
   StaticCrosshair,
   DynamicCrosshair,
+  DynamicCrosshairMarkseries,
   SyncedCharts,
   TimeChart,
   VoronoiLineChart,

--- a/showcase/plot/dynamic-crosshair-markseries.js
+++ b/showcase/plot/dynamic-crosshair-markseries.js
@@ -19,6 +19,7 @@
 // THE SOFTWARE.
 
 import React from 'react';
+import {scaleLinear} from 'd3-scale';
 
 import {
   Crosshair,
@@ -49,7 +50,6 @@ const DATA = [
   {x: 1, y: 4, size: 29}
 ];
 
-import {scaleLinear} from 'd3-scale';
 const x = scaleLinear()
   .domain([1, 3])
   .range([40, 290]);
@@ -58,23 +58,18 @@ const y = scaleLinear()
   .range([260, 10]);
 
 export default class Example extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      data: DATA,
-      selectedPointId: null,
-      showVoronoi: false
-    };
-
-    this._onMouseLeave = this._onMouseLeave.bind(this);
-    this._onNearestXY = this._onNearestXY.bind(this);
+  state = {
+    data: DATA,
+    selectedPointId: null,
+    showVoronoi: false
   }
+
   /**
    * Event handler for onNearestXY.
    * @param {Object} value Selected value.
    * @private
    */
-  _onNearestXY(value, {index}) {
+  _onNearestXY = (value, {index}) => {
     this.setState({selectedPointId: index});
   }
 
@@ -82,7 +77,7 @@ export default class Example extends React.Component {
    * Event handler for onMouseLeave.
    * @private
    */
-  _onMouseLeave() {
+  _onMouseLeave = () => {
     this.setState({selectedPointId: null});
   }
 

--- a/showcase/plot/dynamic-crosshair-markseries.js
+++ b/showcase/plot/dynamic-crosshair-markseries.js
@@ -1,0 +1,127 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import React from 'react';
+
+import {
+  Crosshair,
+  HorizontalGridLines,
+  MarkSeries,
+  VerticalGridLines,
+  XAxis,
+  XYPlot,
+  YAxis,
+  Voronoi
+} from 'index';
+
+const DATA = [
+  {x: 1.4, y: 4, size: 10},
+  {x: 1, y: 5, size: 9},
+  {x: 2, y: 4, size: 11},
+  {x: 2.1, y: 11.8, size: 28},
+  {x: 3, y: 5.4, size: 6},
+  {x: 1, y: 11.8, size: 25},
+  {x: 1.5, y: 14, size: 12},
+  {x: 2.7, y: 13.7, size: 14},
+  {x: 1.7, y: 9, size: 30},
+  {x: 2.4, y: 13.5, size: 20},
+  {x: 1, y: 4, size: 18},
+  {x: 2.4, y: 7.9, size: 14},
+  {x: 1, y: 4, size: 5},
+  {x: 2.9, y: 7.7, size: 26},
+  {x: 1, y: 4, size: 29}
+];
+
+import {scaleLinear} from 'd3-scale';
+const x = scaleLinear()
+  .domain([1, 3])
+  .range([40, 290]);
+const y = scaleLinear()
+  .domain([4, 14])
+  .range([260, 10]);
+
+export default class Example extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      data: DATA,
+      selectedPointId: null,
+      showVoronoi: false
+    };
+
+    this._onMouseLeave = this._onMouseLeave.bind(this);
+    this._onNearestXY = this._onNearestXY.bind(this);
+  }
+  /**
+   * Event handler for onNearestXY.
+   * @param {Object} value Selected value.
+   * @private
+   */
+  _onNearestXY(value, {index}) {
+    this.setState({selectedPointId: index});
+  }
+
+  /**
+   * Event handler for onMouseLeave.
+   * @private
+   */
+  _onMouseLeave() {
+    this.setState({selectedPointId: null});
+  }
+
+  render() {
+    const {data, selectedPointId, showVoronoi} = this.state;
+    return (
+      <div>
+        <label style={{display: 'block'}}>
+          <input type="checkbox"
+            checked={showVoronoi}
+            onChange={e => this.setState({showVoronoi: !showVoronoi})}
+          />
+          Show Voronoi
+        </label>
+        <XYPlot
+          onMouseLeave={this._onMouseLeave}
+          width={300}
+          height={300}>
+          <VerticalGridLines />
+          <HorizontalGridLines />
+          <XAxis />
+          <YAxis />
+          <MarkSeries
+            className="mark-series-example"
+            colorType="literal"
+            data={data.map((point, index) =>
+              ({...point, color: selectedPointId === index ? '#FF9833' : '#12939A'}))}
+            onNearestXY={this._onNearestXY}
+            sizeRange={[5, 13]} />
+          <Crosshair values={this.state.crosshairValues}/>
+          <Voronoi
+            extent={[[40, 10], [290, 260]]}
+            nodes={data}
+            polygonStyle={{stroke: showVoronoi ? 'rgba(0, 0, 0, .2)' : null}}
+            x={d => x(d.x)}
+            y={d => y(d.y)}
+          />
+        </XYPlot>
+      </div>
+    );
+  }
+}

--- a/showcase/plot/dynamic-crosshair-scatterplot.js
+++ b/showcase/plot/dynamic-crosshair-scatterplot.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Uber Technologies, Inc.
+// Copyright (c) 2016-2017 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -33,21 +33,21 @@ import {
 } from 'index';
 
 const DATA = [
-  {x: 1.4, y: 4, size: 10},
-  {x: 1, y: 5, size: 9},
-  {x: 2, y: 4, size: 11},
-  {x: 2.1, y: 11.8, size: 28},
-  {x: 3, y: 5.4, size: 6},
-  {x: 1, y: 11.8, size: 25},
-  {x: 1.5, y: 14, size: 12},
-  {x: 2.7, y: 13.7, size: 14},
+  {x: 1, y: 4, size: 9},
+  {x: 1, y: 5, size: 18},
+  {x: 1, y: 10, size: 5},
+  {x: 1, y: 11, size: 29},
+  {x: 1, y: 13.9, size: 5},
+  {x: 1, y: 14, size: 8},
+  {x: 1.5, y: 11.8, size: 25},
   {x: 1.7, y: 9, size: 30},
-  {x: 2.4, y: 13.5, size: 20},
-  {x: 1, y: 4, size: 18},
+  {x: 2, y: 5, size: 11},
+  {x: 2.1, y: 11.8, size: 28},
   {x: 2.4, y: 7.9, size: 14},
-  {x: 1, y: 4, size: 5},
+  {x: 2.4, y: 13.5, size: 20},
+  {x: 2.7, y: 13.7, size: 14},
   {x: 2.9, y: 7.7, size: 26},
-  {x: 1, y: 4, size: 29}
+  {x: 3, y: 5.4, size: 6}
 ];
 
 const x = scaleLinear()

--- a/showcase/showcase-app.js
+++ b/showcase/showcase-app.js
@@ -28,7 +28,7 @@ const {
   DynamicProgrammaticRightEdgeHints,
   StaticCrosshair,
   DynamicCrosshair,
-  DynamicCrosshairMarkseries,
+  DynamicCrosshairScatterplot,
   SyncedCharts,
   TimeChart,
   VoronoiLineChart,
@@ -197,9 +197,9 @@ class App extends Component {
             <DynamicCrosshair />
           </section>
           <section>
-            <h3>Dynamic Crosshair with MarkSeries</h3>
+            <h3>Dynamic Crosshair Scatteplot</h3>
             <p>Move your mouse over the chart to see the point.</p>
-            <DynamicCrosshairMarkseries />
+            <DynamicCrosshairScatterplot />
           </section>
           <h2>Miscellaneous</h2>
           <section>

--- a/showcase/showcase-app.js
+++ b/showcase/showcase-app.js
@@ -12,7 +12,7 @@ const {
   StackedHistogram,
   AreaChart,
   AreaChartElevated,
-  ScatteplotChart,
+  ScatterplotChart,
   HeatmapChart,
   WidthHeightMarginChart,
   CustomScales,
@@ -85,7 +85,7 @@ class App extends Component {
           </section>
           <section>
             <h3>Mark Series</h3>
-            <ScatteplotChart />
+            <ScatterplotChart />
           </section>
           <section>
             <h3>Area Series</h3>
@@ -197,7 +197,7 @@ class App extends Component {
             <DynamicCrosshair />
           </section>
           <section>
-            <h3>Dynamic Crosshair Scatteplot</h3>
+            <h3>Dynamic Crosshair Scatterplot</h3>
             <p>Move your mouse over the chart to see the point.</p>
             <DynamicCrosshairScatterplot />
           </section>

--- a/showcase/showcase-app.js
+++ b/showcase/showcase-app.js
@@ -28,6 +28,7 @@ const {
   DynamicProgrammaticRightEdgeHints,
   StaticCrosshair,
   DynamicCrosshair,
+  DynamicCrosshairMarkseries,
   SyncedCharts,
   TimeChart,
   VoronoiLineChart,
@@ -194,6 +195,11 @@ class App extends Component {
             <h3>Dynamic Crosshair</h3>
             <p>Move your mouse over the chart to see the point.</p>
             <DynamicCrosshair />
+          </section>
+          <section>
+            <h3>Dynamic Crosshair with MarkSeries</h3>
+            <p>Move your mouse over the chart to see the point.</p>
+            <DynamicCrosshairMarkseries />
           </section>
           <h2>Miscellaneous</h2>
           <section>

--- a/src/plot/series/abstract-series.js
+++ b/src/plot/series/abstract-series.js
@@ -19,7 +19,6 @@
 // THE SOFTWARE.
 
 import React from 'react';
-
 import {voronoi} from 'd3-voronoi';
 
 import PureRenderComponent from 'pure-render-component';

--- a/tests/components/mark-series-tests.js
+++ b/tests/components/mark-series-tests.js
@@ -4,13 +4,46 @@ import {mount} from 'enzyme';
 import MarkSeries from 'plot/series/mark-series';
 import {testRenderWithProps, GENERIC_XYPLOT_SERIES_PROPS} from '../test-utils';
 import Scatterplot from '../../showcase/plot/scatterplot';
+import DynamicCrosshairScatterplot from '../../showcase/plot/dynamic-crosshair-scatterplot';
 
 testRenderWithProps(MarkSeries, GENERIC_XYPLOT_SERIES_PROPS);
 
 test('MarkSeries: Showcase Example - Scatterplot', t => {
   const $ = mount(<Scatterplot />);
-  t.equal($.text(), '1.01.52.02.53.068101214', 'should fine the right text content');
+  t.equal($.text(), '1.01.52.02.53.068101214', 'should find the right text content');
   t.equal($.find('.rv-xy-plot__series--mark circle').length, 5, 'should find the right number of circles');
   t.equal($.find('.mark-series-example').length, 1, 'should find the right number of custom named series');
   t.end();
+});
+
+test('MarkSeries: Showcase Example - Dynamic Crosshair Scatterplot', t => {
+  const $ = mount(<DynamicCrosshairScatterplot />);
+  // NOTE: Point 0 (P0) and Point 1 (P1) are vertically aligned
+  const yDistanceBetweenP0andP1 = 2.5;
+  const chatTopPadding = 10;
+
+  const highlightedCircles1 = $.find('.rv-xy-plot__series--mark circle').reduce(highlightedCircle, []);
+  t.equal(highlightedCircles1.length, 0, 'should not highlight any circles');
+
+  updateCursor(0, yDistanceBetweenP0andP1 / 2 - 0.01);
+  const highlightedCircles2 = $.find('.rv-xy-plot__series--mark circle').reduce(highlightedCircle, []);
+  t.equal(highlightedCircles2.length, 1, 'should highlight one circle');
+  t.deepEqual(highlightedCircles2[0], {cx: 0, cy: 0}, 'should highlight circle at <0, 0>');
+
+  updateCursor(0, yDistanceBetweenP0andP1 / 2);
+  const highlightedCircles3 = $.find('.rv-xy-plot__series--mark circle').reduce(highlightedCircle, []);
+  t.equal(highlightedCircles3.length, 1, 'should highlight one circle');
+  t.deepEqual(highlightedCircles3[0], {cx: 0, cy: 2.5}, 'should highlight circle at <0, 2.5>');
+  t.end();
+
+  function updateCursor(x, y) {
+    $.find('.rv-xy-plot__series--mark')
+      .simulate('mousemove', {nativeEvent: {clientX: x, clientY: y + chatTopPadding}});
+  }
+
+  function highlightedCircle(_highlightedCircle, circle) {
+    const isHighlighted = circle.prop('style').fill === '#FF9833';
+    const circlePosition = {cx: circle.prop('cx'), cy: circle.prop('cy')};
+    return isHighlighted ? [..._highlightedCircle, circlePosition]: _highlightedCircle;
+  }
 });

--- a/tests/components/mark-series-tests.js
+++ b/tests/components/mark-series-tests.js
@@ -44,6 +44,6 @@ test('MarkSeries: Showcase Example - Dynamic Crosshair Scatterplot', t => {
   function highlightedCircle(_highlightedCircle, circle) {
     const isHighlighted = circle.prop('style').fill === '#FF9833';
     const circlePosition = {cx: circle.prop('cx'), cy: circle.prop('cy')};
-    return isHighlighted ? [..._highlightedCircle, circlePosition]: _highlightedCircle;
+    return isHighlighted ? [..._highlightedCircle, circlePosition] : _highlightedCircle;
   }
 });


### PR DESCRIPTION
This PR adds the following:
- `_getXYCoordinateInContainer ` method for `MarkSeries` which can locate the closest point in x and y space and calls `onNearestXY` prop with the closest point being returned to the callback (https://github.com/uber/react-vis/issues/327)
- Add documentation for the `onNearestXY` method (https://github.com/uber/react-vis/issues/332)
- Linting for `docs/markdown/series.md`
- Example for `onNearestXY` interaction and usage

![kapture 2017-03-31 at 14 28 16](https://cloud.githubusercontent.com/assets/6504944/24570059/53b36daa-161e-11e7-93be-22da77a3e6c2.gif)
