### PR TITLE
RadialChart data PropType=Array

### DIFF
--- a/src/radial-chart/index.js
+++ b/src/radial-chart/index.js
@@ -161,7 +161,7 @@ RadialChart.propTypes = {
   animation: AnimationPropType,
   className: PropTypes.string,
   colorType: PropTypes.string,
-  data: PropTypes.object.isRequired,
+  data: PropTypes.array.isRequired,
   height: PropTypes.number.isRequired,
   labelsAboveChildren: PropTypes.bool,
   margin: MarginPropType,


### PR DESCRIPTION
Removes the JS errors caused on all examples