### PR TITLE
arc-series can receive classNames from RadialChart data

### DIFF
--- a/docs/markdown/radial-chart.md
+++ b/docs/markdown/radial-chart.md
@@ -36,7 +36,7 @@ Or as complex as
   {angle: 2, label: 'Super Custom label', subLabel: 'With annotation', radius: 20},
   {angle: 5, radius: 5, label: 'Alt Label'},
   {angle: 3, radius: 14},
-  {angle: 5, radius: 12, subLabel: 'Sub Label only'}
+  {angle: 5, radius: 12, subLabel: 'Sub Label only', className: 'custom-class'}
 ];
 
 #### angle
@@ -44,15 +44,15 @@ Type: `number`
 The only required property for the data, this determines the angular size of each wedge.
 
 #### radius
-Type: `number`  
+Type: `number`
 The distance between the origin and the outside of the arc. This values is scaled linearly by default
 
 #### label
-Type: `string`  
+Type: `string`
 The label to show next to the wedge.
 
 #### subLabel
-Type: `string`  
+Type: `string`
 The subLabel to show next to the wedge. This can be used for annotations to the top label.
 
 #### color (optional)
@@ -62,6 +62,10 @@ The color of a box in the series. By default the color is interpreted as number 
 #### style (optional)
 Type: `object`
 SVG paths (which is what the arc series is made up of) have numerous manipulable properties, so rather than trying to prescribe all of them as props we offer a port to let you style it for yourself. This overrides the series level version of this property.
+
+#### className (optional)
+Type: `string`
+The className to be added to an individual arc in the series.
 
 ## Api
 
@@ -76,7 +80,7 @@ Please refer to [Animation](animation.md) doc for more information.
 
 ##### className (optional)
 
-Type: `string`  
+Type: `string`
 DOM classNames to be added to the wrapper component.
 
 ##### colorDomain, colorRange, colorType

--- a/showcase/radial-chart/donut-chart.js
+++ b/showcase/radial-chart/donut-chart.js
@@ -37,7 +37,7 @@ export default class SimpleRadialChart extends Component {
         innerRadius={100}
         radius={140}
         data={[
-          {angle: 2},
+          {angle: 2, className: 'custom-class'},
           {angle: 6},
           {angle: 2},
           {angle: 3},

--- a/src/plot/series/arc-series.js
+++ b/src/plot/series/arc-series.js
@@ -149,6 +149,7 @@ class ArcSeries extends AbstractSeries {
           };
           const arcedData = arcBuilder();
           const rowStyle = row.style || {};
+          const seriesClassName = row.className || '';
           return (<path {...{
             style: {
               opacity: opacity && opacity(row),
@@ -161,7 +162,7 @@ class ArcSeries extends AbstractSeries {
             onMouseOver: e => this._valueMouseOverHandler(row, e),
             onMouseOut: e => this._valueMouseOutHandler(row, e),
             key: i,
-            className: arcClassName,
+            className: `${arcClassName} ${seriesClassName}`,
             d: arcedData(arcArg)
           }} />);
         })}

--- a/src/plot/series/arc-series.js
+++ b/src/plot/series/arc-series.js
@@ -149,7 +149,7 @@ class ArcSeries extends AbstractSeries {
           };
           const arcedData = arcBuilder();
           const rowStyle = row.style || {};
-          const seriesClassName = row.className || '';
+          const rowClassName = row.className || '';
           return (<path {...{
             style: {
               opacity: opacity && opacity(row),
@@ -162,7 +162,7 @@ class ArcSeries extends AbstractSeries {
             onMouseOver: e => this._valueMouseOverHandler(row, e),
             onMouseOut: e => this._valueMouseOutHandler(row, e),
             key: i,
-            className: `${arcClassName} ${seriesClassName}`,
+            className: `${arcClassName} ${rowClassName}`,
             d: arcedData(arcArg)
           }} />);
         })}

--- a/tests/components/radial-tests.js
+++ b/tests/components/radial-tests.js
@@ -14,7 +14,7 @@ const RADIAL_PROPS = {
     {angle: 2, label: 'yellow'},
     {angle: 5, label: 'cyan'},
     {angle: 3, label: 'magenta'},
-    {angle: 5, label: 'yellow again'}
+    {angle: 5, label: 'yellow again', className: 'custom-class'}
   ],
   height: 300,
   showLabels: true,
@@ -27,6 +27,7 @@ test('RadialChart: Basic rendering', t => {
   const $ = mount(<RadialChart {...RADIAL_PROPS}/>);
   const pieSlices = $.find('.rv-radial-chart__series--pie__slice').length;
   t.equal(pieSlices, RADIAL_PROPS.data.length, 'should find the same number of slices as data entries');
+  t.equal($.find('.rv-radial-chart__series--pie__slice').at(0).prop('className'), 'rv-radial-chart__series--pie__slice custom-class', 'should have custom class if defined in data entry');
 
   const labels = $.find('.rv-xy-plot__series--label-text').length;
   t.equal(labels, RADIAL_PROPS.data.length, 'should find the right number of label wrappers');


### PR DESCRIPTION
Addresses #444 

Within a `RadialChart`, a custom className for an arc can be passed in through `data`.

```jsx
<RadialChart
  data={[
    {angle: 2, className: 'custom-class'},
    {angle: 1}
  ]}
/>
```