### PR TITLE
Pass style

### DIFF
--- a/docs/docs-app/constants/pages.js
+++ b/docs/docs-app/constants/pages.js
@@ -175,6 +175,13 @@ export const docPages = generatePath([
         filename: 'animation.md',
         pageType: 'documentation'
       }
+    }, {
+      name: 'Style',
+      content: {
+        markdown: getDocUrl('style.md'),
+        filename: 'animation.md',
+        pageType: 'documentation'
+      }
     }]
   },
   {
@@ -261,6 +268,14 @@ export const docPages = generatePath([
         content: {
           markdown: getDocUrl('markseries.md'),
           filename: 'markseries.md',
+          pageType: 'documentation'
+        }
+      },
+      {
+        name: 'Line-Mark Series',
+        content: {
+          markdown: getDocUrl('line-mark-series.md'),
+          filename: 'line-mark-series.md',
           pageType: 'documentation'
         }
       }, {

--- a/docs/markdown/axes.md
+++ b/docs/markdown/axes.md
@@ -102,3 +102,18 @@ Height of the axis in pixels. **Already set by default**, but can be overriden b
 
 #### animation (optional)
 See the [XYPlot](xy-plot.md)'s `animation` section for more information.
+
+### style (optional)
+Type: `object`
+An object that contains CSS properties with which the axis component can be entirely re-styled.
+As the Axis component is composite, it is possible to style its different parts individually. See [style](style.md)
+
+The various parts of the axis can be styled by passing an object to the `line`, `ticks`, `text` and `title` properties:
+
+```jsx
+<XAxis title="X Axis" style={{
+  line: {stroke: '#ADDDE1'},
+  ticks: {stroke: '#ADDDE1'},
+  text: {stroke: 'none', fill: '#6b6b76', fontWeight: 600}
+}}/>
+```

--- a/docs/markdown/bar-series.md
+++ b/docs/markdown/bar-series.md
@@ -117,3 +117,7 @@ The opacity for all elements in the series, this property will be over-ridden by
 #### stroke
 Type: `string|number`
 The outer color for all elements in the series, this property will be over-ridden by color specified in the data attribute.
+
+### style
+Type: `object`
+A list of CSS properties to style the series outside of the explicitly set properties. Note that it will override all other properties (ie fill, stroke, opacity, color). See [style](style.md)

--- a/docs/markdown/grids.md
+++ b/docs/markdown/grids.md
@@ -42,6 +42,10 @@ Height of the grid lines in pixels. **Already set by default**, but can be overr
 #### animation (optional)
 See the [XYPlot](xy-plot.md)'s `animation` section for more information.
 
+#### style (optional)
+Type: `object`
+An CSS object that will style these gridlines. 
+
 ## Polar Grids
 
 <!-- INJECT:"FauxScatterplotChart" -->
@@ -82,3 +86,8 @@ The top-bottom value in coordinates of where the circles should be centered.
 #### rRange (optional)
 Type:[`number`, `number`]
 This allows users to specify the exact pixel range over which they wish their rings to appear.
+
+#### style (optional)
+Type: `object`
+An CSS object that will style these gridlines. See [style](style.md)
+

--- a/docs/markdown/hint.md
+++ b/docs/markdown/hint.md
@@ -11,3 +11,24 @@ In case if custom representation of is needed, the component is also able to wra
   </div>
 </Hint>
 ```
+
+### Style (optional)
+Type: `Object`
+You can pass a style object to your Hint component to apply your own styles. See [style](style.md)
+```jsx
+<Hint value={value} style={{fontSize: 14}}/>
+```
+
+Style is a composite component, and individual parts of it can receive different parts.
+The different parts are: content, row, title, value. To style a specific part, you can pass an object to the property with that name.
+```jsx
+<Hint value={value} style={{
+  fontSize: 14,
+  text: {
+    display: 'none'
+  },
+  value {
+    color: 'red'
+  }
+}}/>
+```

--- a/docs/markdown/line-mark-series.md
+++ b/docs/markdown/line-mark-series.md
@@ -1,15 +1,6 @@
-# LineSeries/LineMarkSeries
+# LineMarkSeries
 
-<!-- INJECT:"LineChart" -->
-
-react-vis offers two different types of LineSeries, one that renders SVG and one that renders WebGL.
-The SVG mode is accessed by using the normal `LineSeries`, just as above, while the WebGL mode is used by simply calling
-`LineSeriesGL` instead of `LineSeries`. It is most effective to hover over your points using onNearestX rather
-than onValueMouseOver.
-
-<!-- INJECT:"LineChartGL" -->
-
-**NOTE**: using the GL version of this layer disables animation
+<!-- INJECT:"LineMarkChart" -->
 
 ## API Reference
 
@@ -47,27 +38,37 @@ Apply the provided or named curve function from the D3 shape library to smooth t
 
 ```javascript
 // Setting up with only a name
-const stringCurveProp = <LineSeries data={data} curve={'curveMonotoneX'} .../>;
+const stringCurveProp = <LineMarkSeries data={data} curve={'curveMonotoneX'} .../>;
 
 const configuredCurve = d3Shape.curveCatmullRom.alpha(0.5);
-const funcCurveProp = <LineSeries data={data} curve={configuredCurve} .../>;
+const funcCurveProp = <LineMarkSeries data={data} curve={configuredCurve} .../>;
 ```
+
+#### onNearestXY (optional)
+Type: `function(value, info)`
+A callback function which is triggered on mousemove and returns the closest point vased on the voronoi layout.
+Callback is triggered with two arguments. `value` is the data point, `info` object has following properties:
+- `innerX` is the horizontal position of the value;
+- `innerY` is the vertical position of the value;
+- `index` is the index of the data point in the array of data;
+- `event` is the event object.
 
 #### style (optional)
 Type: `object`
-An object which holds CSS properties that will be applied to the SVG element(s) rendered by the series. This allows you to style series beyond the other explicitly defined properties and without having to use CSS classnames and stylesheets. See [style](style.md)
+An object which holds CSS properties that will be applied to the SVG element(s) rendered by the series. See [style](style.md)This allows you to style series beyond the other explicitly defined properties and without having to use CSS classnames and stylesheets.
 
 ```jsx
-<LineSeries
+<LineMarkSeries
   data={data}
   style={{strokeLinejoin: "round"}}
 />
 ```
 
-## LineSeriesGL API Additions
+`LineMarkSeries` being a composite component (a mix of [LineSeries](line-series.md) and [MarkSeries](mark-series.md)), there are two additional property in the `style` object: `line` and `mark`, which allow you to specify a style for the line or the mark part of the line mark series, respectively.
 
-In addition to the above api the GL version of markSeries exposes several additional props.
-
-#### seriesId (REQUIRED)
-Type: `string`
-This string is used by deck.gl to identify which layer is being requested to render.
+```jsx
+<LineMarkSeries
+  data={data}
+  style={{line: {stroke:"blue"}, mark: {stroke:"red"}}}
+/>
+```

--- a/docs/markdown/polygon-series.md
+++ b/docs/markdown/polygon-series.md
@@ -82,4 +82,5 @@ Type: `function(d, {event})`
 
 #### style
 Type: `object`
-Paths accept a ton of different styles, so rather than prescribe every single one we just accept a general grab bag pf the styles. check out the [w3](https://www.w3schools.com/graphics/svg_path.asp) page for more details.
+Paths accept a ton of different styles, so rather than prescribe every single one we just accept a general grab bag pf the styles. check out the [w3](https://www.w3schools.com/graphics/svg_path.asp) page for more details and the [style] documnetation (style.md).
+

--- a/docs/markdown/series.md
+++ b/docs/markdown/series.md
@@ -75,5 +75,43 @@ Type: `function(info)`
 Type: `function(info)`
 `click` event handler for the entire series. Received `info` object as argument with the only `event` property.
 
+#### style (optional)
+Type: `object`
+An object which holds CSS properties that will be applied to the SVG element(s) rendered by the series. This allows you to style series beyond the other explicitly defined properties and without having to use CSS classnames and stylesheets. For instance, you can set the stroke-linejoin style of a line series to "round":
+```jsx
+<LineSeries
+  data={data}
+  style={{strokeLinejoin: "round"}}
+/>
+```
+LineMark series is a composite series, and as such, it's possible to separate style instructions for the line and the mark part by putting them under a "line" and a "mark" property respectively: 
+
+```jsx
+<LineMarkSeries
+  data={data}
+  style={{
+  	// affect both the line and the mark part
+  	stroke: "red",
+  	.line: {
+  	  // affects just the line series
+  	  strokeWidth: 2
+  	},
+  	.mark {
+  	  // affects just the mark series
+  	  strokeWidth: 4
+  	}
+  }}
+/>
+```
+
+Note that style information passed through the style property will override those passed through props.
+```jsx
+<MarkSeries
+  data={data}
+  /// all the points are red
+  style={{fill: "red"}}
+/>
+```
+
 #### animation (optional)
 See the [XYPlot](xy-plot.md)'s `animation` section for more information.

--- a/docs/markdown/style.md
+++ b/docs/markdown/style.md
@@ -1,0 +1,35 @@
+## Style
+
+In order to control the look and feel of your React-Vis components, you have four strategies.
+
+### the React-Vis style sheet
+React-Vis comes with a default style sheet. You need to import it or otherwise link it to your app (as shown in the [getting started](tutorial/getting-started.md) page), or you may overwrite it. 
+
+### Class names
+You may also use the class names of the React-Vis component to style them through your own stylesheets, or your own style strategies. 
+Furthermore, all series components accept a `className` property, which adds a class of your own choosing to the element. 
+Non-series elements (i.e. [gridlines](grids.md) or [hints](hint.md)) do not take a className property.
+
+### Component-specific properties
+Virtually every component accept several properties that affects its appearance. For instance, [line series](line-series.md) take a `color` property to control the stroke color of the line, but others as well such as strokeWidth that controls its thickness. Each of these is described in detail for each component. 
+
+### Style property
+Finally, components can also accept a special property called `style`. This let you pass an object to the component. The keys of that object are CSS properties, camel-cased (ie `stroke-width` would be written `strokeWidth`) and values are what you'd want to set those properties to. These are the same conventions than when [passing style](https://facebook.github.io/react/docs/dom-elements.html) to a standard DOM element with React.
+
+```javascript
+<LineSeries
+  data={data}
+  style={{strokeWidth: 2}}
+/>
+```
+
+Some React-Vis components are composite in the sense that they group several elements that you may want to style distinctly. For instance, the [line-mark series](line-mark-series.md) combines a [line series](line-series.md) and a [mark series](mark-series.md). While you could pass the same style object to both, you can also use special properties (in this case, `line` and `mark`) to send a specific style object to either or both sub-components. 
+
+```javascript
+<LineMarkSeries
+  data={data}
+  color="red"
+  style={{mark:{stroke: 'white'}}}
+/>
+```
+In that example, without the style property, both lines and marks would be red. Without specifying `mark` in the style property, the stroke color of both lines and marks would be white. Here, the line remains red, and the marks are going to be red (their fill color) but with a white outline.

--- a/docs/markdown/xy-plot.md
+++ b/docs/markdown/xy-plot.md
@@ -52,6 +52,7 @@ XYPlot is a wrapper for series, hints, axes and other components. Most of these 
 * `strokeWidth` (optional), `strokeStyle` (optional) - to control the width of the line series and whether they are dashed or solid.
 * `color` (optional, used instead of `fill` and `stroke` if none of them is passed)
 * `size` (optional)
+* `style` (optional) - css properties as an object.
 
 If the property is not passed in any of the objects, the property is not visualized. The user can override the way how properties are visualized by passing custom range, domain or type of scales to the series or the entire chart (please see [Series](series.md) for more info).
 
@@ -126,6 +127,10 @@ Margin around the chart.
 #### stackBy (optional)
 Type: `string`  
 Stack the chart by the given attribute. If the attribute is `y`, the chart is stacked vertically; if the attribute is `x` then it's stacked horizontally.
+
+### style (optional)
+Type: `object`
+CSS properties that will affect this wrapper component. Those will be applied to the SVG element in which other react-vis components will be created.  
 
 ```jsx
 <XYPlot

--- a/showcase/index.js
+++ b/showcase/index.js
@@ -21,6 +21,7 @@
 import ComplexChart from './plot/complex-chart';
 import LineChart from './plot/line-chart';
 import LineChartGL from './plot/line-chart-gl';
+import LineChartWithStyle from './plot/line-chart-with-style';
 import LineMarkChart from './plot/linemark-chart';
 import BarChart from './plot/bar-chart';
 import StackedVerticalBarChart from './plot/stacked-vertical-bar-chart';
@@ -83,6 +84,7 @@ export const showCase = {
   ComplexChart,
   LineChart,
   LineChartGL,
+  LineChartWithStyle,
   LineMarkChart,
   BarChart,
   StackedVerticalBarChart,

--- a/showcase/plot/line-chart-with-style.js
+++ b/showcase/plot/line-chart-with-style.js
@@ -19,14 +19,15 @@
 // THE SOFTWARE.
 
 import React from 'react';
+import {curveCatmullRom} from 'd3-shape';
 
 import {
   XYPlot,
   XAxis,
   YAxis,
-  VerticalGridLines,
   HorizontalGridLines,
-  LineMarkSeries
+  VerticalGridLines,
+  LineSeries
 } from 'index';
 
 export default class Example extends React.Component {
@@ -35,27 +36,50 @@ export default class Example extends React.Component {
       <XYPlot
         width={300}
         height={300}>
-        <VerticalGridLines />
-        <HorizontalGridLines />
-        <XAxis />
-        <YAxis />
-        <LineMarkSeries
-          className="linemark-series-example"
+        <HorizontalGridLines style={{stroke: '#B7E9ED'}}/>
+        <VerticalGridLines style={{stroke: '#B7E9ED'}}/>
+        <XAxis title="X Axis" style={{
+          line: {stroke: '#ADDDE1'},
+          ticks: {stroke: '#ADDDE1'},
+          text: {stroke: 'none', fill: '#6b6b76', fontWeight: 600}
+        }}/>
+        <YAxis title="Y Axis" />
+        <LineSeries
+          className="first-series"
+          data={[
+            {x: 1, y: 3},
+            {x: 2, y: 5},
+            {x: 3, y: 15},
+            {x: 4, y: 12}
+          ]}
           style={{
-            stroke: 'white'
+            strokeLinejoin: 'round',
+            strokeWidth: 4
           }}
+        />
+        <LineSeries
+          className="second-series"
+          data={null}/>
+        <LineSeries
+          className="third-series"
+          curve={'curveMonotoneX'}
+          strokeDasharray="3 4"
           data={[
             {x: 1, y: 10},
-            {x: 2, y: 5},
-            {x: 3, y: 15}
-          ]}/>
-        <LineMarkSeries
-          className="linemark-series-example-2"
-          curve={'curveMonotoneX'}
+            {x: 2, y: 4},
+            {x: 3, y: 2},
+            {x: 4, y: 15}
+          ]}
+          strokeDasharray="7, 3"
+          />
+        <LineSeries
+          className="fourth-series"
+          curve={curveCatmullRom.alpha(0.5)}
           data={[
-            {x: 1, y: 11},
-            {x: 1.5, y: 29},
-            {x: 3, y: 7}
+            {x: 1, y: 7},
+            {x: 2, y: 11},
+            {x: 3, y: 9},
+            {x: 4, y: 2}
           ]}/>
       </XYPlot>
     );

--- a/showcase/plot/line-chart.js
+++ b/showcase/plot/line-chart.js
@@ -54,6 +54,9 @@ export default class Example extends React.Component {
         <LineSeries
           className="third-series"
           curve={'curveMonotoneX'}
+          style={{
+            strokeDasharray: '2 2'
+          }}
           data={[
             {x: 1, y: 10},
             {x: 2, y: 4},

--- a/showcase/showcase-sections/plots-showcase.js
+++ b/showcase/showcase-sections/plots-showcase.js
@@ -13,6 +13,7 @@ const {
   GridLinesChart,
   HeatmapChart,
   LineChart,
+  LineChartWithStyle,
   LineChartGL,
   LineMarkChart,
   StackedVerticalBarChart,
@@ -29,6 +30,12 @@ const PLOTS = [{
   sourceLink: 'https://github.com/uber/react-vis/blob/master/src/plot/series/line-series.js',
   docsLink: 'http://uber.github.io/react-vis/#/documentation/xy-plot-series/line-series'
 }, {
+  component: LineChartWithStyle,
+  name: 'Line Series with style',
+  sourceLink: 'https://github.com/uber/react-vis/blob/master/src/plot/series/line-series.js',
+  docsLink: 'http://uber.github.io/react-vis/#/documentation/xy-plot-series/line-series'
+},
+{
   component: LineMarkChart,
   name: 'LineMark Series',
   sourceLink: 'https://github.com/uber/react-vis/blob/master/src/plot/series/line-mark-series.js',

--- a/src/plot/axis/axis-line.js
+++ b/src/plot/axis/axis-line.js
@@ -27,14 +27,19 @@ import {ORIENTATION} from 'utils/axis-utils';
 const {LEFT, RIGHT, TOP, BOTTOM} = ORIENTATION;
 
 const propTypes = {
-  width: PropTypes.number.isRequired,
   height: PropTypes.number.isRequired,
+  style: PropTypes.object,
   orientation: PropTypes.oneOf([
     LEFT, RIGHT, TOP, BOTTOM
-  ]).isRequired
+  ]).isRequired,
+  width: React.PropTypes.number.isRequired
 };
 
-function AxisLine({orientation, width, height}) {
+const defaultProps = {
+  style: {}
+};
+
+function AxisLine({orientation, width, height, style}) {
   let lineProps;
   if (orientation === LEFT) {
     lineProps = {
@@ -66,12 +71,12 @@ function AxisLine({orientation, width, height}) {
     };
   }
   return (
-    <line {...lineProps} className="rv-xy-plot__axis__line"/>
+    <line {...lineProps} className="rv-xy-plot__axis__line" style={style}/>
   );
 }
 
+AxisLine.defaultProps = defaultProps;
 AxisLine.displayName = 'AxisLine';
 AxisLine.propTypes = propTypes;
 
 export default AxisLine;
-

--- a/src/plot/axis/axis-ticks.js
+++ b/src/plot/axis/axis-ticks.js
@@ -28,11 +28,16 @@ import {getAttributeScale} from 'utils/scales-utils';
 const {LEFT, RIGHT, TOP, BOTTOM} = ORIENTATION;
 
 const propTypes = {
-  width: PropTypes.number.isRequired,
   height: PropTypes.number.isRequired,
   orientation: PropTypes.oneOf([
     LEFT, RIGHT, TOP, BOTTOM
-  ]).isRequired
+  ]).isRequired,
+  style: PropTypes.object,
+  width: PropTypes.number.isRequired
+};
+
+const defaultProps = {
+  style: {}
 };
 
 function _getTickFormatFn(scale, tickTotal, tickFormat) {
@@ -151,6 +156,7 @@ class AxisTicks extends React.Component {
       orientation,
       width,
       height,
+      style,
       tickFormat,
       tickTotal,
       tickValues
@@ -173,9 +179,17 @@ class AxisTicks extends React.Component {
       const text = tickFormatFn(v);
 
       return (
-        <g key={i} {...translateFn(pos, 0)} className="rv-xy-plot__axis__tick">
-          <line {...pathProps} className="rv-xy-plot__axis__tick__line"/>
-          <text {...textProps} className="rv-xy-plot__axis__tick__text">
+        <g key={i} {...translateFn(pos, 0)}
+        className="rv-xy-plot__axis__tick"
+        style={style}>
+          <line {...pathProps}
+            className="rv-xy-plot__axis__tick__line"
+            style={{...style, ...style.line}}
+          />
+          <text {...textProps}
+            className="rv-xy-plot__axis__tick__text"
+            style={{...style, ...style.text}}
+          >
             {text}
           </text>
         </g>
@@ -192,9 +206,9 @@ class AxisTicks extends React.Component {
   }
 }
 
+AxisTicks.defaultProps = defaultProps;
 AxisTicks.displayName = 'AxisTicks';
 AxisTicks.propTypes = propTypes;
 AxisTicks.requiresSVG = true;
 
 export default AxisTicks;
-

--- a/src/plot/axis/axis-title.js
+++ b/src/plot/axis/axis-title.js
@@ -67,10 +67,11 @@ const propTypes = {
   orientation: PropTypes.oneOf([
     LEFT, RIGHT, TOP, BOTTOM
   ]).isRequired,
+  style: PropTypes.object,
   title: PropTypes.string.isRequired
 };
 
-function AxisTitle({orientation, width, height, title}) {
+function AxisTitle({orientation, width, height, style, title}) {
   const outerGroupTranslateX = orientation === LEFT ? width : 0;
   const outerGroupTranslateY = orientation === TOP ? height : 0;
   const outerGroupTransform = `translate(${outerGroupTranslateX}, ${outerGroupTranslateY})`;
@@ -79,7 +80,7 @@ function AxisTitle({orientation, width, height, title}) {
 
   return (
     <g transform={outerGroupTransform} className="rv-xy-plot__axis__title">
-      <g style={{textAnchor}} transform={innerGroupTransform}>
+      <g style={{...textAnchor, ...style}} transform={innerGroupTransform}>
         <text>{title}</text>
       </g>
     </g>

--- a/src/plot/axis/axis.js
+++ b/src/plot/axis/axis.js
@@ -49,6 +49,8 @@ const propTypes = {
   left: PropTypes.number,
   title: PropTypes.string,
 
+  style: PropTypes.object,
+
   className: PropTypes.string,
   hideTicks: PropTypes.bool,
   hideLine: PropTypes.bool,
@@ -73,6 +75,7 @@ const propTypes = {
 
 const defaultProps = {
   className: '',
+  style: {},
   tickSize: 6,
   tickPadding: 8,
   orientation: BOTTOM
@@ -157,6 +160,7 @@ class Axis extends PureRenderComponent {
       hideTicks,
       left,
       orientation,
+      style,
       title,
       top,
       width
@@ -167,17 +171,21 @@ class Axis extends PureRenderComponent {
     return (
       <g
         transform={`translate(${left},${top})`}
-        className={`${predefinedClassName} ${axisClassName} ${className}`}>
+        className={`${predefinedClassName} ${axisClassName} ${className}`}
+        style={style}>
         {!hideLine && (<AxisLine
           height={height}
           width={width}
-          orientation={orientation}/>)}
-        {!hideTicks && (<AxisTicks {...props} />)}
+          orientation={orientation}
+          style={{...style, ...style.line}}
+          />)}
+        {!hideTicks && (<AxisTicks {...props} style={{...style, ...style.ticks}}/>)}
         {title ?
           <AxisTitle
             title={title}
             height={height}
             width={width}
+            style={{...style, ...style.title}}
             orientation={orientation}/> :
           null}
       </g>

--- a/src/plot/circular-grid-lines.js
+++ b/src/plot/circular-grid-lines.js
@@ -51,6 +51,7 @@ class CircularGridLines extends PureRenderComponent {
       top: marginTop,
       width: innerWidth,
       height: innerHeight,
+      style: {},
       tickTotal: getTicksTotalFromSize(Math.min(innerWidth, innerHeight))
     };
   }
@@ -75,7 +76,8 @@ class CircularGridLines extends PureRenderComponent {
       tickValues,
       marginLeft,
       marginTop,
-      rRange
+      rRange,
+      style
     } = props;
 
     const xScale = getAttributeScale(props, 'x');
@@ -94,7 +96,8 @@ class CircularGridLines extends PureRenderComponent {
             <circle
               {...{cx: 0, cy: 0, r: radius}}
               key={index}
-              className="rv-xy-plot__circular-grid-lines__line" />
+              className="rv-xy-plot__circular-grid-lines__line"
+              style={style} />
           ]);
         }, [])}
       </g>
@@ -111,6 +114,8 @@ CircularGridLines.propTypes = {
   top: PropTypes.number,
   left: PropTypes.number,
   rRange: PropTypes.arrayOf(PropTypes.number),
+
+  style: PropTypes.object,
 
   tickValues: PropTypes.arrayOf(PropTypes.number),
   tickTotal: PropTypes.number,

--- a/src/plot/grid-lines.js
+++ b/src/plot/grid-lines.js
@@ -44,6 +44,8 @@ const propTypes = {
   top: PropTypes.number,
   left: PropTypes.number,
 
+  style: PropTypes.object,
+
   tickValues: PropTypes.array,
   tickTotal: PropTypes.number,
 
@@ -111,6 +113,7 @@ class GridLines extends PureRenderComponent {
       direction,
       width,
       height,
+      style,
       tickTotal,
       tickValues,
       top,
@@ -140,7 +143,8 @@ class GridLines extends PureRenderComponent {
             <line
               {...pathProps}
               key={i}
-              className="rv-xy-plot__grid-lines__line" />
+              className="rv-xy-plot__grid-lines__line"
+              style={style} />
           );
         })}
       </g>

--- a/src/plot/hint.js
+++ b/src/plot/hint.js
@@ -86,6 +86,7 @@ class Hint extends PureRenderComponent {
       scales: PropTypes.object,
       value: PropTypes.object,
       format: PropTypes.func,
+      style: PropTypes.object,
       align: PropTypes.shape({
         horizontal: PropTypes.oneOf([
           ALIGN.AUTO,
@@ -118,7 +119,8 @@ class Hint extends PureRenderComponent {
       align: {
         horizontal: ALIGN.AUTO,
         vertical: ALIGN.AUTO
-      }
+      },
+      style: {}
     };
   }
 
@@ -353,7 +355,7 @@ class Hint extends PureRenderComponent {
     const align = this._getAlign(x, y);
 
     return {
-      style: getAlignStyle ? getAlignStyle(align, x, y) :
+      position: getAlignStyle ? getAlignStyle(align, x, y) :
         this._getAlignStyle(align, x, y),
       className: this._getAlignClassNames(align)
     };
@@ -363,25 +365,27 @@ class Hint extends PureRenderComponent {
     const {
       value,
       format,
-      children
+      children,
+      style
     } = this.props;
 
-    const {style, className} = this._getPositionInfo();
+    const {position, className} = this._getPositionInfo();
     return (
       <div
         className={`rv-hint ${className}`}
         style={{
-          ... style,
+          ...style,
+          ...position,
           position: 'absolute'
         }}>
         {children ?
           children :
-          <div className="rv-hint__content">
+          <div className="rv-hint__content" style={style.content}>
             {format(value).map((formattedProp, i) =>
-              <div key={`rv-hint${i}`}>
-                <span className="rv-hint__title">{formattedProp.title}</span>
+              <div key={`rv-hint${i}`} style={style.row}>
+                <span className="rv-hint__title" style={style.title}>{formattedProp.title}</span>
                 {': '}
-                <span className="rv-hint__value">{formattedProp.value}</span>
+                <span className="rv-hint__value" style={style.value}>{formattedProp.value}</span>
               </div>
             )}
           </div>

--- a/src/plot/series/abstract-series.js
+++ b/src/plot/series/abstract-series.js
@@ -48,11 +48,13 @@ const propTypes = {
   onSeriesClick: PropTypes.func,
   onNearestX: PropTypes.func,
   onNearestXY: PropTypes.func,
+  style: PropTypes.object,
   animation: AnimationPropType
 };
 
 const defaultProps = {
-  className: ''
+  className: '',
+  style: {}
 };
 
 class AbstractSeries extends PureRenderComponent {

--- a/src/plot/series/arc-series.js
+++ b/src/plot/series/arc-series.js
@@ -38,6 +38,12 @@ import {
 const predefinedClassName = 'rv-xy-plot__series rv-xy-plot__series--arc';
 const ATTRIBUTES = ['radius', 'angle'];
 
+const defaultProps = {
+  center: {x: 0, y: 0},
+  className: '',
+  style: {}
+};
+
 class ArcSeries extends AbstractSeries {
   constructor(props) {
     super(props);
@@ -96,7 +102,7 @@ class ArcSeries extends AbstractSeries {
       data,
       marginLeft,
       marginTop,
-      style = {}
+      style
     } = this.props;
 
     if (!data) {
@@ -173,11 +179,7 @@ ArcSeries.propTypes = {
   }),
   arcClassName: PropTypes.string
 };
-ArcSeries.defaultProps = {
-  arcClassName: '',
-  center: {x: 0, y: 0},
-  className: ''
-};
+ArcSeries.defaultProps = defaultProps;
 ArcSeries.displayName = 'ArcSeries';
 
 export default ArcSeries;

--- a/src/plot/series/area-series.js
+++ b/src/plot/series/area-series.js
@@ -45,7 +45,7 @@ class AreaSeries extends AbstractSeries {
 
   render() {
     const {
-      animation, className, curve, data, marginLeft, marginTop
+      animation, className, curve, data, marginLeft, marginTop, style
     } = this.props;
     if (!data) {
       return null;
@@ -79,7 +79,8 @@ class AreaSeries extends AbstractSeries {
         style={{
           opacity,
           stroke,
-          fill
+          fill,
+          ...style
         }}/>
     );
   }

--- a/src/plot/series/bar-series.js
+++ b/src/plot/series/bar-series.js
@@ -51,6 +51,7 @@ class BarSeries extends AbstractSeries {
       lineSizeAttr,
       marginLeft,
       marginTop,
+      style,
       valuePosAttr,
       valueSizeAttr
     } = this.props;
@@ -90,7 +91,8 @@ class BarSeries extends AbstractSeries {
             style: {
               opacity: opacityFunctor && opacityFunctor(d),
               stroke: strokeFunctor && strokeFunctor(d),
-              fill: fillFunctor && fillFunctor(d)
+              fill: fillFunctor && fillFunctor(d),
+              ...style
             },
             [linePosAttr]: lineFunctor(d) - itemSize +
             (itemSize * 2 / sameTypeTotal * sameTypeIndex),

--- a/src/plot/series/heatmap-series.js
+++ b/src/plot/series/heatmap-series.js
@@ -35,7 +35,9 @@ class HeatmapSeries extends AbstractSeries {
   }
 
   render() {
-    const {animation, className, data, marginLeft, marginTop} = this.props;
+    const {
+      animation, className, data, marginLeft, marginTop, style
+    } = this.props;
     if (!data) {
       return null;
     }
@@ -65,7 +67,8 @@ class HeatmapSeries extends AbstractSeries {
             style: {
               stroke: strokeFunctor && strokeFunctor(d),
               fill: fillFunctor && fillFunctor(d),
-              opacity: opacityFunctor && opacityFunctor(d)
+              opacity: opacityFunctor && opacityFunctor(d),
+              ...style
             },
             x: xFunctor(d) - xDistance / 2,
             y: yFunctor(d) - yDistance / 2,

--- a/src/plot/series/line-mark-series.js
+++ b/src/plot/series/line-mark-series.js
@@ -24,23 +24,35 @@ import AbstractSeries from './abstract-series';
 import LineSeries from './line-series';
 import MarkSeries from './mark-series';
 
+const propTypes = {
+  ...LineSeries.propTypes,
+  lineStyle: React.PropTypes.object,
+  markStyle: React.PropTypes.object
+};
+
 class LineMarkSeries extends AbstractSeries {
 
   static get defaultProps() {
-    return LineSeries.defaultProps;
+    return {
+      ...LineSeries.defaultProps,
+      lineStyle: {},
+      markStyle: {}
+    };
   }
 
   render() {
+    const {lineStyle, markStyle, style} = this.props;
     return (
       <g className="rv-xy-plot__series rv-xy-plot__series--linemark">
-        <LineSeries {...this.props} />
-        <MarkSeries {...this.props} />
+        <LineSeries {...this.props} style={{...style, ...lineStyle}}/>
+        <MarkSeries {...this.props} style={{...style, ...markStyle}}/>
       </g>
     );
   }
 }
 
 LineMarkSeries.displayName = 'LineMarkSeries';
+LineMarkSeries.propTypes = propTypes;
 
 export default LineMarkSeries;
 

--- a/src/plot/series/line-series.js
+++ b/src/plot/series/line-series.js
@@ -37,6 +37,7 @@ const STROKE_STYLES = {
 
 const defaultProps = {
   strokeStyle: 'solid',
+  style: {},
   opacity: 1,
   curve: null
 };
@@ -78,7 +79,9 @@ class LineSeries extends AbstractSeries {
       );
     }
 
-    const {strokeDasharray, strokeStyle, strokeWidth, marginLeft, marginTop, curve} = this.props;
+    const {
+      strokeStyle, strokeDasharray, strokeWidth, marginLeft, marginTop, curve, style
+    } = this.props;
 
     const x = this._getAttributeFunctor('x');
     const y = this._getAttributeFunctor('y');
@@ -100,7 +103,8 @@ class LineSeries extends AbstractSeries {
           opacity,
           strokeDasharray: STROKE_STYLES[strokeStyle] || strokeDasharray,
           strokeWidth,
-          stroke
+          stroke,
+          ...style
         }}/>
     );
   }

--- a/src/plot/series/mark-series.js
+++ b/src/plot/series/mark-series.js
@@ -34,7 +34,9 @@ const DEFAULT_STROKE_WIDTH = 1;
 class MarkSeries extends AbstractSeries {
 
   render() {
-    const {animation, className, data, marginLeft, marginTop, strokeWidth} = this.props;
+    const {
+      animation, className, data, marginLeft, marginTop, strokeWidth, style
+    } = this.props;
     if (!data) {
       return null;
     }
@@ -68,7 +70,8 @@ class MarkSeries extends AbstractSeries {
               opacity: opacityFunctor ? opacityFunctor(d) : DEFAULT_OPACITY,
               stroke: strokeFunctor && strokeFunctor(d),
               fill: fillFunctor && fillFunctor(d),
-              strokeWidth: strokeWidth || DEFAULT_STROKE_WIDTH
+              strokeWidth: strokeWidth || DEFAULT_STROKE_WIDTH,
+              ...style
             },
             key: i,
             onClick: e => this._valueClickHandler(d, e),

--- a/src/plot/series/rect-series.js
+++ b/src/plot/series/rect-series.js
@@ -50,6 +50,7 @@ class RectSeries extends AbstractSeries {
       lineSizeAttr,
       marginLeft,
       marginTop,
+      style,
       valuePosAttr,
       valueSizeAttr
     } = this.props;
@@ -85,7 +86,8 @@ class RectSeries extends AbstractSeries {
             style: {
               opacity: opacityFunctor && opacityFunctor(d),
               stroke: strokeFunctor && strokeFunctor(d),
-              fill: fillFunctor && fillFunctor(d)
+              fill: fillFunctor && fillFunctor(d),
+              ...style
             },
             [linePosAttr]: line0Functor(d),
             [lineSizeAttr]: Math.abs(lineFunctor(d) - line0Functor(d)),

--- a/src/plot/xy-plot.js
+++ b/src/plot/xy-plot.js
@@ -97,6 +97,7 @@ class XYPlot extends React.Component {
       onMouseLeave: PropTypes.func,
       onMouseMove: PropTypes.func,
       stackBy: PropTypes.oneOf(ATTRIBUTES),
+      style: PropTypes.object,
       width: PropTypes.number.isRequired
     };
   }
@@ -370,6 +371,7 @@ class XYPlot extends React.Component {
   render() {
     const {
       className,
+      style,
       width,
       height
     } = this.props;
@@ -380,7 +382,8 @@ class XYPlot extends React.Component {
           className={`rv-xy-plot ${className}`}
           style={{
             width: `${width}px`,
-            height: `${height}px`
+            height: `${height}px`,
+            ...this.props.style
           }}/>
       );
     }
@@ -397,6 +400,7 @@ class XYPlot extends React.Component {
           className="rv-xy-plot__inner"
           width={width}
           height={height}
+          style={style}
           onMouseDown={this._mouseDownHandler}
           onMouseMove={this._mouseMoveHandler}
           onMouseLeave={this._mouseLeaveHandler}


### PR DESCRIPTION
In this PR I pass style as a prop to any react-vis component (series, axis, gridlines, hint etc) and that component will take this styling information into account. With this it's possible to completely override style info from the stylesheet or even to style a chart without importing the stylesheet.
I've added one example where axes, gridlines and series are restyled through props. 