### PR TITLE
Allow a markType function to be passed to MarkSeries to enable custom marks

### DIFF
--- a/showcase/plot/scatterplot.js
+++ b/showcase/plot/scatterplot.js
@@ -40,6 +40,7 @@ export default class Example extends React.Component {
         <XAxis />
         <YAxis />
         <MarkSeries
+          {...this.props}
           className="mark-series-example"
           strokeWidth={2}
           sizeRange={[5, 15]}

--- a/src/plot/series/mark-series.js
+++ b/src/plot/series/mark-series.js
@@ -62,10 +62,11 @@ class MarkSeries extends AbstractSeries {
          ref="container"
          transform={`translate(${marginLeft},${marginTop})`}>
         {data.map((d, i) => {
+          const size = sizeFunctor ? sizeFunctor(d) : DEFAULT_SIZE;
+          const x = xFunctor(d);
+          const y = yFunctor(d);
+
           const attrs = {
-            r: sizeFunctor ? sizeFunctor(d) : DEFAULT_SIZE,
-            cx: xFunctor(d),
-            cy: yFunctor(d),
             style: {
               opacity: opacityFunctor ? opacityFunctor(d) : DEFAULT_OPACITY,
               stroke: strokeFunctor && strokeFunctor(d),
@@ -80,9 +81,9 @@ class MarkSeries extends AbstractSeries {
           };
 
           if (typeof markType === 'function') {
-            return markType({attrs, d});
+            return markType({attrs: {...attrs, size, x, y}, d});
           }
-          return <circle {...attrs} />;
+          return <circle {...attrs} cx={x} cy={y} r={size} />;
         })}
       </g>
     );

--- a/src/plot/series/mark-series.js
+++ b/src/plot/series/mark-series.js
@@ -35,7 +35,7 @@ class MarkSeries extends AbstractSeries {
 
   render() {
     const {
-      animation, className, data, marginLeft, marginTop, strokeWidth, style
+      animation, className, data, marginLeft, marginTop, markType, strokeWidth, style
     } = this.props;
     if (!data) {
       return null;
@@ -78,6 +78,10 @@ class MarkSeries extends AbstractSeries {
             onMouseOver: e => this._valueMouseOverHandler(d, e),
             onMouseOut: e => this._valueMouseOutHandler(d, e)
           };
+
+          if (typeof markType === 'function') {
+            return markType({attrs, d});
+          }
           return <circle {...attrs} />;
         })}
       </g>
@@ -88,6 +92,7 @@ class MarkSeries extends AbstractSeries {
 MarkSeries.displayName = 'MarkSeries';
 MarkSeries.propTypes = {
   ...AbstractSeries.propTypes,
+  markType: PropTypes.func,
   strokeWidth: PropTypes.number
 };
 export default MarkSeries;

--- a/tests/components/mark-series-tests.js
+++ b/tests/components/mark-series-tests.js
@@ -16,6 +16,14 @@ test('MarkSeries: Showcase Example - Scatterplot', t => {
   t.end();
 });
 
+test('MarkSeries: Showcase Example - Scatterplot with custom markType', t => {
+  const $ = mount(<Scatterplot markType={({attrs, d}) => <rect /> } />);
+  t.equal($.text(), '1.01.52.02.53.068101214', 'should fine the right text content');
+  t.equal($.find('.rv-xy-plot__series--mark rect').length, 5, 'should find the right number of rect');
+  t.equal($.find('.mark-series-example').length, 1, 'should find the right number of custom named series');
+  t.end();
+});
+
 test('MarkSeries: Showcase Example - Dynamic Crosshair Scatterplot', t => {
   const $ = mount(<DynamicCrosshairScatterplot />);
   // NOTE: Point 0 (P0) and Point 1 (P1) are vertically aligned


### PR DESCRIPTION
Second try at #415. This is a smaller surface area API change but is potentially more powerful.

The interface is still a little tricky since the prop sizes and x and y positions are still tied too closely to circle coordinates (see example), but open to any suggestions.

```js
markType={({attrs: {size, x, y, ...attrs}, d}) => {
  return <rect {...attrs} height={size * 2} width={size * 2} x={x - size} y={y - size} />;
}}
```