### PR TITLE
Sunburst animation

### DIFF
--- a/docs/markdown/sunburst.md
+++ b/docs/markdown/sunburst.md
@@ -103,6 +103,8 @@ Simple boolean on whether or not to show the root node of the tree.
 Type: `boolean|Object`
 Please refer to [Animation](animation.md) doc for more information.
 
+<!-- INJECT:"AnimatedSunburst" -->
+
 #### onValueClick (optional)
 Type: `function`
 - Should accept arguments (arc node, domEvent)

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "docs": "(cd showcase && npm run build && cp bundle.* .. && cd .. && git checkout gh-pages && git commit -am 'Upgrade docs' && git push && git checkout master)",
     "new-docs": "./deploy-docs.sh",
     "start": "(cd showcase && command -v yarn >/dev/null && yarn && npm start || npm install && npm start)",
+    "start-docs": "(cd docs && command -v yarn >/dev/null && yarn && npm start || npm install && npm start)",
     "clean": "rm -rf dist bundle.* index.html && mkdir dist",
     "build": "npm run clean && babel src -d dist --copy-files && node-sass src/main.scss dist/style.css --output-style compressed",
     "lint": "eslint src tests showcase docs --ignore-pattern node_modules --ignore-pattern bundle.js",

--- a/showcase/index.js
+++ b/showcase/index.js
@@ -57,6 +57,7 @@ import TreemapExample from './treemap/dynamic-treemap';
 
 import BasicSunburst from './sunbursts/basic-sunburst';
 import ClockExample from './sunbursts/clock-example';
+import AnimatedSunburst from './sunbursts/animated-sunburst';
 
 import SimpleRadialChart from './radial-chart/simple-radial-chart';
 import DonutChartExample from './radial-chart/donut-chart';
@@ -112,6 +113,7 @@ export const showCase = {
 
   BasicSunburst,
   ClockExample,
+  AnimatedSunburst,
 
   SimpleRadialChart,
   DonutChartExample,

--- a/showcase/showcase-app.js
+++ b/showcase/showcase-app.js
@@ -41,6 +41,7 @@ const {
 
   BasicSunburst,
   ClockExample,
+  AnimatedSunburst,
 
   SimpleRadialChart,
   DonutChartExample,
@@ -273,6 +274,10 @@ class App extends Component {
           <section>
             <h3>Clock</h3>
             <ClockExample />
+          </section>
+          <section>
+            <h3>Animated Sunburst</h3>
+            <AnimatedSunburst />
           </section>
         </article>
         <article id="legends">

--- a/showcase/sunbursts/animated-sunburst.js
+++ b/showcase/sunbursts/animated-sunburst.js
@@ -46,6 +46,8 @@ function updateData() {
   };
 }
 
+const DIVERGING_COLOR_SCALE = ['#00939C', '#85C4C8', '#EC9370', '#C22E00'];
+
 export default class AnimatedSunburst extends React.Component {
   state = {
     data: updateData()
@@ -57,9 +59,13 @@ export default class AnimatedSunburst extends React.Component {
       <div className="animated-sunburst-example-wrapper">
         <button onClick={() => this.setState({data: updateData()})}> UPDATE DATA </button>
         <Sunburst
-          animation
+          animation={{
+            damping: 20,
+            stiffness: 300
+          }}
           data={data}
           colorType={'category'}
+          colorRange={DIVERGING_COLOR_SCALE}
           style={{stroke: '#fff'}}
           height={300}
           width={350}/>

--- a/showcase/sunbursts/animated-sunburst.js
+++ b/showcase/sunbursts/animated-sunburst.js
@@ -1,0 +1,70 @@
+// Copyright (c) 2016 - 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import React from 'react';
+
+import Sunburst from 'sunburst';
+
+function randomLeaf() {
+  return {
+    size: Math.random() * 1000,
+    color: Math.random()
+  };
+}
+
+function updateData() {
+  const totalLeaves = Math.random() * 20;
+  const leaves = [];
+  for (let i = 0; i < totalLeaves; i++) {
+    const leaf = randomLeaf();
+    if (Math.random() > 0.8) {
+      leaf.children = [...new Array(3)].map(() => randomLeaf());
+    }
+    leaves.push(leaf);
+  }
+  return {
+    title: '',
+    color: 1,
+    children: leaves
+  };
+}
+
+export default class AnimatedSunburst extends React.Component {
+  state = {
+    data: updateData()
+  }
+
+  render() {
+    const {data} = this.state;
+    return (
+      <div className="animated-sunburst-example-wrapper">
+        <button onClick={() => this.setState({data: updateData()})}> UPDATE DATA </button>
+        <Sunburst
+          animation
+          data={data}
+          colorType={'category'}
+          style={{stroke: '#fff'}}
+          height={300}
+          width={350}/>
+      </div>
+    );
+  }
+
+}

--- a/showcase/sunbursts/animated-sunburst.js
+++ b/showcase/sunbursts/animated-sunburst.js
@@ -55,6 +55,7 @@ export default class AnimatedSunburst extends React.Component {
 
   render() {
     const {data} = this.state;
+
     return (
       <div className="animated-sunburst-example-wrapper">
         <button onClick={() => this.setState({data: updateData()})}> UPDATE DATA </button>

--- a/showcase/sunbursts/animated-sunburst.js
+++ b/showcase/sunbursts/animated-sunburst.js
@@ -59,10 +59,7 @@ export default class AnimatedSunburst extends React.Component {
       <div className="animated-sunburst-example-wrapper">
         <button onClick={() => this.setState({data: updateData()})}> UPDATE DATA </button>
         <Sunburst
-          animation={{
-            damping: 20,
-            stiffness: 300
-          }}
+          animation={{damping: 20, stiffness: 300}}
           data={data}
           colorType={'category'}
           colorRange={DIVERGING_COLOR_SCALE}

--- a/showcase/sunbursts/basic-sunburst.js
+++ b/showcase/sunbursts/basic-sunburst.js
@@ -76,7 +76,6 @@ export default class BasicSunburst extends React.Component {
     return (
       <div className="basic-sunburst-example-wrapper">
         <Sunburst
-          animation
           className="basic-sunburst-example"
           hideRootNode
           onValueMouseOver={node => {

--- a/src/animation.js
+++ b/src/animation.js
@@ -92,11 +92,24 @@ class Animation extends PureRenderComponent {
     const child = React.Children.only(children);
     const interpolatedProps = interpolator ? interpolator(i) : interpolator;
 
+    // interpolator doesnt play nice with deeply nested objected
+    // so we expose an additional prop for situations like these, soit _data,
+    // which stores the full tree and can be recombined with the sanitized version
+    // after interpolation
+    let data = interpolatedProps && interpolatedProps.data || null;
+    if (data && child.props._data) {
+      data = data.map((row, index) => {
+        const correspondingCell = child.props._data[index];
+        return {...row, parent: correspondingCell.parent, children: correspondingCell.children};
+      });
+    }
+
     return React.cloneElement(
       child,
       {
         ...child.props,
         ...interpolatedProps,
+        data: data || child.props.data || null,
         // enforce re-rendering
         _animation: Math.random()
       }

--- a/src/plot/series/arc-series.js
+++ b/src/plot/series/arc-series.js
@@ -92,7 +92,6 @@ class ArcSeries extends AbstractSeries {
 
   render() {
     const {
-      animatedProps,
       animation,
       className,
       center,
@@ -108,7 +107,7 @@ class ArcSeries extends AbstractSeries {
 
     if (animation) {
       return (
-        <Animation {...this.props} animatedProps={animatedProps || ANIMATED_SERIES_PROPS}>
+        <Animation {...this.props} animatedProps={ANIMATED_SERIES_PROPS}>
           <ArcSeries {...this.props} animation={null}/>
         </Animation>
       );

--- a/src/plot/series/arc-series.js
+++ b/src/plot/series/arc-series.js
@@ -92,6 +92,7 @@ class ArcSeries extends AbstractSeries {
 
   render() {
     const {
+      animatedProps,
       animation,
       className,
       center,
@@ -107,7 +108,7 @@ class ArcSeries extends AbstractSeries {
 
     if (animation) {
       return (
-        <Animation {...this.props} animatedProps={ANIMATED_SERIES_PROPS}>
+        <Animation {...this.props} animatedProps={animatedProps || ANIMATED_SERIES_PROPS}>
           <ArcSeries {...this.props} animation={null}/>
         </Animation>
       );

--- a/src/sunburst/index.js
+++ b/src/sunburst/index.js
@@ -31,10 +31,7 @@ import {
 
 import {AnimationPropType} from 'animation';
 import ArcSeries from 'plot/series/arc-series';
-import {ANIMATED_SERIES_PROPS} from 'utils/series-utils';
 import XYPlot from 'plot/xy-plot';
-
-const ALLOW_ANIMATED_PROPS = ANIMATED_SERIES_PROPS.filter(prop => prop !== 'data');
 
 /**
  * Find the max radius value from the nodes to be rendered after they have been
@@ -102,17 +99,17 @@ class Sunburst extends React.Component {
         xDomain={[-radialDomain, radialDomain]}
         yDomain={[-radialDomain, radialDomain]}>
         <ArcSeries {...{
-          animatedProps: ALLOW_ANIMATED_PROPS,
           colorType,
           ...this.props,
           animation,
           radiusDomain: [0, radialDomain],
-          data: mappedData
+          // need to present a stripped down version for interpolation
+          data: animation ? mappedData.map(row => ({...row, parent: null, children: null})) : mappedData,
+          _data: animation ? mappedData : null
         }}/>
       </XYPlot>
     );
   }
-
 }
 
 Sunburst.displayName = 'Sunburst';

--- a/src/sunburst/index.js
+++ b/src/sunburst/index.js
@@ -31,7 +31,10 @@ import {
 
 import {AnimationPropType} from 'animation';
 import ArcSeries from 'plot/series/arc-series';
+import {ANIMATED_SERIES_PROPS} from 'utils/series-utils';
 import XYPlot from 'plot/xy-plot';
+
+const ALLOW_ANIMATED_PROPS = ANIMATED_SERIES_PROPS.filter(prop => prop !== 'data');
 
 /**
  * Find the max radius value from the nodes to be rendered after they have been
@@ -81,6 +84,7 @@ function getNodesToRender({data, height, hideRootNode, width}) {
 class Sunburst extends React.Component {
   render() {
     const {
+      animation,
       className,
       data,
       height,
@@ -98,9 +102,10 @@ class Sunburst extends React.Component {
         xDomain={[-radialDomain, radialDomain]}
         yDomain={[-radialDomain, radialDomain]}>
         <ArcSeries {...{
+          animatedProps: ALLOW_ANIMATED_PROPS,
           colorType,
           ...this.props,
-          animation: false,
+          animation,
           radiusDomain: [0, radialDomain],
           data: mappedData
         }}/>


### PR DESCRIPTION
Sunburst was previously unable to be animated due to problems with d3-interpolate's handling of deeply nested tree structures. This PR addresses this by adding a method for briefly stripping data of it's tree structure when it's about to be interpolated and then recombining with the original post animation pre-render.

![animated-sunburst](https://cloud.githubusercontent.com/assets/6854312/24832012/6e1f29e8-1c5b-11e7-9eee-ec8e02147c0b.gif)
