### PR TITLE
Radar chart

### DIFF
--- a/docs/docs-app/constants/pages.js
+++ b/docs/docs-app/constants/pages.js
@@ -12,6 +12,7 @@ import SunburstSection from '../../../showcase/showcase-sections/sunburst-showca
 import RadialShowcase from '../../../showcase/showcase-sections/radial-showcase';
 import LegendsShowcase from '../../../showcase/showcase-sections/legends-showcase';
 import SankeysShowcase from '../../../showcase/showcase-sections/sankeys-showcase';
+import RadarShowcase from '../../../showcase/showcase-sections/radar-showcase';
 import TreemapShowcase from '../../../showcase/showcase-sections/treemap-showcase';
 import MiscShowcase from '../../../showcase/showcase-sections/misc-showcase';
 
@@ -85,6 +86,13 @@ export const examplePages = generatePath([
         markdown: getDocUrl('examples/showcase.md'),
         pageType: 'example',
         component: TreemapShowcase
+      }
+    }, {
+      name: 'Radar Charts',
+      content: {
+        markdown: getDocUrl('examples/showcase.md'),
+        pageType: 'example',
+        component: RadarShowcase
       }
     }, {
       name: 'Misc',
@@ -333,6 +341,14 @@ export const docPages = generatePath([
         content: {
           markdown: getDocUrl('treemap.md'),
           filename: 'treemap.md',
+          pageType: 'documentation'
+        }
+      },
+      {
+        name: 'Radar Chart',
+        content: {
+          markdown: getDocUrl('radar-chart.md'),
+          filename: 'radar-chart.md',
           pageType: 'documentation'
         }
       },

--- a/docs/markdown/markseries.md
+++ b/docs/markdown/markseries.md
@@ -109,3 +109,7 @@ Type: `function(info)`
 
 #### animation (optional)  
 See the [XYPlot](xy-plot.md)'s `animation` section for more information.
+
+#### className (optional)
+Type: `string`
+Provide an additional class name for the series.

--- a/docs/markdown/radar-chart.md
+++ b/docs/markdown/radar-chart.md
@@ -1,0 +1,107 @@
+# Radar Charts
+
+Radar charts provide a cute method for displaying many variables simultaneously. It allows for rapid at-a-glance comparisons across a bunch of dimensions. These graphics can effectively be used either with several data rows on a single chart (as below) or as a small multiple. For more information, check out the [Wiki](https://en.wikipedia.org/wiki/Radar_chart), it's got some really neat examples.
+
+<!-- INJECT:"BasicRadarChart" -->
+
+Imagine you have a trio of models of cars that you are trying to compare. You're being data driven so you've collected a number of measurements based on a variety of values. You know basic facts about your variables, eg the interior rating a car can have is 7 and the minimum 1. You can use all this information to produce the above chart! Viola! Informed consumer.
+
+<!-- INJECT:"AnimatedRadarChart" -->
+
+Just like every other chart and series RadarChart expects an array of data, each row or object corresponds to a line or polygon (depending on how you have your chart styled). A key caveat for this chart type is that react-vis can not simply infer the variables from each data object that you wish to plot, so we need you to tell us! So enters the domains prop, an array of object specifying the order and behavior of each of the variables. So you have to tell react-vis a little more to get started, but you get a lot more expressiveness. Let's consider some code. You might provide the following object as props to the radar chart:
+
+```javascript
+const RADAR_PROPS = {
+  data: [{
+    explosions: 7,
+    wow: 10,
+    dog: 8,
+    sickMoves: 9,
+    nice: 7
+  }],
+  domains: [
+    {name: 'nice', domain: [0, 100]},
+    {name: 'explosions', domain: [6.9, 7.1]},
+    {name: 'wow', domain: [0, 11]},
+    {name: 'sickMoves', domain: [0, 20]}
+  ],
+  height: 300,
+  width: 400
+};
+```
+
+In such a case, there would be ONE polygon rendered for four variables (nice/explosions/wow/sickMoves), because those values are listed in the domains prop.
+
+
+## API Reference
+
+
+#### data
+Type: `arrayOf(Objects)`
+
+#### domains
+Type: `arrayOf(Objects)`
+The domains allow the user to specify the nature of the variables being plotted. This information is captured in an object formatted like:
+
+```javascript
+PropTypes.shape({
+  name: PropTypes.string.isRequired,
+  domain: PropTypes.arrayOf([PropTypes.number]).isRequired,
+  tickFormat: PropTypes.func
+})
+```
+
+Let's looks at each member of the object
+
+- name: generates a member of a labelSeries that shows at the end of the corresponding axis
+- domain: a pair of numbers that are interpolated between. Setting these values correctly is essential for making your graphic legible! Because it is often the case that there will only be one or two data rows in a radar chart, react-vis requires the user to specify the exact domain for each variable. Without which we would be unable to plot the variables well.
+- tickFormat: allows the user to provide a formatting function for prettifiying the the way that axis interpolates between the domain values.
+
+#### width
+Type: `number`  
+Width of the component.
+
+#### height
+Type: `number`  
+Height of the component.
+
+#### margin (optional)
+Type: `Object`  
+Default: `{left: 40, right: 10, top: 10, bottom: 40}`
+Margin around the chart.
+
+### style (optional)
+Type: `object`
+An object that contains CSS properties with which the axis component can be entirely re-styled.
+As the RadarChart is composite of several composite elements, it is possible to provide style objects for any and all parts of the tree. See [style](style.md)
+Most generally, there are three top level components `axes`, `labels`, and `polygons`. These in turn lead to their corresponding to style objects. As an example, here is the default style object for the RadarChart:
+
+```jsx
+<RadarChart data={mydata} style={{
+  axes: {
+    line: {},
+    ticks: {},
+    text: {}
+  },
+  labels: {
+    fontSize: 10
+  },
+  polygons: {
+    strokeWidth: 0.5,
+    strokeOpacity: 1,
+    fillOpacity: 0.1
+  }
+}}/>
+```
+
+#### animation (optional)
+Type: `boolean|Object`
+Please refer to [Animation](animation.md) doc for more information.
+
+#### className (optional)
+Type: `string`
+Provide an additional class name for the series.
+
+#### colorType (optional)
+Type: `string`
+Specify the type of color scale to be used on the radar chart, please refer to [Scales and data](scales-and-data.md) for more information.

--- a/showcase/index.js
+++ b/showcase/index.js
@@ -76,6 +76,9 @@ import DonutChartExample from './radial-chart/donut-chart';
 import CustomRadiusRadialChart from './radial-chart/custom-radius-radial-chart';
 import ArcSeriesExample from './radial-chart/arc-series-example';
 
+import BasicRadarChart from './radar-chart/basic-radar-chart';
+import AnimatedRadarChart from './radar-chart/animated-radar-chart';
+
 import BasicSunburst from './sunbursts/basic-sunburst';
 import ClockExample from './sunbursts/clock-example';
 import AnimatedSunburst from './sunbursts/animated-sunburst';
@@ -142,6 +145,9 @@ export const showCase = {
   DonutChartExample,
   CustomRadiusRadialChart,
   ArcSeriesExample,
+
+  AnimatedRadarChart,
+  BasicRadarChart,
 
   BasicSankeyExample,
   VoronoiSankeyExample,

--- a/showcase/radar-chart/animated-radar-chart.js
+++ b/showcase/radar-chart/animated-radar-chart.js
@@ -1,0 +1,90 @@
+// Copyright (c) 2016 - 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import React, {Component} from 'react';
+
+import ShowcaseButton from '../showcase-components/showcase-button';
+import RadarChart from 'radar-chart';
+
+const DATA = [{
+  explosions: 7,
+  wow: 10,
+  dog: 8,
+  sickMoves: 9,
+  nice: 7
+}];
+
+const DOMAIN = [
+  {name: 'nice', domain: [0, 100]},
+  {name: 'explosions', domain: [6.9, 7.1]},
+  {name: 'wow', domain: [0, 11]},
+  {name: 'dog', domain: [0, 16]},
+  {name: 'sickMoves', domain: [0, 20]}
+];
+
+function generateData() {
+  return [
+    Object.keys(DATA[0]).reduce((acc, key) => {
+      acc[key] = DATA[0][key] + 5 * (Math.random() - 0.5);
+      return acc;
+    }, {})
+  ];
+}
+
+export default class AnimatedRadar extends Component {
+  state = {
+    data: DATA
+  }
+
+  render() {
+    const {data} = this.state;
+
+    return (
+      <div className="centered-and-flexed">
+        <RadarChart
+          animation
+          data={data}
+          domains={DOMAIN}
+          style={{
+            polygons: {
+              fillOpacity: 0,
+              strokeWidth: 3
+            },
+            axes: {
+              text: {
+                opacity: 0
+              }
+            }
+          }}
+          margin={{
+            left: 30,
+            top: 30,
+            bottom: 40,
+            right: 50
+          }}
+          width={400}
+          height={300} />
+        <ShowcaseButton
+         onClick={() => this.setState({data: generateData()})}
+         buttonContent={'UPDATE DATA'} />
+      </div>
+    );
+  }
+}

--- a/showcase/radar-chart/animated-radar-chart.js
+++ b/showcase/radar-chart/animated-radar-chart.js
@@ -79,7 +79,7 @@ export default class AnimatedRadar extends Component {
             bottom: 40,
             right: 50
           }}
-          tickFormat={t => Number(t).toFixed(3)}
+          tickFormat={t => ''}
           width={400}
           height={300} />
         <ShowcaseButton

--- a/showcase/radar-chart/animated-radar-chart.js
+++ b/showcase/radar-chart/animated-radar-chart.js
@@ -79,6 +79,7 @@ export default class AnimatedRadar extends Component {
             bottom: 40,
             right: 50
           }}
+          tickFormat={t => Number(t).toFixed(3)}
           width={400}
           height={300} />
         <ShowcaseButton

--- a/showcase/radar-chart/basic-radar-chart.js
+++ b/showcase/radar-chart/basic-radar-chart.js
@@ -1,0 +1,48 @@
+// Copyright (c) 2016 - 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import React, {Component} from 'react';
+
+import RadarChart from 'radar-chart';
+
+const DATA = [
+  {name: 'Mercedes', mileage: 7, price: 10, safety: 8, performance: 9, interior: 7, warranty: 7},
+  {name: 'Honda', mileage: 8, price: 6, safety: 9, performance: 6, interior: 3, warranty: 9},
+  {name: 'Chevrolet', mileage: 5, price: 4, safety: 6, performance: 4, interior: 5, warranty: 6}
+];
+
+export default class BasicRadarChart extends Component {
+  render() {
+    return (
+      <RadarChart
+        data={DATA}
+        domains={[
+          {name: 'mileage', domain: [0, 10]},
+          {name: 'price', domain: [2, 16]},
+          {name: 'safety', domain: [5, 10]},
+          {name: 'performance', domain: [0, 10]},
+          {name: 'interior', domain: [0, 7]},
+          {name: 'warranty', domain: [2, 7]}
+        ]}
+        width={400}
+        height={300} />
+    );
+  }
+}

--- a/showcase/showcase-app.js
+++ b/showcase/showcase-app.js
@@ -3,6 +3,7 @@ import AxesShowcase from './showcase-sections/axes-showcase';
 import PlotsShowcase from './showcase-sections/plots-showcase';
 import SunburstSection from './showcase-sections/sunburst-showcase';
 import RadialShowcase from './showcase-sections/radial-showcase';
+import RadarShowcase from './showcase-sections/radar-showcase';
 import LegendsShowcase from './showcase-sections/legends-showcase';
 import SankeysShowcase from './showcase-sections/sankeys-showcase';
 import TreemapShowcase from './showcase-sections/treemap-showcase';
@@ -23,6 +24,7 @@ class App extends Component {
               <li><a href="#plots">Plots</a></li>
               <li><a href="#axes">Axes</a></li>
               <li><a href="#radial-charts">Radial Charts</a></li>
+              <li><a href="#radar-charts">Radar Charts</a></li>
               <li><a href="#treemaps">Treemaps</a></li>
               <li><a href="#legends">Legends</a></li>
               <li><a href="#sunbursts">Sunbursts</a></li>
@@ -35,6 +37,7 @@ class App extends Component {
         <AxesShowcase />
         <MiscShowcase />
         <RadialShowcase />
+        <RadarShowcase />
         <TreemapShowcase />
         <SunburstSection />
         <LegendsShowcase />

--- a/showcase/showcase-sections/radar-showcase.js
+++ b/showcase/showcase-sections/radar-showcase.js
@@ -9,7 +9,9 @@ const {
 
 const RADAR = [{
   name: 'Basic Radar Chart',
-  component: BasicRadarChart
+  component: BasicRadarChart,
+  sourceLink: 'https://github.com/uber/react-vis/blob/master/src/radar-chart/index.js',
+  docsLink: 'http://uber.github.io/react-vis/#/documentation/other-charts/radar-chart'
 }, {
   name: 'Animated Radar Chart',
   component: AnimatedRadarChart

--- a/showcase/showcase-sections/radar-showcase.js
+++ b/showcase/showcase-sections/radar-showcase.js
@@ -1,0 +1,29 @@
+import React, {Component} from 'react';
+
+import {mapSection} from '../showcase-components/showcase-utils';
+import {showCase} from '../index';
+const {
+  AnimatedRadarChart,
+  BasicRadarChart
+} = showCase;
+
+const RADAR = [{
+  name: 'Basic Radar Chart',
+  component: BasicRadarChart
+}, {
+  name: 'Animated Radar Chart',
+  component: AnimatedRadarChart
+}];
+
+class RadarShowcase extends Component {
+  render() {
+    return (
+      <article id="radar-charts">
+        <h1>Radar Chart</h1>
+        {RADAR.map(mapSection)}
+      </article>
+    );
+  }
+}
+
+export default RadarShowcase;

--- a/src/plot/axis/decorative-axis-ticks.js
+++ b/src/plot/axis/decorative-axis-ticks.js
@@ -21,7 +21,20 @@
 import React from 'react';
 import {generatePoints, getAxisAngle} from 'utils/axis-utils';
 
-// TODO WRITE JSDOC
+/**
+ * Generate the actual polygons to be plotted
+ * @param {Object} props
+ - props.animation {Boolean}
+ - props.axisDomain {Array} a pair of values specifying the domain of the axis
+ - props.numberOfTicks{Number} the number of ticks on the axis
+ - props.axisStart {Object} a object specify in cartesian space the the start of the axis
+ example: {x: 0, y: 0}
+ - props.axisEnd {Object} a object specify in cartesian space the the start of the axis
+ - props.tickValue {Func} a formatting function for the tick values
+ - props.tickSize {Number} a pixel size of the axis
+ - props.style {Object} The style object for the axis
+ * @return {Component} the plotted axis
+ */
 export default function decorativeAxisTick(props) {
   const {axisDomain, numberOfTicks, axisStart, axisEnd, tickValue, tickSize, style} = props;
   const {points} = generatePoints({axisStart, axisEnd, numberOfTicks, axisDomain});

--- a/src/plot/axis/decorative-axis.js
+++ b/src/plot/axis/decorative-axis.js
@@ -60,7 +60,7 @@ class DecorativeAxis extends AbstractSeries {
 
     const x = this._getAttributeFunctor('x');
     const y = this._getAttributeFunctor('y');
-    // TODO ADD MORE OPTION CONTROLS FOR AXIS
+
     return (
       <g className={`${predefinedClassName} ${className}`}
          ref="container"

--- a/src/plot/axis/decorative-axis.js
+++ b/src/plot/axis/decorative-axis.js
@@ -24,6 +24,7 @@ import PropTypes from 'prop-types';
 
 import AbstractSeries from 'plot/series/abstract-series';
 import DecorativeAxisTicks from './decorative-axis-ticks';
+import Animation from 'animation';
 
 const predefinedClassName = 'rv-xy-manipulable-axis rv-xy-plot__axis';
 

--- a/src/plot/series/abstract-series.js
+++ b/src/plot/series/abstract-series.js
@@ -58,6 +58,21 @@ const defaultProps = {
 };
 
 class AbstractSeries extends PureComponent {
+  /**
+   * Tells the rest of the world that it requires SVG to work.
+   * @returns {boolean} Result.
+   */
+  static get requiresSVG() {
+    return true;
+  }
+
+  /**
+   * Get a default config for the parent.
+   * @returns {Object} Empty config.
+   */
+  static getParentConfig() {
+    return {};
+  }
 
   constructor(props) {
     super(props);
@@ -151,22 +166,6 @@ class AbstractSeries extends PureComponent {
     if (onSeriesClick) {
       onSeriesClick({event});
     }
-  }
-
-  /**
-   * Tells the rest of the world that it requires SVG to work.
-   * @returns {boolean} Result.
-   */
-  static get requiresSVG() {
-    return true;
-  }
-
-  /**
-   * Get a default config for the parent.
-   * @returns {Object} Empty config.
-   */
-  static getParentConfig() {
-    return {};
   }
 
   /**

--- a/src/radar-chart/index.js
+++ b/src/radar-chart/index.js
@@ -1,0 +1,192 @@
+// Copyright (c) 2016 - 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+import {scaleLinear} from 'd3-scale';
+import {format} from 'd3-format';
+
+import {AnimationPropType} from 'animation';
+import XYPlot from 'plot/xy-plot';
+import {DISCRETE_COLOR_RANGE} from 'theme';
+import {MarginPropType} from 'utils/chart-utils';
+import PolygonSeries from 'plot/series/polygon-series';
+import LabelSeries from 'plot/series/label-series';
+import DecorativeAxis from 'plot/axis/decorative-axis';
+
+const predefinedClassName = 'rv-radar-chart';
+const DEFAULT_FORMAT = format('.2r');
+// TODO add jsdoc
+function getAxes({domains, animation, style}) {
+  return domains.map((domain, index) => {
+    const angle = index / domains.length * Math.PI * 2;
+    const sortedDomain = domain.domain.sort();
+
+    return (<DecorativeAxis
+      animation
+      key={`${index}-axis`}
+      axisStart={{x: 0, y: 0}}
+      axisEnd={{x: Math.cos(angle), y: Math.sin(angle)}}
+      axisDomain={sortedDomain}
+      numberOfTicks={5}
+      tickValue={t => t === sortedDomain[0] ? '' : DEFAULT_FORMAT(t)}
+      style={style.axes}
+      />);
+  });
+}
+
+// TODO add jsdoc
+function getLabels(domains, style) {
+  return domains.map((domain, index) => {
+    // TODO special handling when there is just one domain
+    const angle = index / domains.length * Math.PI * 2;
+    const radius = 1.2;
+    return {
+      x: radius * Math.cos(angle),
+      y: radius * Math.sin(angle),
+      label: domain.name,
+      style
+    };
+  });
+}
+
+// TODO add jsdoc
+function getPolygons({domains, data, animation, style}) {
+  const scales = domains.reduce((acc, domain) => {
+    acc[domain.name] = scaleLinear().domain(domain.domain).range([0, 1]);
+    return acc;
+  }, {});
+
+  return data.map((row, rowIndex) => {
+    const mappedData = domains.map((domain, index) => {
+      const dataPoint = row[domain.name];
+      // error handling if point doesn't exisit
+      const angle = index / domains.length * Math.PI * 2;
+      // dont let the radius become negative
+      const radius = Math.max(scales[domain.name](dataPoint), 0);
+      return {x: radius * Math.cos(angle), y: radius * Math.sin(angle)};
+    });
+    // add className
+    return (<PolygonSeries
+      animation
+      className={`${predefinedClassName}-polygon`}
+      key={`${rowIndex}-polygon`}
+      data={mappedData}
+      style={{
+        stroke: row.color || row.stroke || DISCRETE_COLOR_RANGE[rowIndex],
+        fill: row.color || row.fill || DISCRETE_COLOR_RANGE[rowIndex],
+        ...style.polygons
+      }}
+      />);
+  });
+}
+
+class RadarChart extends Component {
+  render() {
+    const {
+      animation,
+      className,
+      data,
+      domains,
+      height,
+      width,
+      margin,
+      onMouseLeave,
+      onMouseEnter,
+      style
+    } = this.props;
+
+    return (
+      <XYPlot
+        height={height}
+        width={width}
+        margin={margin}
+        dontCheckIfEmpty
+        className={`${className} ${predefinedClassName}`}
+        onMouseLeave={onMouseLeave}
+        onMouseEnter={onMouseEnter}
+        xDomain={[-1, 1]}
+        yDomain={[-1, 1]}>
+        {getAxes({domains, animation, style})
+          .concat(getPolygons({
+            animation,
+            domains,
+            data,
+            style
+          }))
+          .concat(
+            <LabelSeries
+              animation
+              className={`${predefinedClassName}-label`}
+              data={getLabels(domains, style.labels)} />
+          )
+        }
+      </XYPlot>
+    );
+  }
+}
+
+RadarChart.displayName = 'RadarChart';
+RadarChart.propTypes = {
+  animation: AnimationPropType,
+  className: PropTypes.string,
+  colorType: PropTypes.string,
+  data: PropTypes.arrayOf([
+    PropTypes.object
+  ]).isRequired,
+  domains: PropTypes.arrayOf([
+    PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      domain: PropTypes.arrayOf([PropTypes.number]).isRequired,
+      tickFormat: PropTypes.func
+    })
+  ]).isRequired,
+  height: PropTypes.number.isRequired,
+  margin: MarginPropType,
+  onValueClick: PropTypes.func,
+  onValueMouseOver: PropTypes.func,
+  onValueMouseOut: PropTypes.func,
+  style: PropTypes.shape({
+    labels: PropTypes.object
+  }),
+  width: PropTypes.number.isRequired
+};
+RadarChart.defaultProps = {
+  className: '',
+  colorType: 'category',
+  colorRange: DISCRETE_COLOR_RANGE,
+  style: {
+    axes: {
+      line: {},
+      ticks: {},
+      text: {}
+    },
+    labels: {
+      fontSize: 10
+    },
+    polygons: {
+      strokeWidth: 0.5,
+      strokeOpacity: 1,
+      fillOpacity: 0.1
+    }
+  }
+};
+
+export default RadarChart;

--- a/src/radar-chart/index.js
+++ b/src/radar-chart/index.js
@@ -69,7 +69,7 @@ function getAxes(props) {
  * @param {Object} props
  - props.domains {Array} array of object specifying the way each axis is to be plotted
  - props.style {object} style object for just the labels
- * @return {Array} the plotted axis components
+ * @return {Array} the prepped data for the labelSeries
  */
 function getLabels(props) {
   const {domains, style} = props;
@@ -167,6 +167,7 @@ class RadarChart extends Component {
           .concat(
             <LabelSeries
               animation
+              key={className}
               className={`${predefinedClassName}-label`}
               data={getLabels({domains, style: style.labels})} />
           )
@@ -181,16 +182,14 @@ RadarChart.propTypes = {
   animation: AnimationPropType,
   className: PropTypes.string,
   colorType: PropTypes.string,
-  data: PropTypes.arrayOf([
-    PropTypes.object
-  ]).isRequired,
-  domains: PropTypes.arrayOf([
+  data: PropTypes.arrayOf(PropTypes.object).isRequired,
+  domains: PropTypes.arrayOf(
     PropTypes.shape({
       name: PropTypes.string.isRequired,
-      domain: PropTypes.arrayOf([PropTypes.number]).isRequired,
+      domain: PropTypes.arrayOf(PropTypes.number).isRequired,
       tickFormat: PropTypes.func
     })
-  ]).isRequired,
+  ).isRequired,
   height: PropTypes.number.isRequired,
   margin: MarginPropType,
   style: PropTypes.shape({

--- a/src/radar-chart/index.js
+++ b/src/radar-chart/index.js
@@ -39,10 +39,11 @@ const DEFAULT_FORMAT = format('.2r');
  - props.animation {Boolean}
  - props.domains {Array} array of object specifying the way each axis is to be plotted
  - props.style {object} style object for the whole chart
+ - props.tickFormat {Function} formatting function for axes
  * @return {Array} the plotted axis components
  */
 function getAxes(props) {
-  const {animation, domains, style} = props;
+  const {animation, domains, style, tickFormat} = props;
   return domains.map((domain, index) => {
     const angle = index / domains.length * Math.PI * 2;
     const sortedDomain = domain.domain.sort();
@@ -55,7 +56,8 @@ function getAxes(props) {
         axisEnd={{x: Math.cos(angle), y: Math.sin(angle)}}
         axisDomain={sortedDomain}
         numberOfTicks={5}
-        tickValue={t => t === sortedDomain[0] ? '' : DEFAULT_FORMAT(t)}
+        tickValue={t => tickFormat ? tickFormat(t) :
+            t === sortedDomain[0] ? '' : DEFAULT_FORMAT(t)}
         style={style.axes}
         />
     );
@@ -140,6 +142,7 @@ class RadarChart extends Component {
       margin,
       onMouseLeave,
       onMouseEnter,
+      tickFormat,
       style
     } = this.props;
 
@@ -154,7 +157,7 @@ class RadarChart extends Component {
         onMouseEnter={onMouseEnter}
         xDomain={[-1, 1]}
         yDomain={[-1, 1]}>
-        {getAxes({domains, animation, style})
+        {getAxes({domains, animation, style, tickFormat})
           .concat(getPolygons({
             animation,
             domains,
@@ -195,6 +198,7 @@ RadarChart.propTypes = {
     labels: PropTypes.object,
     polygons: PropTypes.object
   }),
+  tickFormat: PropTypes.func,
   width: PropTypes.number.isRequired
 };
 RadarChart.defaultProps = {

--- a/src/radar-chart/index.js
+++ b/src/radar-chart/index.js
@@ -33,29 +33,45 @@ import DecorativeAxis from 'plot/axis/decorative-axis';
 
 const predefinedClassName = 'rv-radar-chart';
 const DEFAULT_FORMAT = format('.2r');
-// TODO add jsdoc
-function getAxes({domains, animation, style}) {
+/**
+ * Generate axes for each of the domains
+ * @param {Object} props
+ - props.animation {Boolean}
+ - props.domains {Array} array of object specifying the way each axis is to be plotted
+ - props.style {object} style object for the whole chart
+ * @return {Array} the plotted axis components
+ */
+function getAxes(props) {
+  const {animation, domains, style} = props;
   return domains.map((domain, index) => {
     const angle = index / domains.length * Math.PI * 2;
     const sortedDomain = domain.domain.sort();
 
-    return (<DecorativeAxis
-      animation
-      key={`${index}-axis`}
-      axisStart={{x: 0, y: 0}}
-      axisEnd={{x: Math.cos(angle), y: Math.sin(angle)}}
-      axisDomain={sortedDomain}
-      numberOfTicks={5}
-      tickValue={t => t === sortedDomain[0] ? '' : DEFAULT_FORMAT(t)}
-      style={style.axes}
-      />);
+    return (
+      <DecorativeAxis
+        animation={animation}
+        key={`${index}-axis`}
+        axisStart={{x: 0, y: 0}}
+        axisEnd={{x: Math.cos(angle), y: Math.sin(angle)}}
+        axisDomain={sortedDomain}
+        numberOfTicks={5}
+        tickValue={t => t === sortedDomain[0] ? '' : DEFAULT_FORMAT(t)}
+        style={style.axes}
+        />
+    );
   });
 }
 
-// TODO add jsdoc
-function getLabels(domains, style) {
+/**
+ * Generate labels for the ends of the axes
+ * @param {Object} props
+ - props.domains {Array} array of object specifying the way each axis is to be plotted
+ - props.style {object} style object for just the labels
+ * @return {Array} the plotted axis components
+ */
+function getLabels(props) {
+  const {domains, style} = props;
   return domains.map((domain, index) => {
-    // TODO special handling when there is just one domain
     const angle = index / domains.length * Math.PI * 2;
     const radius = 1.2;
     return {
@@ -67,8 +83,22 @@ function getLabels(domains, style) {
   });
 }
 
-// TODO add jsdoc
-function getPolygons({domains, data, animation, style}) {
+/**
+ * Generate the actual polygons to be plotted
+ * @param {Object} props
+ - props.animation {Boolean}
+ - props.data {Array} array of object specifying what values are to be plotted
+ - props.domains {Array} array of object specifying the way each axis is to be plotted
+ - props.style {object} style object for the whole chart
+ * @return {Array} the plotted axis components
+ */
+function getPolygons(props) {
+  const {
+    animation,
+    domains,
+    data,
+    style
+  } = props;
   const scales = domains.reduce((acc, domain) => {
     acc[domain.name] = scaleLinear().domain(domain.domain).range([0, 1]);
     return acc;
@@ -83,9 +113,9 @@ function getPolygons({domains, data, animation, style}) {
       const radius = Math.max(scales[domain.name](dataPoint), 0);
       return {x: radius * Math.cos(angle), y: radius * Math.sin(angle)};
     });
-    // add className
+
     return (<PolygonSeries
-      animation
+      animation={animation}
       className={`${predefinedClassName}-polygon`}
       key={`${rowIndex}-polygon`}
       data={mappedData}
@@ -135,7 +165,7 @@ class RadarChart extends Component {
             <LabelSeries
               animation
               className={`${predefinedClassName}-label`}
-              data={getLabels(domains, style.labels)} />
+              data={getLabels({domains, style: style.labels})} />
           )
         }
       </XYPlot>
@@ -160,11 +190,10 @@ RadarChart.propTypes = {
   ]).isRequired,
   height: PropTypes.number.isRequired,
   margin: MarginPropType,
-  onValueClick: PropTypes.func,
-  onValueMouseOver: PropTypes.func,
-  onValueMouseOut: PropTypes.func,
   style: PropTypes.shape({
-    labels: PropTypes.object
+    axes: PropTypes.object,
+    labels: PropTypes.object,
+    polygons: PropTypes.object
   }),
   width: PropTypes.number.isRequired
 };

--- a/src/utils/axis-utils.js
+++ b/src/utils/axis-utils.js
@@ -82,8 +82,8 @@ export function generateFit(axisStart, axisEnd) {
   }
   const slope = (axisStart.y - axisEnd.y) / (axisStart.x - axisEnd.x);
   return {
-    left: Math.min(axisStart.x, axisEnd.x),
-    right: Math.max(axisStart.x, axisEnd.x),
+    left: axisStart.x,
+    right: axisEnd.x,
     // generate the linear projection of the axis direction
     slope,
     offset: axisStart.y - slope * axisStart.x
@@ -106,13 +106,18 @@ export function generatePoints({axisStart, axisEnd, numberOfTicks, axisDomain}) 
   const {left, right, slope, offset} = generateFit(axisStart, axisEnd);
   // construct a linear band of points, then map them
   const pointSlope = (right - left) / (numberOfTicks);
-  const axisScale = scaleLinear().domain([left, right]).range(axisDomain.sort());
+  const axisScale = scaleLinear().domain([left, right]).range(axisDomain);
 
+  const slopeVertical = axisStart.x === axisEnd.x;
   return {
-    slope: axisStart.x === axisEnd.x ? Infinity : slope,
+    slope: slopeVertical ? Infinity : slope,
     points: range(left, right + pointSlope, pointSlope)
-      // TODO this may be wrong for other directions, that remains to be seen
-      .map(val => ({y: val, x: slope * val + offset, text: axisScale(val)}))
+      .map(val => {
+        if (slopeVertical) {
+          return {y: val, x: slope * val + offset, text: axisScale(val)};
+        }
+        return {x: val, y: slope * val + offset, text: axisScale(val)};
+      })
   };
 }
 

--- a/tests/components/decorative-axis-tests.js
+++ b/tests/components/decorative-axis-tests.js
@@ -25,7 +25,7 @@ test('DecorativeAxis: Showcase Example - DecorativeAxisCrissCross', t => {
 test('DecorativeAxis: Showcase Example - ParallelCoordinatesExample', t => {
   const $ = mount(<ParallelCoordinatesExample />);
   t.equal($.text(),
-    '0.04.79.314192328333742473.03.54.04.55.05.56.06.57.07.58.0460420380340300260220180150110680.023466992120140160180210230160020002300270030003400370041004400480051002523212018161513119.78.07071727475767778808182',
+    '0.04.79.314192328333742473.03.54.04.55.05.56.06.57.07.58.0681101501802202603003403804204600.023466992120140160180210230160020002300270030003400370041004400480051008.09.71113151618202123257071727475767778808182',
     'should find the right text content');
   t.equal($.find('.rv-xy-manipulable-axis').length, 7, 'should find the number of axes');
   t.equal($.find('.rv-xy-plot__axis__tick__line').length, 77, 'should find the number of axis ticks');

--- a/tests/components/radar-chart-tests.js
+++ b/tests/components/radar-chart-tests.js
@@ -42,6 +42,6 @@ test('Radar: Showcase Example - Animated Radial ', t => {
   t.equal($.find('.rv-radar-chart').length, 1, 'should find a radar chart');
   t.equal($.find('.rv-xy-manipulable-axis__ticks').length, 5, 'should find the right number of axes');
   t.equal($.find('.rv-radar-chart-polygon').length, 1, 'should find the right number of axes');
-  t.equal($.find('.rv-radar-chart').text(), '0.00020.00040.00060.00080.000100.0006.9006.9406.9807.0207.0607.1000.0002.2004.4006.6008.80011.00013.2000.0003.2006.4009.60012.80016.0000.0004.0008.00012.00016.00020.000niceexplosionswowdogsickMoves', 'should find the right text content');
+  t.equal($.find('.rv-radar-chart').text(), 'niceexplosionswowdogsickMoves', 'should find the right text content');
   t.end();
 });

--- a/tests/components/radar-chart-tests.js
+++ b/tests/components/radar-chart-tests.js
@@ -28,7 +28,7 @@ const RADAR_PROPS = {
 // make sure that the components render at all
 testRenderWithProps(RadialChart, RADAR_PROPS);
 
-test('RadialChart: Showcase Example - Basic Radar Chart', t => {
+test('Radar: Showcase Example - Basic Radar Chart', t => {
   const $ = mount(<BasicRadarChart />);
   t.equal($.find('.rv-radar-chart').length, 1, 'should find a radar chart');
   t.equal($.find('.rv-xy-manipulable-axis__ticks').length, 6, 'should find the right number of axes');
@@ -37,11 +37,11 @@ test('RadialChart: Showcase Example - Basic Radar Chart', t => {
   t.end();
 });
 
-test('RadialChart: Showcase Example - Animated Radial ', t => {
+test('Radar: Showcase Example - Animated Radial ', t => {
   const $ = mount(<AnimatedRadarChart />);
   t.equal($.find('.rv-radar-chart').length, 1, 'should find a radar chart');
   t.equal($.find('.rv-xy-manipulable-axis__ticks').length, 5, 'should find the right number of axes');
   t.equal($.find('.rv-radar-chart-polygon').length, 1, 'should find the right number of axes');
-  t.equal($.find('.rv-radar-chart').text(), '204060801006.97.07.07.17.12.24.46.68.811133.26.49.613164.08.0121620niceexplosionswowdogsickMoves', 'should find the right text content');
+  t.equal($.find('.rv-radar-chart').text(), '0.00020.00040.00060.00080.000100.0006.9006.9406.9807.0207.0607.1000.0002.2004.4006.6008.80011.00013.2000.0003.2006.4009.60012.80016.0000.0004.0008.00012.00016.00020.000niceexplosionswowdogsickMoves', 'should find the right text content');
   t.end();
 });

--- a/tests/components/radar-chart-tests.js
+++ b/tests/components/radar-chart-tests.js
@@ -1,0 +1,47 @@
+import test from 'tape';
+import React from 'react';
+import {mount} from 'enzyme';
+import RadialChart from 'radial-chart';
+import BasicRadarChart from '../../showcase/radar-chart/basic-radar-chart';
+import AnimatedRadarChart from '../../showcase/radar-chart/animated-radar-chart';
+
+import {testRenderWithProps} from '../test-utils';
+
+const RADAR_PROPS = {
+  data: [{
+    explosions: 7,
+    wow: 10,
+    dog: 8,
+    sickMoves: 9,
+    nice: 7
+  }],
+  domains: [
+    {name: 'nice', domain: [0, 100]},
+    {name: 'explosions', domain: [6.9, 7.1]},
+    {name: 'wow', domain: [0, 11]},
+    {name: 'dog', domain: [0, 16]},
+    {name: 'sickMoves', domain: [0, 20]}
+  ],
+  height: 300,
+  width: 400
+};
+// make sure that the components render at all
+testRenderWithProps(RadialChart, RADAR_PROPS);
+
+test('RadialChart: Showcase Example - Basic Radar Chart', t => {
+  const $ = mount(<BasicRadarChart />);
+  t.equal($.find('.rv-radar-chart').length, 1, 'should find a radar chart');
+  t.equal($.find('.rv-xy-manipulable-axis__ticks').length, 6, 'should find the right number of axes');
+  t.equal($.find('.rv-radar-chart-polygon').length, 3, 'should find the right number of axes');
+  t.equal($.find('.rv-radar-chart').text(), '2.04.06.08.01013107.64.82.09.08.07.06.05.02.04.06.08.0101.42.84.25.67.03.04.05.06.07.0mileagepricesafetyperformanceinteriorwarranty', 'should find the right text content');
+  t.end();
+});
+
+test('RadialChart: Showcase Example - Animated Radial ', t => {
+  const $ = mount(<AnimatedRadarChart />);
+  t.equal($.find('.rv-radar-chart').length, 1, 'should find a radar chart');
+  t.equal($.find('.rv-xy-manipulable-axis__ticks').length, 5, 'should find the right number of axes');
+  t.equal($.find('.rv-radar-chart-polygon').length, 1, 'should find the right number of axes');
+  t.equal($.find('.rv-radar-chart').text(), '204060801006.97.07.07.17.12.24.46.68.811133.26.49.613164.08.0121620niceexplosionswowdogsickMoves', 'should find the right text content');
+  t.end();
+});

--- a/tests/index.js
+++ b/tests/index.js
@@ -45,6 +45,7 @@ import './components/line-series-tests';
 import './components/mark-series-tests';
 import './components/polygon-series-tests';
 import './components/radial-tests';
+import './components/radar-chart-tests';
 import './components/rect-series-tests';
 import './components/treemap-tests';
 import './components/sankey-tests';

--- a/tests/utils/axis-utils-tests.js
+++ b/tests/utils/axis-utils-tests.js
@@ -72,12 +72,12 @@ test('axis-utils #generatePoints', t => {
   });
   const expectedResult = {
     points: [
-      {text: 10, x: 1, y: 0},
-      {text: 28, x: 1, y: 0.2},
-      {text: 46, x: 1, y: 0.4},
-      {text: 64, x: 1, y: 0.6000000000000001},
-      {text: 82, x: 1, y: 0.8},
-      {text: 100, x: 1, y: 1}
+      {text: 10, y: 1, x: 0},
+      {text: 28, y: 1, x: 0.2},
+      {text: 46, y: 1, x: 0.4},
+      {text: 64, y: 1, x: 0.6000000000000001},
+      {text: 82, y: 1, x: 0.8},
+      {text: 100, y: 1, x: 1}
     ],
     slope: -0
   };


### PR DESCRIPTION
This PR adds a new basic chart type: the long awaited radar chart (#299). Couple of small things still to do, but i think it should be ready for review.

- [x] Docs
- [x] Address Todos

![radar](https://cloud.githubusercontent.com/assets/6854312/26435970/d7ee5c82-40c7-11e7-9e12-aeff2403780e.gif)

Open to any suggestions on how to improve the API. Right now we simply ask users to provide rows of polygons for the data prop, and row of domains, like so 

```javascript
const RADAR_PROPS = {
  data: [{
    explosions: 7,
    wow: 10,
    dog: 8,
    sickMoves: 9,
    nice: 7
  }],
  domains: [
    {name: 'nice', domain: [0, 100]},
    {name: 'explosions', domain: [6.9, 7.1]},
    {name: 'wow', domain: [0, 11]},
    {name: 'dog', domain: [0, 16]},
    {name: 'sickMoves', domain: [0, 20]}
  ],
  height: 300,
  width: 400
};
```
Where the order of the domains provide the order of the axes. Here are some questions:
- It doesn't accept children but it could! I am unsure if that's a good idea
- I am not sure how tooltip-ing would work, but it's definitely something that should be considered.
- Some radars feature marks on the vertices, should we support that feature? 
