### PR TITLE
Break apart showcase for dev legibility

### DIFF
--- a/examples/streamgraph/streamgraph-example.js
+++ b/examples/streamgraph/streamgraph-example.js
@@ -69,7 +69,9 @@ class Example extends React.Component {
     const {data, hoveredIndex} = this.state;
     return (
       <div className="streamgraph-example">
-        {!forFrontPage && (<button onClick={() => this.setState({data: generateData()})}>
+        {!forFrontPage && (<button
+          className="showcase-button"
+          onClick={() => this.setState({data: generateData()})}>
           {'Click me!'}
           </button>)}
         <div className="streamgraph">

--- a/showcase/plot/animation-example.js
+++ b/showcase/plot/animation-example.js
@@ -20,6 +20,7 @@
 
 import React from 'react';
 
+import ShowcaseButton from '../showcase-components/showcase-button';
 import {
   XYPlot,
   XAxis,
@@ -57,19 +58,11 @@ export default class Example extends React.Component {
   render() {
     const {modeIndex, data} = this.state;
     return (
-      <div className="simple-treemap-example">
-        <div className="simple-treemap-example-controls">
-          <div
-            className="simple-treemap-example-button"
-            onClick={this.updateModeIndex(false)}>
-            {'PREV'}
-          </div>
+      <div className="centered-and-flexed">
+        <div className="centered-and-flexed-controls">
+          <ShowcaseButton onClick={this.updateModeIndex(false)} buttonContent={'PREV'} />
           <div> {`ANIMATION TECHNIQUE: ${MODE[modeIndex]}`} </div>
-          <div
-            className="simple-treemap-example-button"
-            onClick={this.updateModeIndex(true)}>
-            {'NEXT'}
-          </div>
+          <ShowcaseButton onClick={this.updateModeIndex(true)} buttonContent={'NEXT'} />
         </div>
         <XYPlot
           width={300}
@@ -82,7 +75,7 @@ export default class Example extends React.Component {
             animation={MODE[modeIndex]}
             data={data}/>
         </XYPlot>
-        <button onClick={() => this.setState({data: generateData()})}> UPDATE DATA </button>
+        <ShowcaseButton onClick={() => this.setState({data: generateData()})} buttonContent={'UPDATE DATA'} />
       </div>
     );
   }

--- a/showcase/radial-chart/arc-series-example.js
+++ b/showcase/radial-chart/arc-series-example.js
@@ -20,6 +20,7 @@
 
 import React from 'react';
 
+import ShowcaseButton from '../showcase-components/showcase-button';
 import {
   XYPlot,
   ArcSeries,
@@ -62,10 +63,12 @@ export default class Example extends React.Component {
   render() {
     return (
       <div>
-        <button onClick={() => this.setState({
-          data: updateData(),
-          littleData: updateLittleData()
-        })}> UPDATE </button>
+        <ShowcaseButton
+          onClick={() => this.setState({
+            data: updateData(),
+            littleData: updateLittleData()
+          })}
+          buttonContent={'UPDATE'} />
         <XYPlot
           xDomain={[-5, 5]}
           yDomain={[-5, 5]}

--- a/showcase/showcase-app.js
+++ b/showcase/showcase-app.js
@@ -1,64 +1,14 @@
 import React, {Component} from 'react';
+import AxesShowcase from './showcase-sections/axes-showcase';
+import PlotsShowcase from './showcase-sections/plots-showcase';
+import SunburstSection from './showcase-sections/sunburst-showcase';
+import RadialShowcase from './showcase-sections/radial-showcase';
+import LegendsShowcase from './showcase-sections/legends-showcase';
+import SankeysShowcase from './showcase-sections/sankeys-showcase';
+import TreemapShowcase from './showcase-sections/treemap-showcase';
+import MiscShowcase from './showcase-sections/misc-showcase';
 
 import PropTypes from 'prop-types';
-
-import {showCase} from './index';
-const {
-  ComplexChart,
-  LineChart,
-  LineMarkChart,
-  BarChart,
-  StackedVerticalBarChart,
-  StackedHorizontalBarChart,
-  ClusteredStackedVerticalBarChart,
-  StackedHistogram,
-  AnimationExample,
-  AreaChart,
-  AreaChartElevated,
-  FauxScatterplotChart,
-  ScatterplotChart,
-  HeatmapChart,
-  WidthHeightMarginChart,
-  CustomScales,
-  CustomAxesOrientation,
-  CustomAxisChart,
-  AxisWithTurnedLabels,
-  GridLinesChart,
-  StaticHints,
-  DynamicHints,
-  DynamicComplexEdgeHints,
-  DynamicSimpleEdgeHints,
-  DynamicSimpleTopEdgeHints,
-  DynamicProgrammaticRightEdgeHints,
-  StaticCrosshair,
-  DynamicCrosshair,
-  DynamicCrosshairScatterplot,
-  SyncedCharts,
-  TimeChart,
-  TriangleExample,
-  VoronoiLineChart,
-
-  SimpleTreemap,
-  TreemapExample,
-
-  BasicSunburst,
-  ClockExample,
-  AnimatedSunburst,
-
-  SimpleRadialChart,
-  DonutChartExample,
-  CustomRadiusRadialChart,
-  ArcSeriesExample,
-
-  BasicSankeyExample,
-  VoronoiSankeyExample,
-
-  VerticalDiscreteColorLegendExample,
-  HorizontalDiscreteColorLegendExample,
-  SearchableDiscreteColorLegendExample,
-  ContinuousColorLegendExample,
-  ContinuousSizeLegendExample
-} = showCase;
 
 class App extends Component {
   render() {
@@ -71,255 +21,23 @@ class App extends Component {
             <a className="header-logo" href="#">react-vis</a>
             <nav>
               <li><a href="#plots">Plots</a></li>
+              <li><a href="#axes">Axes</a></li>
               <li><a href="#radial-charts">Radial Charts</a></li>
               <li><a href="#treemaps">Treemaps</a></li>
               <li><a href="#legends">Legends</a></li>
+              <li><a href="#sunbursts">Sunbursts</a></li>
               <li><a href="#sankeys">Sankeys</a></li>
             </nav>
           </div>
         </header>)}
-        <article id="plots">
-          <h1>Plots</h1>
-          {!forExample && (<section>
-            <ComplexChart />
-          </section>)}
-          <h2>Series Types</h2>
-          <section>
-            <h3>Line Series</h3>
-            <LineChart />
-          </section>
-          <section>
-            <h3>LineMark Series</h3>
-            <LineMarkChart />
-          </section>
-          <section>
-            <h3>Mark Series</h3>
-            <ScatterplotChart />
-          </section>
-          <section>
-            <h3>Area Series</h3>
-            <AreaChart />
-          </section>
-          <section>
-            <h3>Area Series With vertical offset</h3>
-            <AreaChartElevated />
-          </section>
-          <section>
-            <h3>Bar Series</h3>
-            <BarChart />
-          </section>
-          <section>
-            <h3>Stacked Horizontal Bar Series</h3>
-            <StackedHorizontalBarChart />
-          </section>
-          <section>
-            <h3>Stacked Vertical Bar Series</h3>
-            <StackedVerticalBarChart />
-          </section>
-          <section>
-            <h3>Clustered Stacked Vertical Bar Series</h3>
-            <ClusteredStackedVerticalBarChart />
-          </section>
-          <section>
-            <h3>Stacked Vertical Rect Series (histogram)</h3>
-            <StackedHistogram />
-          </section>
-          <section>
-            <h3>Heatmap Series</h3>
-            <HeatmapChart />
-          </section>
-          <h2>Basic Components</h2>
-          <section>
-            <h3>Custom Size and Margin</h3>
-            <WidthHeightMarginChart />
-          </section>
-          <section>
-            <h3>Custom scales</h3>
-            <CustomScales />
-          </section>
-          <section>
-            <h3>Custom GridLines</h3>
-            <GridLinesChart />
-          </section>
-          <section>
-            <h3>Circular Gridlines</h3>
-            <FauxScatterplotChart />
-          </section>
-          <h2>Axes</h2>
-          <section>
-            <h3>Custom Axes Orientation</h3>
-            <CustomAxesOrientation />
-          </section>
-          <section>
-            <h3>Custom Axis</h3>
-            <CustomAxisChart />
-          </section>
-          <section>
-            <h3>Turned axis labels</h3>
-            <AxisWithTurnedLabels />
-          </section>
-          <h2>Tooltips</h2>
-          <section>
-            <h3>Static Hints</h3>
-            <StaticHints />
-          </section>
-          <section>
-            <h3>Dynamic Hints</h3>
-            <p>Move mouse over the point to see the hint.</p>
-            <DynamicHints />
-          </section>
-          <section>
-            <h3>Dynamic Simple Edge Hints</h3>
-            <p>Mouse over point. Hint appears on different edges.<br/>
-            Left margin enables first point to show w/o break.</p>
-            <DynamicSimpleEdgeHints />
-          </section>
-          <section>
-            <h3>Dynamic Simple Top Edge Hints</h3>
-            <p>Mouse over point.<br/>
-            horizontalAlign=ALIGN.AUTO,<br/>
-            verticalAlign=ALIGN.TOP_EDGE <br/>
-            Hint pinned to top edge, pole moves<br/>
-            along edge, hint box on right of pole<br/>
-            for first 2 data points and left otherwise.</p>
-            <DynamicSimpleTopEdgeHints />
-          </section>
-          <section>
-            <h3>Dynamic Programmatic Right Edge Hints</h3>
-            <p>Mouse over point.<br/>
-            getAlignStyle method returns style object<br/>
-            with right and top CSS props set (pinned<br/>
-              right edge and at y position) </p>
-            <DynamicProgrammaticRightEdgeHints />
-          </section>
-          <section>
-            <h3>Dynamic Complex Edge Hints</h3>
-            <p>Mouse over point. <br/>
-            Hint uses flex, css to show hint and pole<br/>
-            from point to outside plot edge (css for<br/>
-              margin values).</p>
-            <DynamicComplexEdgeHints />
-          </section>
-          <section>
-            <h3>Static Crosshair</h3>
-            <StaticCrosshair />
-          </section>
-          <section>
-            <h3>Dynamic Crosshair</h3>
-            <p>Move your mouse over the chart to see the point.</p>
-            <DynamicCrosshair />
-          </section>
-          <section>
-            <h3>Dynamic Crosshair Scatterplot</h3>
-            <p>Move your mouse over the chart to see the point.</p>
-            <DynamicCrosshairScatterplot />
-          </section>
-          <h2>Miscellaneous</h2>
-          <section>
-            <h3>Synced Charts</h3>
-            <SyncedCharts />
-          </section>
-          <section>
-            <h3>Time Chart</h3>
-            <TimeChart />
-          </section>
-          <section>
-            <h3>Polygon Example</h3>
-            <TriangleExample />
-          </section>
-          <section>
-            <h3>Voronoi Line Chart</h3>
-            <VoronoiLineChart />
-          </section>
-          <section>
-            <h3>Animation Example</h3>
-            <AnimationExample />
-          </section>
-        </article>
-        <article id="radial-charts">
-          <h1>Radial Chart</h1>
-          <section>
-            <h3>Simple Radial Chart</h3>
-            <SimpleRadialChart />
-          </section>
-          <section>
-            <h3>Simple Donut Chart</h3>
-            <DonutChartExample />
-          </section>
-          <section>
-            <h3>Custom Radius</h3>
-            <CustomRadiusRadialChart />
-          </section>
-
-        </article>
-        <article id="treemaps">
-          <h1>Treemap</h1>
-          <section>
-            <h3>Simple Treemap</h3>
-            <SimpleTreemap />
-          </section>
-          <section>
-            <h3>Animated Treemap</h3>
-            <TreemapExample />
-          </section>
-        </article>
-        <article id="sunbursts">
-          <h1>Sunbursts</h1>
-          <section>
-            <h3>Arc Series Example</h3>
-            <ArcSeriesExample />
-          </section>
-          <section>
-            <h3>Basic Sunburst</h3>
-            <BasicSunburst />
-          </section>
-          <section>
-            <h3>Clock</h3>
-            <ClockExample />
-          </section>
-          <section>
-            <h3>Animated Sunburst</h3>
-            <AnimatedSunburst />
-          </section>
-        </article>
-        <article id="legends">
-          <h1>Legends</h1>
-          <h2>Discrete color legend</h2>
-          <section>
-            <h3>Vertical legend</h3>
-            <VerticalDiscreteColorLegendExample />
-          </section>
-          <section>
-            <h3>Horizontal legend</h3>
-            <HorizontalDiscreteColorLegendExample />
-          </section>
-          <section>
-            <h3>Discrete color legend with search</h3>
-            <SearchableDiscreteColorLegendExample />
-          </section>
-          <h2>Continuous color legend</h2>
-          <section>
-            <h3>Default legend</h3>
-            <ContinuousColorLegendExample />
-          </section>
-          <h2>Continuous size legend</h2>
-          <section>
-            <h3>Default legend</h3>
-            <ContinuousSizeLegendExample />
-          </section>
-        </article>
-
-        <article id="sankeys">
-          <h1>Sankeys</h1>
-          <section>
-            <h3>Basic</h3>
-            <BasicSankeyExample />
-          </section>
-          <section>
-            <h3>With Voronoi Selection</h3>
-            <VoronoiSankeyExample />
-          </section>
-        </article>
+        <PlotsShowcase forExample={forExample}/>
+        <AxesShowcase />
+        <MiscShowcase />
+        <RadialShowcase />
+        <TreemapShowcase />
+        <SunburstSection />
+        <LegendsShowcase />
+        <SankeysShowcase />
       </main>
     );
   }

--- a/showcase/showcase-components/showcase-button.js
+++ b/showcase/showcase-components/showcase-button.js
@@ -19,25 +19,24 @@
 // THE SOFTWARE.
 
 import React from 'react';
-import LesMisData from './les-mis-data.json';
+import PropTypes from 'prop-types';
 
-import './force-directed.scss';
-import ForceDirectedGraph from './force-directed-graph';
-
-export default class Example extends React.Component {
-  state = {
-    strength: Math.random() * 60 - 30
-  }
-
+class ShowcaseButton extends React.Component {
   render() {
-    const {strength} = this.state;
+    const {buttonContent, onClick} = this.props;
     return (
-      <div className="force-directed-example">
-        <button
-          className="showcase-button"
-          onClick={() => this.setState({strength: Math.random() * 60 - 30})}> REWEIGHT </button>
-        <ForceDirectedGraph data={LesMisData} height={500} width={500} animation strength={strength}/>
-      </div>
+      <button
+        className="showcase-button"
+        onClick={onClick}>
+        {buttonContent}
+      </button>
     );
   }
 }
+
+ShowcaseButton.PropTypes = {
+  buttonContent: PropTypes.string.isRequired,
+  onClick: PropTypes.func.isRequired
+};
+
+export default ShowcaseButton;

--- a/showcase/showcase-sections/axes-showcase.js
+++ b/showcase/showcase-sections/axes-showcase.js
@@ -1,0 +1,97 @@
+import React, {Component} from 'react';
+
+import {showCase} from '../index';
+const {
+  AxisWithTurnedLabels,
+  CustomAxisChart,
+  CustomAxesOrientation,
+  DynamicComplexEdgeHints,
+  DynamicCrosshair,
+  DynamicCrosshairScatterplot,
+  DynamicHints,
+  DynamicProgrammaticRightEdgeHints,
+  DynamicSimpleEdgeHints,
+  DynamicSimpleTopEdgeHints,
+  StaticCrosshair,
+  StaticHints
+} = showCase;
+
+class AxesShowcase extends Component {
+  render() {
+    return (
+      <article id="axes">
+        <h2>Axes</h2>
+        <section>
+          <h3>Custom Axes Orientation</h3>
+          <CustomAxesOrientation />
+        </section>
+        <section>
+          <h3>Custom Axis</h3>
+          <CustomAxisChart />
+        </section>
+        <section>
+          <h3>Turned axis labels</h3>
+          <AxisWithTurnedLabels />
+        </section>
+        <h2>Tooltips</h2>
+        <section>
+          <h3>Static Hints</h3>
+          <StaticHints />
+        </section>
+        <section>
+          <h3>Dynamic Hints</h3>
+          <p>Move mouse over the point to see the hint.</p>
+          <DynamicHints />
+        </section>
+        <section>
+          <h3>Dynamic Simple Edge Hints</h3>
+          <p>Mouse over point. Hint appears on different edges.<br/>
+          Left margin enables first point to show w/o break.</p>
+          <DynamicSimpleEdgeHints />
+        </section>
+        <section>
+          <h3>Dynamic Simple Top Edge Hints</h3>
+          <p>Mouse over point.<br/>
+          horizontalAlign=ALIGN.AUTO,<br/>
+          verticalAlign=ALIGN.TOP_EDGE <br/>
+          Hint pinned to top edge, pole moves<br/>
+          along edge, hint box on right of pole<br/>
+          for first 2 data points and left otherwise.</p>
+          <DynamicSimpleTopEdgeHints />
+        </section>
+        <section>
+          <h3>Dynamic Programmatic Right Edge Hints</h3>
+          <p>Mouse over point.<br/>
+          getAlignStyle method returns style object<br/>
+          with right and top CSS props set (pinned<br/>
+            right edge and at y position) </p>
+          <DynamicProgrammaticRightEdgeHints />
+        </section>
+        <section>
+          <h3>Dynamic Complex Edge Hints</h3>
+          <p>Mouse over point. <br/>
+          Hint uses flex, css to show hint and pole<br/>
+          from point to outside plot edge (css for<br/>
+            margin values).</p>
+          <DynamicComplexEdgeHints />
+        </section>
+        <section>
+          <h3>Static Crosshair</h3>
+          <StaticCrosshair />
+        </section>
+        <section>
+          <h3>Dynamic Crosshair</h3>
+          <p>Move your mouse over the chart to see the point.</p>
+          <DynamicCrosshair />
+        </section>
+        <section>
+          <h3>Dynamic Crosshair Scatterplot</h3>
+          <p>Move your mouse over the chart to see the point.</p>
+          <DynamicCrosshairScatterplot />
+        </section>
+      </article>
+    );
+  }
+}
+
+export default AxesShowcase;

--- a/showcase/showcase-sections/legends-showcase.js
+++ b/showcase/showcase-sections/legends-showcase.js
@@ -1,0 +1,45 @@
+import React, {Component} from 'react';
+
+import {showCase} from '../index';
+const {
+  ContinuousColorLegendExample,
+  ContinuousSizeLegendExample,
+  HorizontalDiscreteColorLegendExample,
+  SearchableDiscreteColorLegendExample,
+  VerticalDiscreteColorLegendExample
+} = showCase;
+
+class LegendsExample extends Component {
+  render() {
+    return (
+      <article id="legends">
+        <h1>Legends</h1>
+        <h2>Discrete color legend</h2>
+        <section>
+          <h3>Vertical legend</h3>
+          <VerticalDiscreteColorLegendExample />
+        </section>
+        <section>
+          <h3>Horizontal legend</h3>
+          <HorizontalDiscreteColorLegendExample />
+        </section>
+        <section>
+          <h3>Discrete color legend with search</h3>
+          <SearchableDiscreteColorLegendExample />
+        </section>
+        <h2>Continuous color legend</h2>
+        <section>
+          <h3>Default legend</h3>
+          <ContinuousColorLegendExample />
+        </section>
+        <h2>Continuous size legend</h2>
+        <section>
+          <h3>Default legend</h3>
+          <ContinuousSizeLegendExample />
+        </section>
+      </article>
+    );
+  }
+}
+
+export default LegendsExample;

--- a/showcase/showcase-sections/misc-showcase.js
+++ b/showcase/showcase-sections/misc-showcase.js
@@ -1,0 +1,42 @@
+import React, {Component} from 'react';
+
+import {showCase} from '../index';
+const {
+  AnimationExample,
+  SyncedCharts,
+  TimeChart,
+  TriangleExample,
+  VoronoiLineChart
+} = showCase;
+
+class MiscShowcase extends Component {
+  render() {
+    return (
+      <article>
+        <h2>Miscellaneous</h2>
+        <section>
+          <h3>Synced Charts</h3>
+          <SyncedCharts />
+        </section>
+        <section>
+          <h3>Time Chart</h3>
+          <TimeChart />
+        </section>
+        <section>
+          <h3>Polygon Example</h3>
+          <TriangleExample />
+        </section>
+        <section>
+          <h3>Voronoi Line Chart</h3>
+          <VoronoiLineChart />
+        </section>
+        <section>
+          <h3>Animation Example</h3>
+          <AnimationExample />
+        </section>
+      </article>
+    );
+  }
+}
+
+export default MiscShowcase;

--- a/showcase/showcase-sections/plots-showcase.js
+++ b/showcase/showcase-sections/plots-showcase.js
@@ -1,0 +1,104 @@
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+import {showCase} from '../index';
+const {
+  AreaChart,
+  AreaChartElevated,
+  BarChart,
+  ClusteredStackedVerticalBarChart,
+  ComplexChart,
+  CustomScales,
+  FauxScatterplotChart,
+  GridLinesChart,
+  HeatmapChart,
+  LineChart,
+  LineMarkChart,
+  StackedVerticalBarChart,
+  StackedHorizontalBarChart,
+  StackedHistogram,
+  ScatterplotChart,
+  WidthHeightMarginChart
+} = showCase;
+
+class PlotsShowcase extends Component {
+  render() {
+    const {forExample} = this.props;
+    return (
+      <article id="plots">
+        <h1>Plots</h1>
+        {!forExample && (<section>
+          <ComplexChart />
+        </section>)}
+        <h2>Series Types</h2>
+        <section>
+          <h3>Line Series</h3>
+          <LineChart />
+        </section>
+        <section>
+          <h3>LineMark Series</h3>
+          <LineMarkChart />
+        </section>
+        <section>
+          <h3>Mark Series</h3>
+          <ScatterplotChart />
+        </section>
+        <section>
+          <h3>Area Series</h3>
+          <AreaChart />
+        </section>
+        <section>
+          <h3>Area Series With vertical offset</h3>
+          <AreaChartElevated />
+        </section>
+        <section>
+          <h3>Bar Series</h3>
+          <BarChart />
+        </section>
+        <section>
+          <h3>Stacked Horizontal Bar Series</h3>
+          <StackedHorizontalBarChart />
+        </section>
+        <section>
+          <h3>Stacked Vertical Bar Series</h3>
+          <StackedVerticalBarChart />
+        </section>
+        <section>
+          <h3>Clustered Stacked Vertical Bar Series</h3>
+          <ClusteredStackedVerticalBarChart />
+        </section>
+        <section>
+          <h3>Stacked Vertical Rect Series (histogram)</h3>
+          <StackedHistogram />
+        </section>
+        <section>
+          <h3>Heatmap Series</h3>
+          <HeatmapChart />
+        </section>
+
+        <h2>Basic Components</h2>
+        <section>
+          <h3>Custom Size and Margin</h3>
+          <WidthHeightMarginChart />
+        </section>
+        <section>
+          <h3>Custom scales</h3>
+          <CustomScales />
+        </section>
+        <section>
+          <h3>Custom GridLines</h3>
+          <GridLinesChart />
+        </section>
+        <section>
+          <h3>Circular Gridlines</h3>
+          <FauxScatterplotChart />
+        </section>
+      </article>
+    );
+  }
+}
+
+PlotsShowcase.propTypes = {
+  forExample: PropTypes.bool
+};
+
+export default PlotsShowcase;

--- a/showcase/showcase-sections/radial-showcase.js
+++ b/showcase/showcase-sections/radial-showcase.js
@@ -1,0 +1,33 @@
+import React, {Component} from 'react';
+
+import {showCase} from '../index';
+const {
+  CustomRadiusRadialChart,
+  DonutChartExample,
+  SimpleRadialChart
+} = showCase;
+
+class RadialShowcase extends Component {
+  render() {
+    return (
+      <article id="radial-charts">
+        <h1>Radial Chart</h1>
+        <section>
+          <h3>Simple Radial Chart</h3>
+          <SimpleRadialChart />
+        </section>
+        <section>
+          <h3>Simple Donut Chart</h3>
+          <DonutChartExample />
+        </section>
+        <section>
+          <h3>Custom Radius</h3>
+          <CustomRadiusRadialChart />
+        </section>
+
+      </article>
+    );
+  }
+}
+
+export default RadialShowcase;

--- a/showcase/showcase-sections/sankeys-showcase.js
+++ b/showcase/showcase-sections/sankeys-showcase.js
@@ -1,0 +1,27 @@
+import React, {Component} from 'react';
+
+import {showCase} from '../index';
+const {
+  BasicSankeyExample,
+  VoronoiSankeyExample
+} = showCase;
+
+class SankeysSection extends Component {
+  render() {
+    return (
+      <article id="sankeys">
+        <h1>Sankeys</h1>
+        <section>
+          <h3>Basic</h3>
+          <BasicSankeyExample />
+        </section>
+        <section>
+          <h3>With Voronoi Selection</h3>
+          <VoronoiSankeyExample />
+        </section>
+      </article>
+    );
+  }
+}
+
+export default SankeysSection;

--- a/showcase/showcase-sections/sunburst-showcase.js
+++ b/showcase/showcase-sections/sunburst-showcase.js
@@ -1,0 +1,37 @@
+import React, {Component} from 'react';
+
+import {showCase} from '../index';
+const {
+  AnimatedSunburst,
+  ArcSeriesExample,
+  BasicSunburst,
+  ClockExample
+} = showCase;
+
+class SunburstSection extends Component {
+  render() {
+    return (
+      <article id="sunbursts">
+        <h1>Sunbursts</h1>
+        <section>
+          <h3>Arc Series Example</h3>
+          <ArcSeriesExample />
+        </section>
+        <section>
+          <h3>Basic Sunburst</h3>
+          <BasicSunburst />
+        </section>
+        <section>
+          <h3>Clock</h3>
+          <ClockExample />
+        </section>
+        <section>
+          <h3>Animated Sunburst</h3>
+          <AnimatedSunburst />
+        </section>
+      </article>
+    );
+  }
+}
+
+export default SunburstSection;

--- a/showcase/showcase-sections/treemap-showcase.js
+++ b/showcase/showcase-sections/treemap-showcase.js
@@ -1,0 +1,27 @@
+import React, {Component} from 'react';
+
+import {showCase} from '../index';
+const {
+  SimpleTreemap,
+  TreemapExample
+} = showCase;
+
+class TreemapShowcase extends Component {
+  render() {
+    return (
+      <article id="treemaps">
+        <h1>Treemap</h1>
+        <section>
+          <h3>Simple Treemap</h3>
+          <SimpleTreemap />
+        </section>
+        <section>
+          <h3>Animated Treemap</h3>
+          <TreemapExample />
+        </section>
+      </article>
+    );
+  }
+}
+
+export default TreemapShowcase;

--- a/showcase/sunbursts/animated-sunburst.js
+++ b/showcase/sunbursts/animated-sunburst.js
@@ -21,6 +21,7 @@
 import React from 'react';
 
 import Sunburst from 'sunburst';
+import ShowcaseButton from '../showcase-components/showcase-button';
 
 function randomLeaf() {
   return {
@@ -58,7 +59,9 @@ export default class AnimatedSunburst extends React.Component {
 
     return (
       <div className="animated-sunburst-example-wrapper">
-        <button onClick={() => this.setState({data: updateData()})}> UPDATE DATA </button>
+        <ShowcaseButton
+          onClick={() => this.setState({data: updateData()})}
+          buttonContent={'UPDATE'} />
         <Sunburst
           animation={{damping: 20, stiffness: 300}}
           data={data}

--- a/showcase/treemap/dynamic-treemap.js
+++ b/showcase/treemap/dynamic-treemap.js
@@ -21,6 +21,7 @@
 import React from 'react';
 
 import Treemap from 'treemap';
+import ShowcaseButton from '../showcase-components/showcase-button';
 
 function _getRandomData() {
   const totalLeaves = Math.random() * 20;
@@ -70,9 +71,9 @@ export default class DynamicTreemapExample extends React.Component {
     };
     return (
       <div className="dynamic-treemap-example">
-        <button onClick={() => this.setState({useCirclePacking: !useCirclePacking})}>
-          TOGGLE CIRCLE PACK
-        </button>
+        <ShowcaseButton
+          onClick={() => this.setState({useCirclePacking: !useCirclePacking})}
+          buttonContent={'TOGGLE CIRCLE PACK'} />
         <Treemap {...treeProps}/>
         click above to the update data
         {hoveredNode && hoveredNode.value}

--- a/showcase/treemap/simple-treemap.js
+++ b/showcase/treemap/simple-treemap.js
@@ -23,6 +23,7 @@ import React from 'react';
 import Treemap from 'treemap';
 
 import D3FlareData from './d3-flare-example.json';
+import ShowcaseButton from '../showcase-components/showcase-button';
 
 const MODE = [
   'circlePack',
@@ -50,19 +51,11 @@ export default class SimpleTreemapExample extends React.Component {
   render() {
     const {modeIndex} = this.state;
     return (
-      <div className="simple-treemap-example">
-        <div className="simple-treemap-example-controls">
-          <div
-            className="simple-treemap-example-button"
-            onClick={this.updateModeIndex(false)}>
-            {'PREV MODE'}
-          </div>
+      <div className="centered-and-flexed">
+        <div className="centered-and-flexed-controls">
+          <ShowcaseButton onClick={this.updateModeIndex(false)} buttonContent={'PREV MODE'} />
           <div> {MODE[modeIndex]} </div>
-          <div
-            className="simple-treemap-example-button"
-            onClick={this.updateModeIndex(true)}>
-            {'NEXT MODE'}
-          </div>
+          <ShowcaseButton onClick={this.updateModeIndex(true)} buttonContent={'NEXT MODE'} />
         </div>
         <Treemap
           animation

--- a/src/styles/examples.scss
+++ b/src/styles/examples.scss
@@ -313,7 +313,7 @@ article {
   }
 }
 
-.simple-treemap-example {
+.centered-and-flexed {
   align-items: center;
   display: flex;
   flex-direction: column;
@@ -324,21 +324,12 @@ article {
     border: thin solid rgba(#ddd, .5);
   }
 
-  .simple-treemap-example-controls {
+  .centered-and-flexed-controls {
     align-items: center;
     display: flex;
     justify-content: space-between;
     padding: 10px 0;
     width: 75%;
-  }
-
-  .simple-treemap-example-button {
-    border: thin solid #333;
-    border-radius: 5px;
-    cursor: pointer;
-    font-size: 10px;
-    font-weight: 600;
-    padding: 5px 10px;
   }
 }
 
@@ -350,12 +341,22 @@ article {
 
 .clustered-stacked-bar-chart-example {
   .rv-discrete-color-legend {
-    position: absolute;
-    top: 0px;
     left: 40px;
+    position: absolute;
+    top: 0;
   }
 }
 
 .basic-sunburst-example-path-name {
   height: 20px;
+}
+
+.showcase-button {
+  background: #fff;
+  border: thin solid #333;
+  border-radius: 5px;
+  cursor: pointer;
+  font-size: 10px;
+  font-weight: 600;
+  padding: 5px 10px;
 }

--- a/tests/components/arc-series-tests.js
+++ b/tests/components/arc-series-tests.js
@@ -9,7 +9,7 @@ testRenderWithProps(ArcSeries, GENERIC_XYPLOT_SERIES_PROPS);
 
 test('MarkSeries: Showcase Example - ArcSeriesExample', t => {
   const $ = mount(<ArcSeriesExample />);
-  t.equal($.text(), ' UPDATE -4-2024-4-2024', 'should find the right text content');
+  t.equal($.text(), 'UPDATE-4-2024-4-2024', 'should find the right text content');
   t.equal($.find('.rv-xy-plot__series--arc').length, 2, 'should find the right number of series');
   t.equal($.find('.rv-xy-plot__series--arc path').length, 8, 'with the right number of arc in them');
   t.end();


### PR DESCRIPTION
The showcase app started sprawl pretty darn hard, this PR breaks it up. If we like we can break it up inside of the examples page so that people dont have to scroll as hard. Addresses some of #343 