### PR TITLE
Add borders component

### DIFF
--- a/docs/markdown/borders.md
+++ b/docs/markdown/borders.md
@@ -1,0 +1,54 @@
+## Borders
+
+Sometimes when modifying the domain of the XYPlot it can be useful to enforce a border, so that some components appear, and others do not. One way to do this is to use the `Borders` component. It is a simple component that creates rectangles the directly correspond to the margins of the plot.
+
+<!-- INJECT:"GradientExample" -->
+
+For example, a set up like this:
+
+```jsx
+<XYPlot xDomain={[1.2, 3]} yDomain={[11, 26]} width={300} height={300}>
+  <AreaSeries
+    data={[
+      {x: 1, y: 10, y0: 1},
+      {x: 2, y: 25, y0: 5},
+      {x: 3, y: 15, y0: 3}
+    ]}/>
+  <Borders style={{
+    bottom: {fill: '#fff'},
+    left: {fill: '#fff'},
+    right: {fill: '#fff'},
+    top: {fill: '#fff'}
+  }}/>
+  <XAxis />
+  <YAxis />
+  <AreaSeries
+    data={[
+      {x: 1, y: 5, y0: 6},
+      {x: 2, y: 20, y0: 11},
+      {x: 3, y: 10, y0: 9}
+    ]}/>
+</XYPlot>
+```
+
+would cause the first area series to be truncated underneath the borders, while the second one would not be! This level of granular border control can be useful if you are using multiple kinds of series, for instance if you have a mark series that you wish to show the entire mark for, and a line series that you are alright with truncating at the border.
+
+## API Reference
+
+### className (optional)
+Type: `String`
+A class name to apply to each of the borders, as well as the root border container. It will be enumerates on top the borders using suffixes, eg if className={"my-cool-class"} the top rectangle will have a class name "my-cool-class-top".
+
+### Style (optional)
+Type: `Object`
+You can pass a style object to your Hint component to apply your own styles. See [style](style.md)
+```jsx
+<Borders style={{
+  bottom: {fill: '#fff'},
+  left: {fill: '#fff'},
+  right: {fill: '#fff'},
+  top: {fill: '#fff'}
+}}/>
+```
+
+Because border its made up of four individual rectangular components (there being four borders on an XYPlot) it is advisable to specify styles for all four rectangles. This can be done using either the style object or css-classes.

--- a/showcase/misc/gradient-example.js
+++ b/showcase/misc/gradient-example.js
@@ -27,13 +27,16 @@ import {
   VerticalGridLines,
   HorizontalGridLines,
   AreaSeries,
-  GradientDefs
+  GradientDefs,
+  Borders
 } from 'index';
 
 export default class GradientExample extends React.Component {
   render() {
     return (
       <XYPlot
+        xDomain={[1.2, 3]}
+        yDomain={[11, 26]}
         width={300}
         height={300}>
         <GradientDefs>
@@ -44,8 +47,7 @@ export default class GradientExample extends React.Component {
         </GradientDefs>
         <VerticalGridLines />
         <HorizontalGridLines />
-        <XAxis />
-        <YAxis />
+
         <AreaSeries
           color={'url(#CoolGradient)'}
           data={[
@@ -53,6 +55,14 @@ export default class GradientExample extends React.Component {
             {x: 2, y: 25, y0: 5},
             {x: 3, y: 15, y0: 3}
           ]}/>
+        <Borders style={{
+          bottom: {fill: '#fff'},
+          left: {fill: 'url(#CoolGradient)', opacity: 0.3},
+          right: {fill: '#fff'},
+          top: {fill: '#fff'}
+        }}/>
+        <XAxis />
+        <YAxis />
         <AreaSeries
           data={[
             {x: 1, y: 5, y0: 6},

--- a/showcase/showcase-app.js
+++ b/showcase/showcase-app.js
@@ -27,6 +27,7 @@ class App extends Component {
               <li><a href="#legends">Legends</a></li>
               <li><a href="#sunbursts">Sunbursts</a></li>
               <li><a href="#sankeys">Sankeys</a></li>
+              <li><a href="#misc">Misc</a></li>
             </nav>
           </div>
         </header>)}

--- a/showcase/showcase-sections/misc-showcase.js
+++ b/showcase/showcase-sections/misc-showcase.js
@@ -26,8 +26,9 @@ const MISC = [{
   name: 'Voronoi Line Chart',
   component: VoronoiLineChart
 }, {
-  name: 'Gradient Example',
-  component: GradientExample
+  name: 'Gradient & Custom Border Example',
+  component: GradientExample,
+  sourceLink: 'https://github.com/uber/react-vis/blob/master/showcase/misc/gradient-example.js'
 }, {
   name: 'Animation Example',
   component: AnimationExample,
@@ -42,7 +43,7 @@ const MISC = [{
 class MiscShowcase extends Component {
   render() {
     return (
-      <article>
+      <article id="misc">
         <h2>Miscellaneous</h2>
         {MISC.map(mapSection)}
       </article>

--- a/src/index.js
+++ b/src/index.js
@@ -41,6 +41,7 @@ export ArcSeries from 'plot/series/arc-series';
 export LineMarkSeries from 'plot/series/line-mark-series';
 export LineMarkSeriesCanvas from 'plot/series/line-mark-series-canvas';
 export Hint from 'plot/hint';
+export Borders from 'plot/borders';
 export Crosshair from 'plot/crosshair';
 export XYPlot from 'plot/xy-plot';
 export XAxis from 'plot/axis/x-axis';

--- a/src/plot/borders.js
+++ b/src/plot/borders.js
@@ -1,0 +1,92 @@
+// Copyright (c) 2016 - 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import React from 'react';
+
+import PropTypes from 'prop-types';
+
+import PureRenderComponent from 'pure-render-component';
+
+const propTypes = {
+  style: PropTypes.shape({
+    bottom: PropTypes.object,
+    left: PropTypes.object,
+    right: PropTypes.object,
+    top: PropTypes.object
+  }),
+  // supplied by xyplot
+  marginTop: PropTypes.number,
+  marginBottom: PropTypes.number,
+  marginLeft: PropTypes.number,
+  marginRight: PropTypes.number,
+  innerWidth: PropTypes.number,
+  innerHeight: PropTypes.number
+};
+
+const CLASSES = {
+  bottom: 'rv-xy-plot__borders-bottom',
+  container: 'rv-xy-plot__borders',
+  left: 'rv-xy-plot__borders-left',
+  right: 'rv-xy-plot__borders-right',
+  top: 'rv-xy-plot__borders-top'
+};
+
+class Borders extends PureRenderComponent {
+  render() {
+    const {
+      marginTop,
+      marginBottom,
+      marginLeft,
+      marginRight,
+      innerWidth,
+      innerHeight,
+      style,
+      className
+    } = this.props;
+    const height = innerHeight + marginTop + marginBottom;
+    const width = innerWidth + marginLeft + marginRight;
+    return (
+      <g className={`${CLASSES.container} ${className}`}>
+        <rect className={`${CLASSES.bottom} ${className}-bottom`} style={style.bottom}
+          x={0} y={height - marginBottom} width={width} height={marginBottom} />
+        <rect className={`${CLASSES.left} ${className}-left`} style={style.left}
+          x={0} y={0} width={marginLeft} height={height} />
+        <rect className={`${CLASSES.right} ${className}-right`} style={style.right}
+          x={width - marginRight} y={0} width={marginRight} height={height} />
+        <rect className={`${CLASSES.top} ${className}-top`} style={style.top}
+          x={0} y={0} width={width} height={marginTop} />
+      </g>
+    );
+  }
+}
+
+Borders.displayName = 'Borders';
+Borders.defaultProps = {
+  style: {
+    bottom: {},
+    left: {},
+    right: {},
+    top: {}
+  }
+};
+Borders.propTypes = propTypes;
+Borders.requiresSVG = true;
+
+export default Borders;

--- a/tests/components/borders-tests.js
+++ b/tests/components/borders-tests.js
@@ -1,0 +1,15 @@
+import test from 'tape';
+import React from 'react';
+import {mount} from 'enzyme';
+import Borders from 'plot/borders';
+import {testRenderWithProps, GENERIC_XYPLOT_SERIES_PROPS} from '../test-utils';
+import GradientExample from '../../showcase/misc/gradient-example';
+
+testRenderWithProps(Borders, GENERIC_XYPLOT_SERIES_PROPS);
+
+test('Borders: GradientExample', t => {
+  const $ = mount(<GradientExample />);
+  t.equal($.find('.rv-xy-plot__borders').length, 1, 'should find the right number of borders containers');
+  t.equal($.find('.rv-xy-plot__borders rect').length, 4, 'should find the right number of borders');
+  t.end();
+});

--- a/tests/index.js
+++ b/tests/index.js
@@ -31,6 +31,7 @@ import './components';
 import './components/area-series-tests';
 import './components/arc-series-tests';
 import './components/bar-series-tests';
+import './components/borders-tests';
 import './components/canvas-component-tests';
 import './components/circular-grid-lines-tests';
 import './components/gradient-tests';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1384,15 +1384,7 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@^1.5.2:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
-  dependencies:
-    inherits "^2.0.3"
-    readable-stream "^2.2.2"
-    typedarray "^0.0.6"
-
-concat-stream@~1.5.0, concat-stream@~1.5.1:
+concat-stream@^1.5.2, concat-stream@~1.5.0, concat-stream@~1.5.1:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.5.2.tgz#708978624d856af41a5a741defdd261da752c266"
   dependencies:
@@ -1591,10 +1583,6 @@ d3-format@1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.2.0.tgz#6b480baa886885d4651dc248a8f4ac9da16db07a"
 
-d3-hexbin@^0.2.1:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/d3-hexbin/-/d3-hexbin-0.2.2.tgz#9c5837dacfd471ab05337a9e91ef10bfc4f98831"
-
 d3-hierarchy@^1.0.3:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/d3-hierarchy/-/d3-hierarchy-1.1.4.tgz#96c3942f3f21cf997a11b4edf00dde2a77b4c6d0"
@@ -1684,15 +1672,6 @@ debug@^2.1.1, debug@^2.2.0, debug@^2.6.0:
 decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
-
-deck.gl@^4.0.0:
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/deck.gl/-/deck.gl-4.0.6.tgz#8c0ccb0eb083fb89285997e54707e7b105f2f114"
-  dependencies:
-    d3-hexbin "^0.2.1"
-    earcut "^2.0.6"
-    gl-matrix "^2.3.2"
-    lodash.flattendeep "^4.4.0"
 
 deep-equal@^1.0.1, deep-equal@~1.0.1:
   version "1.0.1"
@@ -1862,10 +1841,6 @@ duplexer2@^0.1.2, duplexer2@~0.1.0, duplexer2@~0.1.2:
 duplexer@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
-
-earcut@^2.0.6:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/earcut/-/earcut-2.1.1.tgz#157634e5f3ebb42224e475016e86a5b6ce556b45"
 
 ecc-jsbn@~0.1.1:
   version "0.1.1"
@@ -2394,14 +2369,6 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-gl-constants@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/gl-constants/-/gl-constants-1.0.0.tgz#597a504e364750ff50253aa35f8dea7af4a5d233"
-
-gl-matrix@^2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/gl-matrix/-/gl-matrix-2.3.2.tgz#aac808c74af7d5db05fe04cb60ca1a0fcb174d74"
-
 glob-base@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-base/-/glob-base-0.3.0.tgz#dbb164f6221b1c0b1ccf82aea328b497df0ea3c4"
@@ -2645,7 +2612,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@^2.0.1, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
@@ -3147,10 +3114,6 @@ lodash.flatten@^4.2.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
 
-lodash.flattendeep@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
-
 lodash.foreach@^4.3.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
@@ -3224,14 +3187,6 @@ lru-cache@^4.0.1:
   dependencies:
     pseudomap "^1.0.1"
     yallist "^2.0.0"
-
-luma.gl@^3.0.0-beta.11:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/luma.gl/-/luma.gl-3.0.1.tgz#7a41e36467cbf4bcf33aa9caf6c60018e8e7495c"
-  dependencies:
-    gl-constants "^1.0.0"
-    gl-matrix "^2.3.2"
-    webgl-debug "^1.0.2"
 
 map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
@@ -4033,7 +3988,7 @@ readable-stream@^1.0.33, readable-stream@~1.1.9:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.2.6:
+readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.6:
   version "2.2.9"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.9.tgz#cf78ec6f4a6d1eb43d26488cac97f042e74b7fc8"
   dependencies:
@@ -4776,7 +4731,7 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typedarray@^0.0.6, typedarray@~0.0.5:
+typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
@@ -4868,10 +4823,6 @@ vm-browserify@~0.0.1:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-0.0.4.tgz#5d7ea45bbef9e4a6ff65f95438e0a87c357d5a73"
   dependencies:
     indexof "0.0.1"
-
-webgl-debug@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/webgl-debug/-/webgl-debug-1.0.2.tgz#93bac5aed181343a136ad34f249920d3b9ccc69a"
 
 webidl-conversions@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
When domain is set on the XYPlot the series that it contains can sometimes spill over into margin. One potential solution would be to not allow overflow, however this can be limiting because of the relatively flat structure of the XYPlot. The most versatile solution (imo) is to create a Borders component that is directly correlated to the margins of the plot. That way the user can embed it into the structure of their chart however they wish. 

![screen shot 2017-05-08 at 12 31 44 pm](https://cloud.githubusercontent.com/assets/6854312/25821599/a29d8ea2-33ea-11e7-8d64-adc2e78275c4.png)


This addresses issue #407 