### PR TITLE
Move react/react-dom out of devDeps to peerDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,15 +67,14 @@
     "jsdom": "^9.9.1",
     "node-sass": "^4.2.0",
     "nyc": "^10.0.0",
-    "react": "^15.5.4",
     "react-addons-test-utils": ">=15.4.2",
-    "react-dom": "^15.5.4",
     "stylelint": "^7.7.1",
     "stylelint-config-standard": "^15.0.1",
     "tape": "^4.6.3",
     "uglify-js": "^2.8.22"
   },
   "peerDependencies": {
+    "react-dom": "^15.5.4",
     "react": "0.14.x - 15.x"
   },
   "keywords": [


### PR DESCRIPTION
It is unclear why react/react-dom are listed in devDependencies, and seems to cause errors with multiple react versions when linking react-vis for development. 