### PR TITLE
Accessibility

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,18 +5,21 @@
   },
   "extends": [
     "uber-es2015",
-    "uber-jsx"
+    "uber-jsx",
+    "plugin:jsx-a11y/recommended"
   ],
   "rules": {
     "consistent-return": 0,
     "max-len": [1, 110, 4],
     "max-params": ["error", 6],
     "object-curly-spacing": 0,
-    "babel/object-curly-spacing": 2
+    "babel/object-curly-spacing": 2,
+    "jsx-a11y/no-static-element-interactions": 0
   },
   "parser": "babel-eslint",
   "plugins": [
     "react",
-    "babel"
+    "babel",
+    "jsx-a11y"
   ]
 }

--- a/docs/markdown/treemap.md
+++ b/docs/markdown/treemap.md
@@ -117,19 +117,19 @@ Each point consists of following properties:
 Type: `boolean|Object`
 Please refer to [Animation](animation.md) doc for more information.
 
-#### onLeafClick (optional)
+#### onValueClick (optional)
 Type: `function`
 - Should accept arguments (leafNode, domEvent)
 
 Pass in a function that will be called on click on a given leaf.
 
-#### onLeafMouseOver (optional)
+#### onValueMouseOver (optional)
 Type: `function`
 - Should accept arguments (leafNode, domEvent)
 
 Pass in a function that will be called on mouseEnter on a given leaf.
 
-#### onLeafMouseOut (optional)
+#### onValueMouseOut (optional)
 Type: `function`
 - Should accept arguments (leafNode, domEvent)
 

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "eslint-config-uber-es2015": "^3.0.1",
     "eslint-config-uber-jsx": "^3.0.1",
     "eslint-plugin-babel": "^4.0.0",
+    "eslint-plugin-jsx-a11y": "^4.0.0",
     "eslint-plugin-react": "^6.9.0",
     "jsdom": "^9.9.1",
     "node-sass": "^4.2.0",

--- a/showcase/plot/dynamic-crosshair-scatterplot.js
+++ b/showcase/plot/dynamic-crosshair-scatterplot.js
@@ -85,8 +85,9 @@ export default class Example extends React.Component {
     const {data, selectedPointId, showVoronoi} = this.state;
     return (
       <div>
-        <label style={{display: 'block'}}>
+        <label htmlFor="showVoronoi" style={{display: 'block'}}>
           <input type="checkbox"
+            id="showVoronoi"
             checked={showVoronoi}
             onChange={e => this.setState({showVoronoi: !showVoronoi})}
           />

--- a/showcase/plot/voronoi-line-chart.js
+++ b/showcase/plot/voronoi-line-chart.js
@@ -75,8 +75,9 @@ export default class Example extends React.Component {
     const {hoveredNode, showVoronoi} = this.state;
     return (
       <div>
-        <label style={{display: 'block'}}>
+        <label style={{display: 'block'}} htmlFor="showVoronoiCheckbox">
           <input
+            id="showVoronoiCheckbox"
             type="checkbox"
             checked={showVoronoi}
             onChange={e => this.setState({showVoronoi: !showVoronoi})}
@@ -107,8 +108,8 @@ export default class Example extends React.Component {
           <Voronoi
             extent={[[margin.left, margin.top], [width - margin.right, height - margin.bottom]]}
             nodes={lines.reduce((acc, d) => [...acc, ...d], [])}
-            onHover={node => this.setState({hoveredNode: node})}
-            onBlur={() => this.setState({hoveredNode: null})}
+            onValueMouseEnter={node => this.setState({hoveredNode: node})}
+            onValueMouseLeave={() => this.setState({hoveredNode: null})}
             polygonStyle={{stroke: showVoronoi ? 'rgba(0, 0, 0, .2)' : null}}
             x={d => x(d.x)}
             y={d => y(d.y)}

--- a/showcase/radial-chart/custom-radius-radial-chart.js
+++ b/showcase/radial-chart/custom-radius-radial-chart.js
@@ -71,8 +71,8 @@ export default class SimpleRadialChart extends Component {
             opacity: (!hoveredSection || hoveredSection === 5) ? 1 : 0.6
           }
         ]}
-        onSectionMouseOver={row => this.setState({hoveredSection: row.id})}
-        onSectionMouseOut={() => this.setState({hoveredSection: false})}
+        onValueMouseEnter={row => this.setState({hoveredSection: row.id})}
+        onValueMouseLeave={() => this.setState({hoveredSection: false})}
         width={600}
         height={300} />
     );

--- a/showcase/sankey/voronoi.js
+++ b/showcase/sankey/voronoi.js
@@ -34,8 +34,8 @@ export default class VoronoiSankeyExample extends React.Component {
         width={200}
         height={200}
         hasVoronoi
-        onHover={node => this.setState({activeNode: node})}
-        onBlur={() => this.setState({activeNode: null})}
+        onValueMouseEnter={node => this.setState({activeNode: node})}
+        onValueMouseLeave={() => this.setState({activeNode: null})}
       />
     );
   }

--- a/showcase/showcase-app.js
+++ b/showcase/showcase-app.js
@@ -18,7 +18,7 @@ class App extends Component {
 
         {!forExample && (<header>
           <div className="header-contents">
-            <a className="header-logo" href="#">react-vis</a>
+            <a className="header-logo" href="#plots">react-vis</a>
             <nav>
               <li><a href="#plots">Plots</a></li>
               <li><a href="#axes">Axes</a></li>

--- a/showcase/treemap/dynamic-treemap.js
+++ b/showcase/treemap/dynamic-treemap.js
@@ -62,9 +62,9 @@ export default class DynamicTreemapExample extends React.Component {
         stiffness: 300
       },
       data: this.state.treemapData,
-      onLeafMouseOver: x => this.setState({hoveredNode: x}),
-      onLeafMouseOut: () => this.setState({hoveredNode: false}),
-      onLeafClick: () => this.setState({treemapData: _getRandomData()}),
+      onValueMouseEnter: x => this.setState({hoveredNode: x}),
+      onValueMouseLeave: () => this.setState({hoveredNode: false}),
+      onValueClick: () => this.setState({treemapData: _getRandomData()}),
       height: 300,
       mode: this.state.useCirclePacking ? 'circlePack' : 'squarify',
       width: 350

--- a/src/legends/discrete-color-legend-item.js
+++ b/src/legends/discrete-color-legend-item.js
@@ -44,7 +44,7 @@ function DiscreteColorLegendItem({onClick, title, color, disabled,
     className += ' clickable';
   }
   return (
-    <div {...{className, onClick}}>
+    <div {...{className, onClick}} role="button" tabIndex={onClick ? 0 : null}>
       <span
         className="rv-discrete-color-legend-item__color"
         style={disabled ? null : {background: color}} />

--- a/src/plot/series/abstract-series.js
+++ b/src/plot/series/abstract-series.js
@@ -40,12 +40,6 @@ const propTypes = {
   width: PropTypes.number,
   height: PropTypes.number,
   data: PropTypes.array,
-  onValueMouseOver: PropTypes.func,
-  onValueMouseOut: PropTypes.func,
-  onValueClick: PropTypes.func,
-  onSeriesMouseOver: PropTypes.func,
-  onSeriesMouseOut: PropTypes.func,
-  onSeriesClick: PropTypes.func,
   onNearestX: PropTypes.func,
   onNearestXY: PropTypes.func,
   animation: AnimationPropType
@@ -56,100 +50,6 @@ const defaultProps = {
 };
 
 class AbstractSeries extends PureRenderComponent {
-
-  constructor(props) {
-    super(props);
-    this._seriesMouseOverHandler = this._seriesMouseOverHandler.bind(this);
-    this._valueMouseOverHandler = this._valueMouseOverHandler.bind(this);
-    this._seriesMouseOutHandler = this._seriesMouseOutHandler.bind(this);
-    this._valueMouseOutHandler = this._valueMouseOutHandler.bind(this);
-    this._seriesClickHandler = this._seriesClickHandler.bind(this);
-    this._valueClickHandler = this._valueClickHandler.bind(this);
-  }
-
-  /**
-   * Mouse over handler for the specific series' value.
-   * @param {Object} d Value object
-   * @param {Object} event Event.
-   * @protected
-   */
-  _valueMouseOverHandler(d, event) {
-    const {onValueMouseOver, onSeriesMouseOver} = this.props;
-    if (onValueMouseOver) {
-      onValueMouseOver(d, {event});
-    }
-    if (onSeriesMouseOver) {
-      onSeriesMouseOver({event});
-    }
-  }
-
-  /**
-   * Mouse over handler for the entire series.
-   * @param {Object} event Event.
-   * @protected
-   */
-  _seriesMouseOverHandler(event) {
-    const {onSeriesMouseOver} = this.props;
-    if (onSeriesMouseOver) {
-      onSeriesMouseOver({event});
-    }
-  }
-
-  /**
-   * Mouse out handler for the specific series' value.
-   * @param {Object} d Value object
-   * @param {Object} event Event.
-   * @protected
-   */
-  _valueMouseOutHandler(d, event) {
-    const {onValueMouseOut, onSeriesMouseOut} = this.props;
-    if (onValueMouseOut) {
-      onValueMouseOut(d, {event});
-    }
-    if (onSeriesMouseOut) {
-      onSeriesMouseOut({event});
-    }
-  }
-
-  /**
-   * Mouse out handler for the entire series.
-   * @param {Object} event Event.
-   * @protected
-   */
-  _seriesMouseOutHandler(event) {
-    const {onSeriesMouseOut} = this.props;
-    if (onSeriesMouseOut) {
-      onSeriesMouseOut({event});
-    }
-  }
-
-  /**
-   * Click handler for the specific series' value.
-   * @param {Object} d Value object
-   * @param {Object} event Event.
-   * @protected
-   */
-  _valueClickHandler(d, event) {
-    const {onValueClick, onSeriesClick} = this.props;
-    if (onValueClick) {
-      onValueClick(d, {event});
-    }
-    if (onSeriesClick) {
-      onSeriesClick({event});
-    }
-  }
-
-  /**
-   * Click handler for the entire series.
-   * @param {Object} event Event.
-   * @protected
-   */
-  _seriesClickHandler(event) {
-    const {onSeriesClick} = this.props;
-    if (onSeriesClick) {
-      onSeriesClick({event});
-    }
-  }
 
   /**
    * Tells the rest of the world that it requires SVG to work.

--- a/src/plot/series/arc-series.js
+++ b/src/plot/series/arc-series.js
@@ -34,6 +34,12 @@ import {
   getMissingScaleProps,
   getScalePropTypesByAttribute
 } from 'utils/scales-utils';
+import {
+  seriesEventHandlers,
+  seriesEventPropTypes,
+  valueEventHandlers,
+  valueEventPropTypes
+} from 'utils/interactivity-utils';
 
 const predefinedClassName = 'rv-xy-plot__series rv-xy-plot__series--arc';
 const ATTRIBUTES = ['radius', 'angle'];
@@ -98,6 +104,7 @@ class ArcSeries extends AbstractSeries {
       className,
       center,
       data,
+      focusable,
       marginLeft,
       marginTop,
       style = {}
@@ -136,9 +143,8 @@ class ArcSeries extends AbstractSeries {
 
     return (
       <g className={`${predefinedClassName} ${className}`}
-        onMouseOver={this._seriesMouseOverHandler}
-        onMouseOut={this._seriesMouseOutHandler}
-        onClick={this._seriesClickHandler}
+        tabIndex = {focusable ? 0 : null}
+        {...seriesEventHandlers(this.props)}
         ref="container"
         transform={`translate(${marginLeft + xTranslate},${marginTop + yTranslate})`}>
         {data.map((row, i) => {
@@ -159,9 +165,7 @@ class ArcSeries extends AbstractSeries {
               ...style,
               ...rowStyle
             },
-            onClick: e => this._valueClickHandler(row, e),
-            onMouseOver: e => this._valueMouseOverHandler(row, e),
-            onMouseOut: e => this._valueMouseOutHandler(row, e),
+            ...valueEventHandlers(this.props, row),
             key: i,
             d: arcedData(arcArg)
           }} />);
@@ -174,6 +178,8 @@ ArcSeries.propTypes = {
   ...AbstractSeries.propTypes,
   ...getScalePropTypesByAttribute('radius'),
   ...getScalePropTypesByAttribute('angle'),
+  ...seriesEventPropTypes,
+  ...valueEventPropTypes,
   center: PropTypes.shape({
     x: PropTypes.number,
     y: PropTypes.number

--- a/src/plot/series/area-series.js
+++ b/src/plot/series/area-series.js
@@ -24,8 +24,11 @@ import * as d3Shape from 'd3-shape';
 import Animation from 'animation';
 import {DEFAULT_OPACITY} from 'theme';
 import {ANIMATED_SERIES_PROPS} from 'utils/series-utils';
-
 import AbstractSeries from './abstract-series';
+import {
+  seriesEventHandlers,
+  seriesEventPropTypes
+} from 'utils/interactivity-utils';
 
 const predefinedClassName = 'rv-xy-plot__series rv-xy-plot__series--line';
 
@@ -45,7 +48,7 @@ class AreaSeries extends AbstractSeries {
 
   render() {
     const {
-      animation, className, curve, data, marginLeft, marginTop
+      animation, className, curve, data, focusable, marginLeft, marginTop
     } = this.props;
     if (!data) {
       return null;
@@ -68,14 +71,14 @@ class AreaSeries extends AbstractSeries {
     const newOpacity = this._getAttributeValue('opacity');
     const opacity = Number.isFinite(newOpacity) ? newOpacity : DEFAULT_OPACITY;
     const d = this._renderArea(data, x, y0, y, curve);
+
     return (
       <path
         d={d}
         className={`${predefinedClassName} ${className}`}
         transform={`translate(${marginLeft},${marginTop})`}
-        onMouseOver={this._seriesMouseOverHandler}
-        onMouseOut={this._seriesMouseOutHandler}
-        onClick={this._seriesClickHandler}
+        tabIndex={focusable ? 0 : null}
+        {...seriesEventHandlers(this.props)}
         style={{
           opacity,
           stroke,
@@ -83,9 +86,12 @@ class AreaSeries extends AbstractSeries {
         }}/>
     );
   }
-
 }
 
+AreaSeries.propTypes = {
+  ...AbstractSeries.propTypes,
+  ...seriesEventPropTypes
+};
 AreaSeries.displayName = 'AreaSeries';
 
 export default AreaSeries;

--- a/src/plot/series/bar-series.js
+++ b/src/plot/series/bar-series.js
@@ -26,14 +26,18 @@ import Animation from 'animation';
 import {ANIMATED_SERIES_PROPS} from 'utils/series-utils';
 
 import AbstractSeries from './abstract-series';
+import {
+  valueEventHandlers,
+  valueEventPropTypes
+} from 'utils/interactivity-utils';
 
 const predefinedClassName = 'rv-xy-plot__series rv-xy-plot__series--bar';
 
 class BarSeries extends AbstractSeries {
-
   static get propTypes() {
     return {
-      ... AbstractSeries.propTypes,
+      ...AbstractSeries.propTypes,
+      ...valueEventPropTypes,
       linePosAttr: PropTypes.string,
       valuePosAttr: PropTypes.string,
       lineSizeAttr: PropTypes.string,
@@ -63,6 +67,7 @@ class BarSeries extends AbstractSeries {
       animation,
       className,
       data,
+      focusable,
       linePosAttr,
       lineSizeAttr,
       marginLeft,
@@ -103,6 +108,7 @@ class BarSeries extends AbstractSeries {
         transform={`translate(${marginLeft},${marginTop})`}>
         {data.map((d, i) => {
           const attrs = {
+            key: i,
             style: {
               opacity: opacityFunctor && opacityFunctor(d),
               stroke: strokeFunctor && strokeFunctor(d),
@@ -113,10 +119,8 @@ class BarSeries extends AbstractSeries {
             [lineSizeAttr]: itemSize * 2 / sameTypeTotal,
             [valuePosAttr]: Math.min(value0Functor(d), valueFunctor(d)),
             [valueSizeAttr]: Math.abs(-value0Functor(d) + valueFunctor(d)),
-            onClick: e => this._valueClickHandler(d, e),
-            onMouseOver: e => this._valueMouseOverHandler(d, e),
-            onMouseOut: e => this._valueMouseOutHandler(d, e),
-            key: i
+            tabIndex: focusable ? 0 : null,
+            ...valueEventHandlers(this.props, d)
           };
           return (<rect {...attrs} />);
         })}

--- a/src/plot/series/heatmap-series.js
+++ b/src/plot/series/heatmap-series.js
@@ -24,6 +24,10 @@ import Animation from 'animation';
 import {ANIMATED_SERIES_PROPS} from 'utils/series-utils';
 
 import AbstractSeries from './abstract-series';
+import {
+  valueEventHandlers,
+  valueEventPropTypes
+} from 'utils/interactivity-utils';
 
 const predefinedClassName = 'rv-xy-plot__series rv-xy-plot__series--heatmap';
 
@@ -72,9 +76,7 @@ class HeatmapSeries extends AbstractSeries {
             width: xDistance,
             height: yDistance,
             key: i,
-            onClick: e => this._valueClickHandler(d, e),
-            onMouseOver: e => this._valueMouseOverHandler(d, e),
-            onMouseOut: e => this._valueMouseOutHandler(d, e)
+            ...valueEventHandlers(this.props, d)
           };
           return (<rect {...attrs} />);
         })}
@@ -84,7 +86,8 @@ class HeatmapSeries extends AbstractSeries {
 }
 
 HeatmapSeries.propTypes = {
-  ...AbstractSeries.propTypes
+  ...AbstractSeries.propTypes,
+  ...valueEventPropTypes
 };
 
 HeatmapSeries.displayName = 'HeatmapSeries';

--- a/src/plot/series/line-series.js
+++ b/src/plot/series/line-series.js
@@ -25,6 +25,10 @@ import * as d3Shape from 'd3-shape';
 import Animation from 'animation';
 import {DEFAULT_OPACITY} from 'theme';
 import {ANIMATED_SERIES_PROPS} from 'utils/series-utils';
+import {
+  seriesEventHandlers,
+  seriesEventPropTypes
+} from 'utils/interactivity-utils';
 
 import AbstractSeries from './abstract-series';
 
@@ -43,6 +47,7 @@ const defaultProps = {
 
 const propTypes = {
   ...AbstractSeries.propTypes,
+  ...seriesEventPropTypes,
   strokeStyle: PropTypes.oneOf(Object.keys(STROKE_STYLES)),
   curve: PropTypes.oneOfType([
     PropTypes.string,
@@ -66,7 +71,7 @@ class LineSeries extends AbstractSeries {
   }
 
   render() {
-    const {animation, className, data} = this.props;
+    const {animation, className, data, focusable} = this.props;
     if (!data) {
       return null;
     }
@@ -93,9 +98,8 @@ class LineSeries extends AbstractSeries {
         d={d}
         className={`${predefinedClassName} ${className}`}
         transform={`translate(${marginLeft},${marginTop})`}
-        onMouseOver={this._seriesMouseOverHandler}
-        onMouseOut={this._seriesMouseOutHandler}
-        onClick={this._seriesClickHandler}
+        tabIndex={focusable ? 0 : null}
+        {...seriesEventHandlers(this.props)}
         style={{
           opacity,
           strokeDasharray: STROKE_STYLES[strokeStyle] || strokeDasharray,

--- a/src/plot/series/mark-series.js
+++ b/src/plot/series/mark-series.js
@@ -27,6 +27,10 @@ import {ANIMATED_SERIES_PROPS} from 'utils/series-utils';
 import {DEFAULT_SIZE, DEFAULT_OPACITY} from 'theme';
 
 import AbstractSeries from './abstract-series';
+import {
+  valueEventHandlers,
+  valueEventPropTypes
+} from 'utils/interactivity-utils';
 
 const predefinedClassName = 'rv-xy-plot__series rv-xy-plot__series--mark';
 const DEFAULT_STROKE_WIDTH = 1;
@@ -34,7 +38,7 @@ const DEFAULT_STROKE_WIDTH = 1;
 class MarkSeries extends AbstractSeries {
 
   render() {
-    const {animation, className, data, marginLeft, marginTop, strokeWidth} = this.props;
+    const {animation, className, data, focusable, marginLeft, marginTop, strokeWidth} = this.props;
     if (!data) {
       return null;
     }
@@ -61,19 +65,18 @@ class MarkSeries extends AbstractSeries {
          transform={`translate(${marginLeft},${marginTop})`}>
         {data.map((d, i) => {
           const attrs = {
-            r: sizeFunctor ? sizeFunctor(d) : DEFAULT_SIZE,
             cx: xFunctor(d),
             cy: yFunctor(d),
+            key: i,
+            r: sizeFunctor ? sizeFunctor(d) : DEFAULT_SIZE,
             style: {
               opacity: opacityFunctor ? opacityFunctor(d) : DEFAULT_OPACITY,
               stroke: strokeFunctor && strokeFunctor(d),
               fill: fillFunctor && fillFunctor(d),
               strokeWidth: strokeWidth || DEFAULT_STROKE_WIDTH
             },
-            key: i,
-            onClick: e => this._valueClickHandler(d, e),
-            onMouseOver: e => this._valueMouseOverHandler(d, e),
-            onMouseOut: e => this._valueMouseOutHandler(d, e)
+            tabIndex: focusable ? 0 : null,
+            ...valueEventHandlers(this.props, d)
           };
           return <circle {...attrs} />;
         })}
@@ -85,6 +88,7 @@ class MarkSeries extends AbstractSeries {
 MarkSeries.displayName = 'MarkSeries';
 MarkSeries.propTypes = {
   ...AbstractSeries.propTypes,
+  ...valueEventPropTypes,
   strokeWidth: PropTypes.number
 };
 export default MarkSeries;

--- a/src/plot/series/polygon-series.js
+++ b/src/plot/series/polygon-series.js
@@ -25,6 +25,11 @@ import {ANIMATED_SERIES_PROPS} from 'utils/series-utils';
 
 import AbstractSeries from './abstract-series';
 
+import {
+  seriesEventHandlers,
+  seriesEventPropTypes
+} from 'utils/interactivity-utils';
+
 const predefinedClassName = 'rv-xy-plot__series rv-xy-plot__series--polygon';
 const DEFAULT_COLOR = '#12939A';
 
@@ -35,7 +40,8 @@ class PolygonSeries extends AbstractSeries {
 
   static get propTypes() {
     return {
-      ... AbstractSeries.propTypes
+      ...AbstractSeries.propTypes,
+      ...seriesEventPropTypes
     };
   }
 
@@ -67,14 +73,12 @@ class PolygonSeries extends AbstractSeries {
     return (
       <path {...{
         className: `${predefinedClassName} ${className}`,
-        onMouseOver: this._seriesMouseOverHandler,
-        onMouseOut: this._seriesMouseOutHandler,
-        onClick: this._seriesClickHandler,
-        fill: color || DEFAULT_COLOR,
-        style,
         d: generatePath(data, xFunctor, yFunctor),
-        transform: `translate(${marginLeft},${marginTop})`,
-        ref: 'container'
+        fill: color || DEFAULT_COLOR,
+        ref: 'container',
+        style,
+        ...seriesEventHandlers(this.props),
+        transform: `translate(${marginLeft},${marginTop})`
       }}/>
     );
   }

--- a/src/plot/series/rect-series.js
+++ b/src/plot/series/rect-series.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 - 2017 Uber Technologies, Inc.
+// Copyright (c) 2016 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -27,13 +27,19 @@ import {ANIMATED_SERIES_PROPS} from 'utils/series-utils';
 
 import AbstractSeries from './abstract-series';
 
+import {
+  valueEventHandlers,
+  valueEventPropTypes
+} from 'utils/interactivity-utils';
+
 const predefinedClassName = 'rv-xy-plot__series rv-xy-plot__series--rect';
 
 class RectSeries extends AbstractSeries {
 
   static get propTypes() {
     return {
-      ... AbstractSeries.propTypes,
+      ...AbstractSeries.propTypes,
+      ...valueEventPropTypes,
       linePosAttr: PropTypes.string,
       valuePosAttr: PropTypes.string,
       lineSizeAttr: PropTypes.string,
@@ -46,6 +52,7 @@ class RectSeries extends AbstractSeries {
       animation,
       className,
       data,
+      focusable,
       linePosAttr,
       lineSizeAttr,
       marginLeft,
@@ -91,9 +98,8 @@ class RectSeries extends AbstractSeries {
             [lineSizeAttr]: Math.abs(lineFunctor(d) - line0Functor(d)),
             [valuePosAttr]: Math.min(value0Functor(d), valueFunctor(d)),
             [valueSizeAttr]: Math.abs(-value0Functor(d) + valueFunctor(d)),
-            onClick: e => this._valueClickHandler(d, e),
-            onMouseOver: e => this._valueMouseOverHandler(d, e),
-            onMouseOut: e => this._valueMouseOutHandler(d, e),
+            tabIndex: focusable ? 0 : null,
+            ...valueEventHandlers(this.props),
             key: i
           };
           return (<rect {...attrs} />);

--- a/src/plot/voronoi.js
+++ b/src/plot/voronoi.js
@@ -1,11 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {voronoi} from 'd3-voronoi';
+import {valueEventPropTypes, valueEventHandlers} from 'utils/interactivity-utils';
 
-const NOOP = f => f;
-
-function Voronoi({className, extent, nodes, onBlur, onClick, onHover, polygonStyle, style, x, y}) {
+function Voronoi(props) {
   // Create a voronoi with each node center points
+  const {
+    className,
+    extent,
+    nodes,
+    polygonStyle,
+    style,
+    x,
+    y
+  } = props;
+
   const voronoiInstance = voronoi()
     .x(x)
     .y(y)
@@ -17,15 +26,14 @@ function Voronoi({className, extent, nodes, onBlur, onClick, onHover, polygonSty
         <path
           className="rv-voronoi__cell"
           d={`M${d.join('L')}Z`}
-          onClick={() => onClick(d.data)}
-          onMouseOver={() => onHover(d.data)}
-          onMouseOut={() => onBlur(d.data)}
           fill="none"
+          key={i}
+          {...valueEventHandlers(props, d.data)}
           style={{
             pointerEvents: 'all',
             ...polygonStyle
           }}
-          key={i} />
+        />
       ))}
     </g>
   );
@@ -35,22 +43,17 @@ Voronoi.requiresSVG = true;
 
 Voronoi.defaultProps = {
   className: '',
-  onBlur: NOOP,
-  onClick: NOOP,
-  onHover: NOOP,
   x: d => d.x,
   y: d => d.y
 };
 
 Voronoi.propTypes = {
+  ...valueEventPropTypes,
   className: PropTypes.string,
   extent: PropTypes.arrayOf(
     PropTypes.arrayOf(PropTypes.number)
   ).isRequired,
   nodes: PropTypes.arrayOf(PropTypes.object).isRequired,
-  onBlur: PropTypes.func,
-  onClick: PropTypes.func,
-  onHover: PropTypes.func,
   x: PropTypes.func,
   y: PropTypes.func
 };

--- a/src/plot/xy-plot.js
+++ b/src/plot/xy-plot.js
@@ -26,6 +26,7 @@ import {extractScalePropsFromProps, getMissingScaleProps} from 'utils/scales-uti
 import {getStackedData, getSeriesChildren, getSeriesPropsFromChildren} from 'utils/series-utils';
 import {getInnerDimensions, MarginPropType} from 'utils/chart-utils';
 import {AnimationPropType} from 'animation';
+import {eventPropTypes, eventHandlers} from 'utils/interactivity-utils';
 import {CONTINUOUS_COLOR_RANGE, SIZE_RANGE, OPACITY_TYPE} from 'theme';
 
 const ATTRIBUTES = [
@@ -85,14 +86,11 @@ class XYPlot extends React.Component {
 
   static get propTypes() {
     return {
+      ...eventPropTypes,
       animation: AnimationPropType,
       className: PropTypes.string,
       height: PropTypes.number.isRequired,
       margin: MarginPropType,
-      onMouseDown: PropTypes.func,
-      onMouseEnter: PropTypes.func,
-      onMouseLeave: PropTypes.func,
-      onMouseMove: PropTypes.func,
       stackBy: PropTypes.oneOf(ATTRIBUTES),
       width: PropTypes.number.isRequired
     };
@@ -106,9 +104,6 @@ class XYPlot extends React.Component {
 
   constructor(props) {
     super(props);
-    this._mouseDownHandler = this._mouseDownHandler.bind(this);
-    this._mouseLeaveHandler = this._mouseLeaveHandler.bind(this);
-    this._mouseEnterHandler = this._mouseEnterHandler.bind(this);
     this._mouseMoveHandler = this._mouseMoveHandler.bind(this);
     const {stackBy} = props;
     const children = getSeriesChildren(props.children);
@@ -133,25 +128,6 @@ class XYPlot extends React.Component {
   }
 
   /**
-   * Trigger mouse-down related callbacks if they are available.
-   * @param {React.SyntheticEvent} event Mouse down event.
-   * @private
-   */
-  _mouseDownHandler(event) {
-    const {onMouseDown, children} = this.props;
-    if (onMouseDown) {
-      onMouseDown(event);
-    }
-    const seriesChildren = getSeriesChildren(children);
-    seriesChildren.forEach((child, index) => {
-      const component = this.refs[`series${index}`];
-      if (component && component.onParentMouseDown) {
-        component.onParentMouseDown(event);
-      }
-    });
-  }
-
-  /**
    * Trigger movement-related callbacks if they are available.
    * @param {React.SyntheticEvent} event Mouse move event.
    * @private
@@ -168,30 +144,6 @@ class XYPlot extends React.Component {
         component.onParentMouseMove(event);
       }
     });
-  }
-
-  /**
-   * Trigger onMouseLeave handler if it was passed in props.
-   * @param {Event} event Native event.
-   * @private
-   */
-  _mouseLeaveHandler(event) {
-    const {onMouseLeave} = this.props;
-    if (onMouseLeave) {
-      onMouseLeave({event});
-    }
-  }
-
-  /**
-   * Trigger onMouseEnter handler if it was passed in props.
-   * @param {Event} event Native event.
-   * @private
-   */
-  _mouseEnterHandler(event) {
-    const {onMouseEnter} = this.props;
-    if (onMouseEnter) {
-      onMouseEnter({event});
-    }
   }
 
   /**
@@ -341,10 +293,9 @@ class XYPlot extends React.Component {
           className="rv-xy-plot__inner"
           width={width}
           height={height}
-          onMouseDown={this._mouseDownHandler}
           onMouseMove={this._mouseMoveHandler}
-          onMouseLeave={this._mouseLeaveHandler}
-          onMouseEnter={this._mouseEnterHandler}>
+          {...eventHandlers(this.props)}
+        >
           {components.filter(c => c && c.type.requiresSVG)}
         </svg>
         {components.filter(c => c && !c.type.requiresSVG)}

--- a/src/radial-chart/index.js
+++ b/src/radial-chart/index.js
@@ -30,8 +30,11 @@ import {
   extractScalePropsFromProps,
   getMissingScaleProps
 } from 'utils/scales-utils';
-
-const NOOP = d => d;
+import {
+  valueEventHandlers,
+  valueEventPropTypes,
+  ValueFocusable
+} from 'utils/interactivity-utils';
 
 const ATTRIBUTES = [
   'angle',
@@ -76,13 +79,11 @@ function assignColorsToData(data) {
 class RadialChart extends React.Component {
   static get propTypes() {
     return {
+      ...valueEventPropTypes,
       animation: AnimationPropType,
       className: PropTypes.string,
       height: PropTypes.number.isRequired,
       margin: MarginPropType,
-      onSectionMouseOver: PropTypes.func,
-      onSectionMouseOut: PropTypes.func,
-      onSectionClick: PropTypes.func,
       showLabels: PropTypes.bool,
       width: PropTypes.number.isRequired
     };
@@ -110,19 +111,6 @@ class RadialChart extends React.Component {
       data: nextData,
       arc: this._getArcFromProps(nextScaleProps)
     });
-  }
-
-  /**
-   * Triggers a callback on a section if the callback is set.
-   * @param {function} handler Callback function.
-   * @param {Object} d Data point of the arc.
-   * @param {Object} event Event.
-   * @private
-   */
-  _sectionHandler(handler = NOOP, d, event) {
-    const {arc} = this.state;
-    const [x, y] = arc.centroid(d);
-    handler(d.data, {event, x, y});
   }
 
   /**
@@ -280,21 +268,15 @@ class RadialChart extends React.Component {
    * @private
    */
   _renderOverlay(pieData, arc) {
-    const {
-      onSectionMouseOver,
-      onSectionMouseOut,
-      onSectionClick
-    } = this.props;
-
     return (d, i) => {
+      const [x, y] = arc.centroid(d);
       return (<path {...{
         className: 'rv-radial-chart__series--pie__slice-overlay',
+        key: `${i}-listeners`,
         d: arc(pieData[i]),
         style: {opacity: 0},
-        onMouseEnter: e => this._sectionHandler(onSectionMouseOver, pieData[i], e),
-        onMouseLeave: e => this._sectionHandler(onSectionMouseOut, pieData[i], e),
-        onClick: e => this._sectionHandler(onSectionClick, pieData[i], e),
-        key: `${i}-listeners`
+        tabIndex: this.props.focusable ? 0 : null,
+        ...valueEventHandlers(this.props, {...d, x, y})
       }}/>);
     };
   }
@@ -356,4 +338,4 @@ class RadialChart extends React.Component {
 
 RadialChart.displayName = 'RadialChart';
 
-export default RadialChart;
+export default ValueFocusable(RadialChart);

--- a/src/sankey/index.js
+++ b/src/sankey/index.js
@@ -4,8 +4,12 @@ import {sankey} from 'd3-sankey-align';
 
 import Voronoi from 'plot/voronoi';
 import {DISCRETE_COLOR_RANGE} from 'theme';
-
-const NOOP = f => f;
+import {
+  valueEventHandlers,
+  valueEventPropTypes,
+  valueEventHandlerPassThrough,
+  ValueFocusable
+} from 'utils/interactivity-utils';
 
 const DEFAULT_LINK_COLOR = DISCRETE_COLOR_RANGE[1];
 const DEFAULT_LINK_OPACITY = 0.7;
@@ -21,13 +25,11 @@ class Sankey extends Component {
     layout: 50,
     margin: 20,
     nodePadding: 10,
-    nodeWidth: 10,
-    onBlur: NOOP,
-    onClick: NOOP,
-    onHover: NOOP
+    nodeWidth: 10
   }
 
   static propTypes = {
+    ...valueEventPropTypes,
     align: PropTypes.oneOf(['justify', 'left', 'right', 'center']),
     className: PropTypes.string,
     hasVoronoi: PropTypes.bool,
@@ -47,9 +49,6 @@ class Sankey extends Component {
     nodePadding: PropTypes.number,
     nodes: PropTypes.arrayOf(PropTypes.object).isRequired,
     nodeWidth: PropTypes.number,
-    onBlur: PropTypes.func,
-    onClick: PropTypes.func,
-    onHover: PropTypes.func,
     width: PropTypes.number.isRequired
   }
 
@@ -58,6 +57,7 @@ class Sankey extends Component {
     const {
       align,
       className,
+      focusable,
       hasVoronoi,
       height,
       layout,
@@ -66,9 +66,6 @@ class Sankey extends Component {
       nodePadding,
       nodes,
       nodeWidth,
-      onBlur,
-      onClick,
-      onHover,
       width
     } = this.props;
 
@@ -106,12 +103,12 @@ class Sankey extends Component {
               opacity={Number.isFinite(node.opacity) ? node.opacity : DEFAULT_NODE_OPACITY}
               key={node.id || node.key || `node-${i}`}>
               <rect
-                onClick={() => onClick(node)}
-                onMouseOver={() => onHover(node)}
-                onMouseOut={() => onBlur(node)}
+                tabIndex={focusable ? 0 : null}
                 fill={node.color || DEFAULT_NODE_COLOR}
                 height={node.dy}
-                width={nWidth} />
+                width={nWidth}
+                {...valueEventHandlers(this.props, node)}
+              />
             </g>
           ))}
 
@@ -120,9 +117,7 @@ class Sankey extends Component {
               className="rv-sankey__voronoi"
               extent={[[-margin, -margin], [width + margin, height + margin]]}
               nodes={nodes}
-              onBlur={onBlur}
-              onClick={onClick}
-              onHover={onHover}
+              {...valueEventHandlerPassThrough(this.props)}
               x={d => d.x + d.dx / 2}
               y={d => d.y + d.dy / 2}
             />
@@ -135,4 +130,4 @@ class Sankey extends Component {
 
 }
 
-export default Sankey;
+export default ValueFocusable(Sankey);

--- a/src/styles/examples.scss
+++ b/src/styles/examples.scss
@@ -111,7 +111,6 @@ article {
   cursor: pointer;
   font-family: Sintony, Helvetica, sans-serif;
   font-size: 14px;
-  outline: none;
   padding: 11px 20px;
   text-transform: uppercase;
 

--- a/src/treemap/index.js
+++ b/src/treemap/index.js
@@ -36,6 +36,7 @@ import {
 import {CONTINUOUS_COLOR_RANGE, DEFAULT_COLOR, DEFAULT_OPACITY, OPACITY_TYPE} from 'theme';
 import {AnimationPropType} from 'animation';
 import {getAttributeFunctor, getMissingScaleProps} from 'utils/scales-utils';
+import {valueEventPropTypes} from 'utils/interactivity-utils';
 
 import TreemapLeaf from './treemap-leaf';
 
@@ -53,8 +54,6 @@ const TREEMAP_LAYOUT_MODES = [
   'partition',
   'partition-pivot'
 ];
-
-const NOOP = d => d;
 
 const ATTRIBUTES = ['opacity', 'color'];
 
@@ -85,6 +84,7 @@ class Treemap extends React.Component {
 
   static get propTypes() {
     return {
+      ...valueEventPropTypes,
       animation: AnimationPropType,
       className: PropTypes.string,
       data: PropTypes.object.isRequired,
@@ -92,9 +92,6 @@ class Treemap extends React.Component {
       mode: PropTypes.oneOf(
         Object.keys(TREEMAP_TILE_MODES).concat(TREEMAP_LAYOUT_MODES)
       ),
-      onLeafClick: PropTypes.func,
-      onLeafMouseOver: PropTypes.func,
-      onLeafMouseOut: PropTypes.func,
       useCirclePacking: PropTypes.bool,
       padding: PropTypes.number.isRequired,
       width: PropTypes.number.isRequired
@@ -110,9 +107,6 @@ class Treemap extends React.Component {
         children: []
       },
       mode: 'squarify',
-      onLeafClick: NOOP,
-      onLeafMouseOver: NOOP,
-      onLeafMouseOut: NOOP,
       opacityType: OPACITY_TYPE,
       _opacityValue: DEFAULT_OPACITY,
       padding: 1

--- a/src/treemap/treemap-leaf.js
+++ b/src/treemap/treemap-leaf.js
@@ -24,6 +24,11 @@ import PropTypes from 'prop-types';
 
 import Animation, {AnimationPropType} from 'animation';
 import {getFontColorFromBackground} from 'utils/scales-utils';
+import {
+  valueEventHandlers,
+  valueEventPropTypes,
+  ValueFocusable
+} from 'utils/interactivity-utils';
 
 const ANIMATED_PROPS = [
   'colorRange', 'colorDomain', 'color',
@@ -35,13 +40,11 @@ class TreemapLeaf extends React.Component {
 
   static get propTypes() {
     return {
+      ...valueEventPropTypes,
       animation: AnimationPropType,
       height: PropTypes.number.isRequired,
       mode: PropTypes.string,
       node: PropTypes.object.isRequired,
-      onLeafClick: PropTypes.func,
-      onLeafMouseOver: PropTypes.func,
-      onLeafMouseOut: PropTypes.func,
       scales: PropTypes.object.isRequired,
       width: PropTypes.number.isRequired,
       r: PropTypes.number.isRequired,
@@ -55,11 +58,9 @@ class TreemapLeaf extends React.Component {
   render() {
     const {
       animation,
+      focusable,
       mode,
       node,
-      onLeafClick,
-      onLeafMouseOver,
-      onLeafMouseOut,
       r,
       scales,
       x0,
@@ -80,12 +81,13 @@ class TreemapLeaf extends React.Component {
     const opacity = scales.opacity(node);
     const color = getFontColorFromBackground(background);
     const {data: {title}} = node;
+
     return (
       <div
         className={`rv-treemap__leaf ${useCirclePacking ? 'rv-treemap__leaf--circle' : ''}`}
-        onMouseEnter={event => onLeafMouseOver(node, event)}
-        onMouseLeave={event => onLeafMouseOut(node, event)}
-        onClick={event => onLeafClick(node, event)}
+        tabIndex={focusable ? 0 : null}
+        role={focusable ? 'button' : null}
+        {...valueEventHandlers(this.props, node)}
         style={{
           top: useCirclePacking ? (y0 - r) : y0,
           left: useCirclePacking ? (x0 - r) : x0,
@@ -101,4 +103,4 @@ class TreemapLeaf extends React.Component {
   }
 }
 
-export default TreemapLeaf;
+export default ValueFocusable(TreemapLeaf);

--- a/src/utils/interactivity-utils.js
+++ b/src/utils/interactivity-utils.js
@@ -1,0 +1,148 @@
+// Copyright (c) 2016 - 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+
+const focusEvents = (eventType = '') => ([
+  `${eventType}Blur`,
+  `${eventType}Focus`
+]);
+
+const keyEvents = (eventType = '') => ([
+  `${eventType}KeyDown`,
+  `${eventType}KeyPress`,
+  `${eventType}KeyUp`
+]);
+
+const nonMouseEvents = (eventType = '') => ([
+  ...focusEvents(eventType),
+  ...keyEvents(eventType)
+]);
+
+const mouseEvents = (eventType = '') => ([
+  `${eventType}Click`,
+  `${eventType}MouseEnter`,
+  `${eventType}MouseLeave`,
+  `${eventType}MouseOut`,
+  `${eventType}MouseOver`
+]);
+
+const interactiveEvents = (eventType = '') => ([
+  ...focusEvents(eventType),
+  ...keyEvents(eventType),
+  ...mouseEvents(eventType)
+]);
+
+const prependOn = s => `on${s}`;
+
+const propTypeReduction = (accumulator, current) => {
+  accumulator[current] = PropTypes.func;
+  return accumulator;
+};
+
+export const events = interactiveEvents();
+export const eventProps = events.map(prependOn);
+export const eventPropTypes = eventProps.reduce(propTypeReduction, {});
+
+export const seriesEvents = interactiveEvents('Series');
+export const seriesEventProps = seriesEvents.map(prependOn);
+export const seriesEventPropTypes = seriesEventProps.reduce(propTypeReduction, {});
+
+export const valueEvents = interactiveEvents('Value');
+export const valueEventProps = valueEvents.map(prependOn);
+export const valueEventPropTypes = valueEventProps.reduce(propTypeReduction, {});
+
+export const focusableHOC = (eventPropNames = nonMouseEvents().map(prependOn)) =>
+  WrappedComponent =>
+    class FocusableWrapper extends Component {
+      render() {
+        const focusable = eventPropNames.some(propName => this.props[propName]);
+        return <WrappedComponent {...this.props} {...{focusable}} />;
+      }
+    };
+
+export const Focusable = focusableHOC();
+export const SeriesFocusable = focusableHOC(nonMouseEvents('Series').map(prependOn));
+export const ValueFocusable = focusableHOC(nonMouseEvents('Value').map(prependOn));
+
+const passThroughReduction = props =>
+  (accumulator, current) => {
+    accumulator[current] = props[current];
+    return accumulator;
+  };
+
+const handlerReduction = (eventType = '', props, d) =>
+  (accumulator, current) => {
+    const eventName = current.replace(eventType, '');
+    accumulator[eventName] = event => props[current](d, event);
+    return accumulator;
+  };
+
+export const eventHandlerPassthrough = props =>
+  eventProps
+  .filter(e => props[e])
+  .reduce(passThroughReduction(props), {});
+
+export const eventHandlers = props =>
+  eventProps
+  .filter(e => props[e])
+  .reduce(handlerReduction('', props), {});
+
+export const seriesEventHandlerPassThrough = props =>
+  seriesEventProps
+  .filter(e => props[e])
+  .reduce(passThroughReduction(props), {});
+
+export const seriesEventHandlers = props =>
+  seriesEventProps
+  .filter(e => props[e])
+  .reduce(handlerReduction('Series', props), {});
+
+export const valueEventHandlerPassThrough = props =>
+  valueEventProps
+  .filter(e => props[e])
+  .reduce(passThroughReduction(props), {});
+
+export const valueEventHandlers = (props, d) =>
+  valueEventProps
+  .filter(e => props[e])
+  .reduce(handlerReduction('Value', props, d), {});
+
+export default {
+  eventHandlerPassthrough,
+  eventHandlers,
+  eventProps,
+  eventPropTypes,
+  events,
+  Focusable,
+  seriesEventHandlerPassThrough,
+  seriesEventHandlers,
+  seriesEventProps,
+  seriesEventPropTypes,
+  seriesEvents,
+  SeriesFocusable,
+  valueEventHandlerPassThrough,
+  valueEventHandlers,
+  valueEventProps,
+  valueEventPropTypes,
+  valueEvents,
+  ValueFocusable
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -110,6 +110,12 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+aria-query@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-0.3.0.tgz#cb8a9984e2862711c83c80ade5b8f5ca0de2b467"
+  dependencies:
+    ast-types-flow "0.0.7"
+
 arr-diff@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-2.0.0.tgz#8f3b827f955a8bd669697e4a4256ac3ceae356cf"
@@ -172,6 +178,10 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
 assert-plus@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.2.0.tgz#d74e1b87e7affc0db8aadb7021f3fe48101ab234"
+
+ast-types-flow@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
 
 async-each@^1.0.0:
   version "1.0.1"
@@ -1381,6 +1391,10 @@ d@~0.1.1:
   dependencies:
     es5-ext "~0.10.2"
 
+damerau-levenshtein@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz#03191c432cb6eea168bb77f3a55ffdccb8978514"
+
 dashdash@^1.12.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
@@ -1538,6 +1552,10 @@ electron-to-chromium@^1.2.5:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.2.7.tgz#4f748061407e478c76256d04496972b71f647407"
 
+emoji-regex@^6.1.0:
+  version "6.4.2"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.4.2.tgz#a30b6fee353d406d96cfb9fa765bdc82897eff6e"
+
 encoding@^0.1.11:
   version "0.1.12"
   resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
@@ -1681,6 +1699,17 @@ eslint-config-uber-jsx@^3.0.1:
 eslint-plugin-babel@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-babel/-/eslint-plugin-babel-4.1.1.tgz#ef285c87039b67beb3bbd227f5b0eed4fb376b87"
+
+eslint-plugin-jsx-a11y@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-4.0.0.tgz#779bb0fe7b08da564a422624911de10061e048ee"
+  dependencies:
+    aria-query "^0.3.0"
+    ast-types-flow "0.0.7"
+    damerau-levenshtein "^1.0.0"
+    emoji-regex "^6.1.0"
+    jsx-ast-utils "^1.0.0"
+    object-assign "^4.0.1"
 
 eslint-plugin-react@^6.7.1, eslint-plugin-react@^6.9.0:
   version "6.10.0"
@@ -2619,7 +2648,7 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.3.6"
 
-jsx-ast-utils@^1.3.4:
+jsx-ast-utils@^1.0.0, jsx-ast-utils@^1.3.4:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-1.4.0.tgz#5afe38868f56bc8cc7aeaef0100ba8c75bd12591"
   dependencies:


### PR DESCRIPTION
## Introduction

This is pretty broad so will take a bit of working through, opening to track work in progress and start a conversation about getting these changes shipped.

As discussed in #285 I looked at using `react-a11y` - however had a bunch of issues implementing it and the mutation of the `React` object doesn't seem to play nice at this point. Also, it doesn't seem to be actively maintained, therefore giving that a miss for now.

In general, I'm trying to get the library in a state where it would pass [WCAG 2.0 'A' guidelines](https://www.w3.org/WAI/intro/wcag), although making this opt in such that the library is still handy for use cases that aren't accessibility hardened - it'll be up to the user to implement event handling and keyboard navigation accessibly, although examples and backing code will guide them along heir way 😄 

## Scope

* Adds `eslint-plugin-jsx-a11y` and fixes linting errors in src and examples
* Adds keyboard handlers, and `tabindex` attributes to all components that support
* Standardizes handler names (this probably makes these changes semver major)
* Adds guidance on how to implement `react-vis` accessibly

## Todo

* [x] Conditionally add event handlers only if defined
* [ ] Add applicable ARIA props
* [x] Add handlers to legends
* [ ] Add sensible default focus styling (potentially can just use browser native styling)
* [ ] Clean up property ordering
* [ ] Add tests
* [ ] Documentation for all new handlers
* [ ] Examples and best practices for implementing `react-vis` in an accessible manner

## Potential further work

* Colorblind friendly mode (textures, color palette changing)
* Captioning for visualizations

Fixes #285