### PR TITLE
feat(sankey): add labels support

### DIFF
--- a/docs/markdown/sankey.md
+++ b/docs/markdown/sankey.md
@@ -34,11 +34,14 @@ An array of objects matching the following shape:
 
 ```
 {
+  name: String,
   color: String,
   opacity: Number,
   key: String
 }
 ```
+
+The name will be displayed as a label next to its node.
 
 All these fields are optional.
 
@@ -96,6 +99,12 @@ Defaults to `50`.
 
 Determine if the node selection will be done using a voronoi or not. Although less
 precise, it can help providing a better interactive experience to the user.
+
+Defaults to `false`.
+
+##### hideLabels
+
+Hide the display of the node names if specified to true.
 
 Defaults to `false`.
 

--- a/src/sankey/index.js
+++ b/src/sankey/index.js
@@ -18,6 +18,7 @@ class Sankey extends Component {
     align: 'justify',
     className: '',
     hasVoronoi: false,
+    hideLabels: false,
     layout: 50,
     margin: 20,
     nodePadding: 10,
@@ -32,6 +33,7 @@ class Sankey extends Component {
     className: PropTypes.string,
     hasVoronoi: PropTypes.bool,
     height: PropTypes.number.isRequired,
+    hideLabels: PropTypes.bool,
     layout: PropTypes.number,
     links: PropTypes.arrayOf(PropTypes.shape({
       source: PropTypes.oneOfType([
@@ -60,6 +62,7 @@ class Sankey extends Component {
       className,
       hasVoronoi,
       height,
+      hideLabels,
       layout,
       links,
       margin,
@@ -112,6 +115,18 @@ class Sankey extends Component {
                 fill={node.color || DEFAULT_NODE_COLOR}
                 height={node.dy}
                 width={nWidth} />
+
+              {!hideLabels && node.name && (
+                <text
+                  textAnchor={node.x < width / 2 ? 'start' : 'end'}
+                  dy=".35em"
+                  x={node.x < width / 2 ? nWidth + 10 : -10}
+                  y={node.dy / 2}
+                >
+                  {node.name}
+                </text>
+              )}
+
             </g>
           ))}
 

--- a/tests/components/sankey-tests.js
+++ b/tests/components/sankey-tests.js
@@ -1,6 +1,7 @@
 import test from 'tape';
 import React from 'react';
 import {mount} from 'enzyme';
+
 import Sankey from 'sankey';
 import BasicSankey from '../../showcase/sankey/basic';
 import VoronoiSankey from '../../showcase/sankey/voronoi';
@@ -16,6 +17,23 @@ import {testRenderWithProps} from '../test-utils';
 
 // make sure that the components render at all
 testRenderWithProps(Sankey, SANKEY_PROPS);
+
+test('Sankey: labels', t => {
+  const wrap = mount(
+    <Sankey
+      height={100}
+      width={100}
+      nodes={[{name: 'one'}, {name: 'two'}]}
+      links={[{source: 0, target: 1}]} />
+  );
+
+  t.equal(wrap.find('text').length, 2, 'there should be two node labels');
+  wrap.setProps({hideLabels: true});
+  t.equal(wrap.find('text').length, 0, 'the labels should now be hidden');
+
+  t.end();
+
+});
 
 test('Sankey: Showcase Example - BasicSankey', t => {
   const $ = mount(<BasicSankey />);


### PR DESCRIPTION
![screen shot 2017-05-21 at 12 02 02 am](https://cloud.githubusercontent.com/assets/6033345/26281867/c3092f70-3db8-11e7-941a-888f2fb7e5a1.png)

Display by default the `name` property of the nodes as labels.
Also provides a `hideLabels` property, turned off by default