### PR TITLE
Fix discrete color legend

### DIFF
--- a/showcase/index.js
+++ b/showcase/index.js
@@ -57,6 +57,7 @@ import HorizontalDiscreteColorLegendExample from './legends/horizontal-discrete-
 import SearchableDiscreteColorLegendExample from './legends/searchable-discrete-color';
 import ContinuousColorLegendExample from './legends/continuous-color';
 import ContinuousSizeLegendExample from './legends/continuous-size';
+import HorizontalDiscreteCustomPalette from './legends/horizontal-discrete-custom-palette';
 
 import AnimationExample from './misc/animation-example';
 import SyncedCharts from './misc/synced-charts';
@@ -137,6 +138,7 @@ export const showCase = {
 
   VerticalDiscreteColorLegendExample,
   HorizontalDiscreteColorLegendExample,
+  HorizontalDiscreteCustomPalette,
   SearchableDiscreteColorLegendExample,
   ContinuousColorLegendExample,
   ContinuousSizeLegendExample

--- a/showcase/legends/horizontal-discrete-custom-palette.js
+++ b/showcase/legends/horizontal-discrete-custom-palette.js
@@ -1,0 +1,54 @@
+// Copyright (c) 2016 - 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the 'Software'), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import React from 'react';
+
+import DiscreteColorLegend from 'legends/discrete-color-legend';
+
+const ITEMS = [
+  'Options',
+  'Buttons',
+  'Select boxes',
+  'Date inputs',
+  'Password inputs',
+  'Forms',
+  'Other'
+];
+
+const COLORS = [
+  '#6588cd',
+  '#66b046',
+  '#a361c7',
+  '#ad953f',
+  '#c75a87',
+  '#55a47b',
+  '#cb6141'
+];
+
+export default function DiscreteColorExample() {
+  return (
+    <DiscreteColorLegend
+      colors={COLORS}
+      orientation="horizontal"
+      width={300}
+      items={ITEMS}
+    />
+  );
+}

--- a/showcase/showcase-sections/legends-showcase.js
+++ b/showcase/showcase-sections/legends-showcase.js
@@ -5,6 +5,7 @@ const {
   ContinuousColorLegendExample,
   ContinuousSizeLegendExample,
   HorizontalDiscreteColorLegendExample,
+  HorizontalDiscreteCustomPalette,
   SearchableDiscreteColorLegendExample,
   VerticalDiscreteColorLegendExample
 } = showCase;
@@ -15,6 +16,9 @@ const DISCRETE_LEGENDS = [{
 }, {
   name: 'Horizontal legend',
   component: HorizontalDiscreteColorLegendExample
+}, {
+  name: 'Custom palette',
+  component: HorizontalDiscreteCustomPalette
 }, {
   name: 'Discrete color legend with search',
   component: SearchableDiscreteColorLegendExample

--- a/src/legends/discrete-color-legend.js
+++ b/src/legends/discrete-color-legend.js
@@ -49,6 +49,15 @@ const defaultProps = {
   orientation: 'vertical'
 };
 
+/**
+ * Add color information to a list of legend items.
+ * @param {Array} items - list of legend items
+ * @param {string} [items.title] - label of the legend item
+ * @param {string} [items.color] - color of the legend item
+ * @param {Array} colors - array of colors.
+ * @returns {Array} Array of tick values.
+ */
+
 function fillItemsWithDefaults(items, colors) {
   return items.map((item, i) => {
     return {

--- a/src/legends/discrete-color-legend.js
+++ b/src/legends/discrete-color-legend.js
@@ -49,19 +49,20 @@ const defaultProps = {
   orientation: 'vertical'
 };
 
-function fillItemsWithDefaults(items) {
+function fillItemsWithDefaults(items, colors) {
   return items.map((item, i) => {
     return {
       title: item.title ? item.title : item,
       color: item.color ?
         item.color :
-        DISCRETE_COLOR_RANGE[i % DISCRETE_COLOR_RANGE.length],
+        colors[i % colors.length],
       disabled: Boolean(item.disabled)
     };
   });
 }
 
 function DiscreteColorLegend({
+  colors,
   items: initialItems,
   width,
   height,
@@ -69,7 +70,7 @@ function DiscreteColorLegend({
   orientation,
   className
 }) {
-  const updatedItems = fillItemsWithDefaults(initialItems);
+  const updatedItems = fillItemsWithDefaults(initialItems, colors);
   return (
     <div
       className={`rv-discrete-color-legend ${orientation} ${className}`}

--- a/src/legends/searchable-discrete-color-legend.js
+++ b/src/legends/searchable-discrete-color-legend.js
@@ -42,15 +42,17 @@ const defaultProps = {
 
 function SearchableDiscreteColorLegend(props) {
   const {
+    className,
+    colors,
+    height,
     items,
     onItemClick,
-    searchFn,
     onSearchChange,
-    searchText,
+    orientation,
+    searchFn,
     searchPlaceholder,
-    width,
-    height,
-    className
+    searchText,
+    width
   } = props;
   const onChange = onSearchChange ?
     ({target: {value}}) => onSearchChange(value) :
@@ -68,8 +70,11 @@ function SearchableDiscreteColorLegend(props) {
       </form>
       <div className="rv-search-wrapper__contents">
         <DiscreteColorLegend
+          colors={colors}
           items={filteredItems}
-          onItemClick={onItemClick}/>
+          onItemClick={onItemClick}
+          orientation={orientation}
+        />
       </div>
     </div>
   );

--- a/tests/components/legends-tests.js
+++ b/tests/components/legends-tests.js
@@ -7,6 +7,8 @@ import ContinuousColorLegend from '../../showcase/legends/continuous-color';
 import HorizontalDiscreteLegend from '../../showcase/legends/horizontal-discrete-color';
 import VerticalDiscreteLegend from '../../showcase/legends/vertical-discrete-color';
 import SearchableDiscreteLegend from '../../showcase/legends/searchable-discrete-color';
+import HorizontalDiscreteCustomPalette from
+  '../../showcase/legends/horizontal-discrete-custom-palette';
 
 test('Continuous Size Legend', t => {
   const $ = mount(<ContinuousSizeLegend/>);
@@ -24,7 +26,7 @@ test('Continuous Color Legend', t => {
   t.end();
 });
 
-test('Discerete Legends', t => {
+test('Discrete Legends', t => {
   [HorizontalDiscreteLegend, VerticalDiscreteLegend].forEach(Component => {
     const $ = mount(<Component/>);
     t.equal($.text(), 'OptionsButtonsSelect boxesDate inputsPassword inputsFormsOther',
@@ -32,6 +34,17 @@ test('Discerete Legends', t => {
     t.equal($.find('.rv-discrete-color-legend-item__color').length, 7,
     'should find the right number of elements');
   });
+
+  t.deepEqual(mount(<HorizontalDiscreteLegend/>)
+    .find('.rv-discrete-color-legend-item__color').first()
+    .props().style, {background: '#12939A'},
+    'normal discrete legend uses default palette');
+
+  t.deepEqual(mount(<HorizontalDiscreteCustomPalette/>)
+    .find('.rv-discrete-color-legend-item__color').first()
+    .props().style, {background: '#6588cd'},
+    'custom discrete legend uses custom palette');
+
 
   const $ = mount(<SearchableDiscreteLegend/>);
   t.equal($.text(), 'ApplesBananasBlueberriesCarrotsEggplantsLimesPotatoes',

--- a/tests/components/legends-tests.js
+++ b/tests/components/legends-tests.js
@@ -45,7 +45,6 @@ test('Discrete Legends', t => {
     .props().style, {background: '#6588cd'},
     'custom discrete legend uses custom palette');
 
-
   const $ = mount(<SearchableDiscreteLegend/>);
   t.equal($.text(), 'ApplesBananasBlueberriesCarrotsEggplantsLimesPotatoes',
   'should find the correct text content for the searchable legend');


### PR DESCRIPTION
DiscreteColorLegend has a colors default property, which should be used to pass a pass a palette (ie an array of colors). instead, it uses DISCRETE_COLOR_RANGE regardless. This is especially annoying given that DISCRETE_COLOR_RANGE is not directly accessible by users. 
in this PR, DiscreteColorLegend can take the colors property into account. 
Added an example.