### PR TITLE
Allow unanimatedProps passed through Axis.js to support not interpola…

### DIFF
--- a/docs/markdown/animation.md
+++ b/docs/markdown/animation.md
@@ -4,11 +4,11 @@ Animation makes your charts feel physical, it makes them feel alive, shoot it ma
 
 *Booleans*: if true is present then `react-vis` will use the `no-wobble` preset (see below)
 
-*Strings*: React-motion offers several different motion presets that cover most use cases. To access them set your animation prop to one of [noWobble, gentle, wobbly, stiff].
+*Strings*: react-motion offers several different motion presets that cover most use cases. To access them set your animation prop to one of [noWobble, gentle, wobbly, stiff].
 
 <!-- INJECT:"AnimationExample" -->
 
-*Objects*: React-motion expects an object formatting like `{damping: NUMBER, stiffness: NUMBER}`, and if you want to give us an object like that, we will hand it direct to react-motion. You can also pass an object with `{nonAnimatedProps: ['foo', 'bar']}` to prevent those props from being interpolated by d3-interpolator.
+*Objects*: react-motion expects an object formatting like `{damping: NUMBER, stiffness: NUMBER}`, and if you want to give us an object like that, we will hand it direct to react-motion. You can also pass an object with `{nonAnimatedProps: ['foo', 'bar']}` to prevent those props from being interpolated by d3-interpolator.
 
 <!-- INJECT:"TreemapExample" -->
 

--- a/docs/markdown/animation.md
+++ b/docs/markdown/animation.md
@@ -8,7 +8,7 @@ Animation makes your charts feel physical, it makes them feel alive, shoot it ma
 
 <!-- INJECT:"AnimationExample" -->
 
-*Objects*: react-motion expects an object formatting like {damping: NUMBER, stiffness: NUMBER}, and if you want to give us an object like that, we will hand it direct to react-motion.
+*Objects*: React-motion expects an object formatting like `{damping: NUMBER, stiffness: NUMBER}`, and if you want to give us an object like that, we will hand it direct to react-motion. You can also pass an object with `{nonAnimatedProps: ['foo', 'bar']}` to prevent those props from being interpolated by d3-interpolator.
 
 <!-- INJECT:"TreemapExample" -->
 

--- a/src/animation.js
+++ b/src/animation.js
@@ -7,6 +7,7 @@ const ANIMATION_PROPTYPES = PropTypes.oneOfType([
   PropTypes.string,
   PropTypes.shape({
     stiffness: PropTypes.number,
+    nonAnimatedProps: PropTypes.string,
     damping: PropTypes.number
   }),
   PropTypes.bool

--- a/src/plot/axis/axis.js
+++ b/src/plot/axis/axis.js
@@ -141,8 +141,8 @@ class Axis extends PureComponent {
 
 
     if (animation) {
-      const animatedProps = unanimatedProps ? defaultAnimatedProps.filter(
-        prop => unanimatedProps.indexOf(prop) < 0
+      const animatedProps = animation.nonAnimatedProps ? defaultAnimatedProps.filter(
+        prop => animation.nonAnimatedProps.indexOf(prop) < 0
       ) : defaultAnimatedProps
 
       return (

--- a/src/plot/axis/axis.js
+++ b/src/plot/axis/axis.js
@@ -137,13 +137,12 @@ class Axis extends PureComponent {
 
   render() {
 
-    const {animation, unanimatedProps} = this.props;
-
+    const {animation} = this.props;
 
     if (animation) {
       const animatedProps = animation.nonAnimatedProps ? defaultAnimatedProps.filter(
         prop => animation.nonAnimatedProps.indexOf(prop) < 0
-      ) : defaultAnimatedProps
+      ) : defaultAnimatedProps;
 
       return (
         <Animation {...this.props} {...{animatedProps}}>

--- a/src/plot/axis/axis.js
+++ b/src/plot/axis/axis.js
@@ -29,7 +29,7 @@ import AxisLine from './axis-line';
 import AxisTicks from './axis-ticks';
 import AxisTitle from './axis-title';
 
-const animatedProps = [
+const defaultAnimatedProps = [
   'xRange', 'yRange', 'xDomain', 'yDomain',
   'width', 'height', 'marginLeft', 'marginTop', 'marginRight', 'marginBottom',
   'tickSize', 'tickTotal', 'tickSizeInner', 'tickSizeOuter'
@@ -137,9 +137,14 @@ class Axis extends PureComponent {
 
   render() {
 
-    const {animation} = this.props;
+    const {animation, unanimatedProps} = this.props;
+
 
     if (animation) {
+      const animatedProps = unanimatedProps ? defaultAnimatedProps.filter(
+        prop => unanimatedProps.indexOf(prop) < 0
+      ) : defaultAnimatedProps
+
       return (
         <Animation {...this.props} {...{animatedProps}}>
           <Axis {...this.props} animation={null}/>

--- a/src/plot/xy-plot.js
+++ b/src/plot/xy-plot.js
@@ -290,7 +290,7 @@ class XYPlot extends React.Component {
    * @private
    */
   _getClonedChildComponents() {
-    const {animation, unanimatedProps} = this.props;
+    const {animation} = this.props;
     const {scaleMixins, data} = this.state;
     const dimensions = getInnerDimensions(this.props, DEFAULT_MARGINS);
     const children = React.Children.toArray(this.props.children);
@@ -303,18 +303,14 @@ class XYPlot extends React.Component {
         const {seriesIndex} = seriesProps[index];
         dataProps = {data: data[seriesIndex]};
       }
-      let clonedElementProps = {
+      return React.cloneElement(child, {
         animation,
         ...dimensions,
         ...seriesProps[index],
         ...scaleMixins,
         ...child.props,
         ...dataProps
-      }
-      if (unanimatedProps){
-        clonedElementProps.unanimatedProps = unanimatedProps
-      }
-      return React.cloneElement(child, clonedElementProps);
+      });
     });
   }
 

--- a/src/plot/xy-plot.js
+++ b/src/plot/xy-plot.js
@@ -230,6 +230,7 @@ class XYPlot extends React.Component {
 
     const filteredData = data.filter(d => d);
     const allData = [].concat(...filteredData);
+
     const defaultScaleProps = this._getDefaultScaleProps(props);
     const userScaleProps = extractScalePropsFromProps(props, ATTRIBUTES);
     const missingScaleProps = getMissingScaleProps({
@@ -304,8 +305,8 @@ class XYPlot extends React.Component {
         dataProps = {data: data[seriesIndex]};
       }
       return React.cloneElement(child, {
-        animation,
         ...dimensions,
+        animation,
         ...seriesProps[index],
         ...scaleMixins,
         ...child.props,

--- a/src/plot/xy-plot.js
+++ b/src/plot/xy-plot.js
@@ -230,7 +230,6 @@ class XYPlot extends React.Component {
 
     const filteredData = data.filter(d => d);
     const allData = [].concat(...filteredData);
-
     const defaultScaleProps = this._getDefaultScaleProps(props);
     const userScaleProps = extractScalePropsFromProps(props, ATTRIBUTES);
     const missingScaleProps = getMissingScaleProps({
@@ -291,7 +290,7 @@ class XYPlot extends React.Component {
    * @private
    */
   _getClonedChildComponents() {
-    const {animation} = this.props;
+    const {animation, unanimatedProps} = this.props;
     const {scaleMixins, data} = this.state;
     const dimensions = getInnerDimensions(this.props, DEFAULT_MARGINS);
     const children = React.Children.toArray(this.props.children);
@@ -304,14 +303,18 @@ class XYPlot extends React.Component {
         const {seriesIndex} = seriesProps[index];
         dataProps = {data: data[seriesIndex]};
       }
-      return React.cloneElement(child, {
-        ...dimensions,
+      let clonedElementProps = {
         animation,
+        ...dimensions,
         ...seriesProps[index],
         ...scaleMixins,
         ...child.props,
         ...dataProps
-      });
+      }
+      if (unanimatedProps){
+        clonedElementProps.unanimatedProps = unanimatedProps
+      }
+      return React.cloneElement(child, clonedElementProps);
     });
   }
 

--- a/tests/components/animation-tests.js
+++ b/tests/components/animation-tests.js
@@ -18,34 +18,39 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import './setup';
+import test from 'tape';
+import React from 'react';
+import {mount} from 'enzyme';
 
-import './utils/axis-utils-tests';
-import './utils/chart-utils-tests';
-import './utils/data-utils-tests';
-import './utils/react-utils-tests';
-import './utils/scales-utils-tests';
-import './utils/series-utils-tests';
+import Animation from 'animation';
+import Axis from 'plot/axis/axis';
+import AxisTicks from 'plot/axis/axis-ticks';
+import VerticalBarSeries from 'plot/series/vertical-bar-series';
+import XYPlot from 'plot/xy-plot';
 
-import './components';
-import './components/animation-tests';
-import './components/area-series-tests';
-import './components/arc-series-tests';
-import './components/bar-series-tests';
-import './components/borders-tests';
-import './components/canvas-component-tests';
-import './components/circular-grid-lines-tests';
-import './components/decorative-axis-tests';
-import './components/gradient-tests';
-import './components/heatmap-tests';
-import './components/legends-tests';
-import './components/label-series-tests';
-import './components/line-series-tests';
-import './components/mark-series-tests';
-import './components/polygon-series-tests';
-import './components/radial-tests';
-import './components/rect-series-tests';
-import './components/treemap-tests';
-import './components/sankey-tests';
-import './components/sunburst-tests';
-import './components/xy-plot-tests';
+test('Animation interpolates xDomain when specified', t => {
+  const wrapper = mount(
+    <XYPlot
+      width={300}
+      height={300}>
+      <VerticalBarSeries
+        data={[
+          {x: 1, y: 0}
+        ]}/>
+      <Axis
+        attr={'x'}
+        animation={{nonAnimatedProps: ['xDomain']}}
+        xDomain={['Black']}/>
+    </XYPlot>
+  );
+
+  const renderedAnimationWrapper = wrapper.find(Animation);
+
+  t.deepEqual(
+    renderedAnimationWrapper.children(AxisTicks).prop('xDomain'),
+    ['Black'],
+    'Axis interpolates props and passes to Animation'
+  );
+
+  t.end();
+});

--- a/tests/components/xy-plot-tests.js
+++ b/tests/components/xy-plot-tests.js
@@ -116,3 +116,35 @@ test('Render a stacked bar chart with other children', t => {
 
   t.end();
 });
+
+test('Render a bar chart with some nonAnimatedProps', t => {
+  const wrapper = shallow(
+    <XYPlot
+      width={300}
+      height={300}
+      animation={{nonAnimatedProps: ['xDomain']}}>
+      <VerticalBarSeries
+        data={[
+          {x: 1, y: 0}
+        ]}/>
+      <XAxis/>
+    </XYPlot>
+  );
+
+  const renderedXAxisWrapper = wrapper.find(XAxis);
+  const renderedVerticalBarsWrapper = wrapper.find(VerticalBarSeries);
+
+  t.deepEqual(
+    renderedXAxisWrapper.at(0).prop('animation'),
+    {nonAnimatedProps: ['xDomain']},
+    'XAxis has nonAnimatedProps'
+  );
+
+  t.deepEqual(
+    renderedVerticalBarsWrapper.at(0).prop('animation'),
+    {nonAnimatedProps: ['xDomain']},
+    'VerticalBarSeries has nonAnimatedProps'
+  );
+
+  t.end();
+});


### PR DESCRIPTION
Previously, if you had an XYPlot, it would render its axis with hardcoded "animatedProps" meaning if you had anything in your axis-titles they would be ran through the d3-interpolator which is not always intended. 

This PR allows you to pass unanimatedProps and not interpolate some props of an axis via a XYPlot.
