### PR TITLE
Fix PropTypes.

### DIFF
--- a/src/plot/axis/axis-line.js
+++ b/src/plot/axis/axis-line.js
@@ -32,7 +32,7 @@ const propTypes = {
   orientation: PropTypes.oneOf([
     LEFT, RIGHT, TOP, BOTTOM
   ]).isRequired,
-  width: React.PropTypes.number.isRequired
+  width: PropTypes.number.isRequired
 };
 
 const defaultProps = {

--- a/src/plot/series/label-series.js
+++ b/src/plot/series/label-series.js
@@ -87,7 +87,7 @@ class LabelSeries extends AbstractSeries {
   }
 }
 
-LabelSeries.PropTypes = {
+LabelSeries.propTypes = {
   animation: PropTypes.bool,
   allowOffsetToBeReversed: PropTypes.bool,
   className: PropTypes.string,

--- a/src/plot/series/line-mark-series.js
+++ b/src/plot/series/line-mark-series.js
@@ -19,6 +19,7 @@
 // THE SOFTWARE.
 
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import AbstractSeries from './abstract-series';
 import LineSeries from './line-series';
@@ -26,8 +27,8 @@ import MarkSeries from './mark-series';
 
 const propTypes = {
   ...LineSeries.propTypes,
-  lineStyle: React.PropTypes.object,
-  markStyle: React.PropTypes.object
+  lineStyle: PropTypes.object,
+  markStyle: PropTypes.object
 };
 
 class LineMarkSeries extends AbstractSeries {

--- a/src/radial-chart/index.js
+++ b/src/radial-chart/index.js
@@ -157,7 +157,7 @@ class RadialChart extends Component {
 }
 
 RadialChart.displayName = 'RadialChart';
-RadialChart.PropTypes = {
+RadialChart.propTypes = {
   animation: AnimationPropType,
   className: PropTypes.string,
   colorType: PropTypes.string,

--- a/src/sunburst/index.js
+++ b/src/sunburst/index.js
@@ -107,7 +107,7 @@ class Sunburst extends React.Component {
 }
 
 Sunburst.displayName = 'Sunburst';
-Sunburst.PropTypes = {
+Sunburst.propTypes = {
   animation: AnimationPropType,
   className: PropTypes.string,
   colorType: PropTypes.string,


### PR DESCRIPTION
This PR fixed some invalid use of PropTypes across the library:

- `AxisLine` and `LineMarkSeries` still use the deprecated `React.PropTypes`
- `LabelSeries`, `RadialChart` and `Sunburst` declared them via `Component.PropTypes` instead of `Component.propTypes`.