### PR TITLE
Add outline mode to mark-series-gl

### DIFF
--- a/docs/markdown/line-series.md
+++ b/docs/markdown/line-series.md
@@ -57,6 +57,6 @@ const funcCurveProp = <LineSeries data={data} curve={configuredCurve} .../>;
 
 In addition to the above api the GL version of markSeries exposes several additional props.
 
-#### seriesId
-Type: `string` (REQUIRED)
+#### seriesId (REQUIRED)
+Type: `string`
 This string is used by deck.gl to identify which layer is being requested to render.

--- a/docs/markdown/line-series.md
+++ b/docs/markdown/line-series.md
@@ -52,3 +52,11 @@ const stringCurveProp = <LineSeries data={data} curve={'curveMonotoneX'} .../>;
 const configuredCurve = d3Shape.curveCatmullRom.alpha(0.5);
 const funcCurveProp = <LineSeries data={data} curve={configuredCurve} .../>;
 ```
+
+## LineSeriesGL API Additions
+
+In addition to the above api the GL version of markSeries exposes several additional props.
+
+#### seriesId
+Type: `string` (REQUIRED)
+This string is used by deck.gl to identify which layer is being requested to render.

--- a/docs/markdown/markseries.md
+++ b/docs/markdown/markseries.md
@@ -112,3 +112,15 @@ Type: `function(info)`
 
 #### animation (optional)  
 See the [XYPlot](xy-plot.md)'s `animation` section for more information.
+
+## MarkSeriesGL API Additions
+
+In addition to the above api the GL version of markSeries exposes several additional props.
+
+#### seriesId
+Type: `string` (REQUIRED)
+This string is used by deck.gl to identify which layer is being requested to render.
+
+#### outline (optional)
+Type: `Boolean`
+This boolean determines whether or not to switch to the outline mode for the markes

--- a/docs/markdown/markseries.md
+++ b/docs/markdown/markseries.md
@@ -117,8 +117,8 @@ See the [XYPlot](xy-plot.md)'s `animation` section for more information.
 
 In addition to the above api the GL version of markSeries exposes several additional props.
 
-#### seriesId
-Type: `string` (REQUIRED)
+#### seriesId (REQUIRED)
+Type: `string`
 This string is used by deck.gl to identify which layer is being requested to render.
 
 #### outline (optional)

--- a/src/plot/series/mark-series-gl.js
+++ b/src/plot/series/mark-series-gl.js
@@ -45,7 +45,7 @@ class MarkSeriesGL extends AbstractSeries {
       colorRange,
       sizeDomain,
       sizeRange,
-      fp64
+      outline
     } = props;
 
     const xFunctor = getAttributeFunctor(props, 'x');
@@ -64,6 +64,7 @@ class MarkSeriesGL extends AbstractSeries {
         return [color.r, color.g, color.b, (opacityFunctor(p) || DEFAULT_OPACITY) * 255];
       },
       opacity: 1,
+      outline,
       projectionMode: COORDINATE_SYSTEM.IDENTITY,
       updateTriggers: {
         getPosition: _renderKey,
@@ -74,8 +75,7 @@ class MarkSeriesGL extends AbstractSeries {
       radiusMinPixels: 2,
       pickable: true,
       onHover: row => props.onValueMouseOver(row.object),
-      onClick: row => props.onValueClick(row.object),
-      fp64
+      onClick: row => props.onValueClick(row.object)
     });
   }
 
@@ -88,13 +88,13 @@ MarkSeriesGL.displayName = 'MarkSeriesGL';
 MarkSeriesGL.defaultProps = {
   onValueMouseOver: () => {},
   onValueClick: () => {},
-  fp64: false
+  outline: false
 };
 
 MarkSeriesGL.propTypes = {
   ...AbstractSeries.propTypes,
   seriesId: PropTypes.string.isRequired,
-  fp64: PropTypes.bool
+  outline: PropTypes.bool
 };
 
 export default MarkSeriesGL;


### PR DESCRIPTION
Deck.gl supports outlines for circles, so it seems like something we should offer as well!

![screen shot 2017-04-13 at 10 07 07 am](https://cloud.githubusercontent.com/assets/6854312/25015523/f8c82580-2030-11e7-80aa-7e3f0ec377d6.png)
