### PR TITLE
Circular grid lines

### DIFF
--- a/showcase/index.js
+++ b/showcase/index.js
@@ -29,6 +29,7 @@ import StackedHistogram from './plot/stacked-histogram';
 import AreaChart from './plot/area-chart';
 import AreaChartElevated from './plot/area-chart-elevated';
 import ScatterplotChart from './plot/scatterplot';
+import FauxScatterplotChart from './plot/faux-radial-scatterplot';
 import HeatmapChart from './plot/heatmap-chart';
 import WidthHeightMarginChart from './plot/width-height-margin';
 import CustomScales from './plot/custom-scales';
@@ -76,6 +77,7 @@ export const showCase = {
   StackedHistogram,
   AreaChart,
   AreaChartElevated,
+  FauxScatterplotChart,
   ScatterplotChart,
   HeatmapChart,
   WidthHeightMarginChart,

--- a/showcase/plot/faux-radial-scatterplot.js
+++ b/showcase/plot/faux-radial-scatterplot.js
@@ -18,24 +18,56 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import './setup';
+import React from 'react';
 
-import './utils/axis-utils-tests';
-import './utils/data-utils-tests';
-import './utils/scales-utils-tests';
-import './utils/react-utils-tests';
-import './utils/series-utils-tests';
+import {
+  XYPlot,
+  XAxis,
+  YAxis,
+  MarkSeries,
+  CircularGridLines
+} from 'index';
 
-import './components';
-import './components/area-series-tests';
-import './components/bar-series-tests';
-import './components/circular-grid-lines-tests';
-import './components/heatmap-tests';
-import './components/legends-tests';
-import './components/line-series-tests';
-import './components/mark-series-tests';
-import './components/radial-tests';
-import './components/rect-series-tests';
-import './components/treemap-tests';
-import './components/sankey-tests';
-import './components/xy-plot-tests';
+const data = [
+  {r: 1, theta: Math.PI / 3, size: 30},
+  {r: 1.7, theta: 2 * Math.PI / 3, size: 10},
+  {r: 2, theta: Math.PI, size: 1},
+  {r: 3, theta: 3 * Math.PI / 2, size: 12},
+  {r: 2.5, theta: Math.PI / 4, size: 4},
+  {r: 0, theta: Math.PI / 4, size: 1}
+];
+
+const margin = {
+  top: 10,
+  bottom: 10,
+  left: 10,
+  right: 10
+};
+
+const WIDTH = 300;
+const HEIGHT = 300;
+
+export default class Example extends React.Component {
+  render() {
+    return (
+      <XYPlot
+        margin={margin}
+        xDomain={[-3, 3]}
+        yDomain={[-3, 3]}
+        width={WIDTH}
+        height={HEIGHT}>
+        <CircularGridLines />
+        <XAxis top={(HEIGHT - margin.top) / 2}/>
+        <YAxis left={(WIDTH - margin.left - margin.right) / 2}/>
+        <MarkSeries
+          strokeWidth={2}
+          sizeRange={[5, 15]}
+          data={data.map(row => ({
+            ...row,
+            x: Math.cos(row.theta) * row.r,
+            y: Math.sin(row.theta) * row.r
+          }))}/>
+      </XYPlot>
+    );
+  }
+}

--- a/showcase/showcase-app.js
+++ b/showcase/showcase-app.js
@@ -12,6 +12,7 @@ const {
   StackedHistogram,
   AreaChart,
   AreaChartElevated,
+  FauxScatterplotChart,
   ScatterplotChart,
   HeatmapChart,
   WidthHeightMarginChart,
@@ -131,6 +132,10 @@ class App extends Component {
           <section>
             <h3>Custom GridLines</h3>
             <GridLinesChart />
+          </section>
+          <section>
+            <h3>Circular Gridlines</h3>
+            <FauxScatterplotChart />
           </section>
           <h2>Axes</h2>
           <section>

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,7 @@ export Crosshair from 'plot/crosshair';
 export XYPlot from 'plot/xy-plot';
 export XAxis from 'plot/axis/x-axis';
 export YAxis from 'plot/axis/y-axis';
+export CircularGridLines from 'plot/circular-grid-lines';
 export GridLines from 'plot/grid-lines';
 export VerticalGridLines from 'plot/vertical-grid-lines';
 export HorizontalGridLines from 'plot/horizontal-grid-lines';

--- a/src/plot/circular-grid-lines.js
+++ b/src/plot/circular-grid-lines.js
@@ -43,9 +43,7 @@ const propTypes = {
   tickTotal: PropTypes.number,
 
   animation: AnimationPropType,
-
-  // Not expected to be used by the users.
-  // TODO: Add underscore to these properties later.
+  // generally supplied by xyplot
   marginTop: PropTypes.number,
   marginBottom: PropTypes.number,
   marginLeft: PropTypes.number,
@@ -82,7 +80,7 @@ class CircularGridLines extends PureRenderComponent {
     const {animation, centerX, centerY} = this.props;
     if (animation) {
       return (
-        <Animation {...this.props} {...{animatedProps}}>
+        <Animation {...this.props} animatedProps={animatedProps}>
           <CircularGridLines {...this.props} animation={null}/>
         </Animation>
       );

--- a/src/plot/circular-grid-lines.js
+++ b/src/plot/circular-grid-lines.js
@@ -1,0 +1,131 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import React, {PropTypes} from 'react';
+
+import PureRenderComponent from 'pure-render-component';
+import {getAttributeScale} from 'utils/scales-utils';
+import Animation from 'animation';
+
+import {
+  getTicksTotalFromSize,
+  getTickValues
+} from '../utils/axis-utils';
+
+import {AnimationPropType} from '../utils/animation-utils';
+
+const propTypes = {
+  centerX: PropTypes.number,
+  centerY: PropTypes.number,
+  width: PropTypes.number,
+  height: PropTypes.number,
+  top: PropTypes.number,
+  left: PropTypes.number,
+
+  tickValues: PropTypes.array,
+  tickTotal: PropTypes.number,
+
+  animation: AnimationPropType,
+
+  // Not expected to be used by the users.
+  // TODO: Add underscore to these properties later.
+  marginTop: PropTypes.number,
+  marginBottom: PropTypes.number,
+  marginLeft: PropTypes.number,
+  marginRight: PropTypes.number,
+  innerWidth: PropTypes.number,
+  innerHeight: PropTypes.number
+};
+
+const animatedProps = [
+  'xRange', 'yRange', 'xDomain', 'yDomain',
+  'width', 'height', 'marginLeft', 'marginTop', 'marginRight', 'marginBottom',
+  'tickTotal'
+];
+
+class CircularGridLines extends PureRenderComponent {
+
+  _getDefaultProps() {
+    const {
+      innerWidth,
+      innerHeight,
+      marginTop,
+      marginLeft
+    } = this.props;
+    return {
+      left: marginLeft,
+      top: marginTop,
+      width: innerWidth,
+      height: innerHeight,
+      tickTotal: getTicksTotalFromSize(Math.min(innerWidth, innerHeight))
+    };
+  }
+
+  render() {
+    const {animation, centerX, centerY} = this.props;
+    if (animation) {
+      return (
+        <Animation {...this.props} {...{animatedProps}}>
+          <CircularGridLines {...this.props} animation={null}/>
+        </Animation>
+      );
+    }
+
+    const props = {
+      ...this._getDefaultProps(),
+      ...this.props
+    };
+
+    const {
+      tickTotal,
+      tickValues,
+      marginLeft,
+      marginTop
+    } = props;
+
+    const xScale = getAttributeScale(props, 'x');
+    const yScale = getAttributeScale(props, 'y');
+    const values = getTickValues(xScale, tickTotal, tickValues);
+    return (
+      <g
+        transform={`translate(${xScale(centerX) + marginLeft},${yScale(centerY) + marginTop})`}
+        className="rv-xy-plot__circular-grid-lines">
+        {values.map((value, index) => {
+          return (
+            <circle
+              {...{cx: 0, cy: 0, r: xScale(value)}}
+              key={index}
+              className="rv-xy-plot__circular-grid-lines__line" />
+          );
+        })}
+      </g>
+    );
+  }
+}
+
+CircularGridLines.displayName = 'CircularGridLines';
+CircularGridLines.propTypes = propTypes;
+CircularGridLines.defaultProps = {
+  centerX: 0,
+  centerY: 0
+};
+CircularGridLines.requiresSVG = true;
+
+export default CircularGridLines;

--- a/src/plot/grid-lines.js
+++ b/src/plot/grid-lines.js
@@ -49,8 +49,7 @@ const propTypes = {
 
   animation: AnimationPropType,
 
-  // Not expected to be used by the users.
-  // TODO: Add underscore to these properties later.
+  // generally supplied by xyplot
   marginTop: React.PropTypes.number,
   marginBottom: React.PropTypes.number,
   marginLeft: React.PropTypes.number,

--- a/src/styles/plot.scss
+++ b/src/styles/plot.scss
@@ -45,6 +45,11 @@ $rv-xy-plot-tooltip-padding: 7px 10px;
   stroke: $rv-xy-plot-axis-line-color;
 }
 
+.rv-xy-plot__circular-grid-lines__line {
+  fill-opacity: 0;
+  stroke: $rv-xy-plot-axis-line-color;
+}
+
 .rv-xy-plot__series--line {
   fill: none;
   stroke: #000;

--- a/tests/components/circular-grid-lines-tests.js
+++ b/tests/components/circular-grid-lines-tests.js
@@ -1,0 +1,15 @@
+import test from 'tape';
+import React from 'react';
+import {mount} from 'enzyme';
+import CircularGridLines from 'plot/circular-grid-lines';
+import {testRenderWithProps, GENERIC_XYPLOT_SERIES_PROPS} from '../test-utils';
+import FauxRadialScatterplot from '../../showcase/plot/faux-radial-scatterplot';
+
+testRenderWithProps(CircularGridLines, GENERIC_XYPLOT_SERIES_PROPS);
+
+test('CircularGridLines: Showcase Example - FauxRadialScatterplot', t => {
+  const $ = mount(<FauxRadialScatterplot />);
+  t.equal($.text(), '-3-2-10123-3-2-10123', 'should find the right text content');
+  t.equal($.find('.rv-xy-plot__circular-grid-lines__line').length, 7, 'should find the right number of circles');
+  t.end();
+});


### PR DESCRIPTION
This PR adds a circular grid line component. This is a valuable component to have if users wish to make radial scatter plots (see below), or when making radar charts (#299)

<img width="469" alt="screen shot 2017-04-02 at 5 31 25 pm" src="https://cloud.githubusercontent.com/assets/6854312/24592386/45094a38-17ca-11e7-96f2-3bbede3893c3.png">
