### PR TITLE
Custom marks

### DIFF
--- a/showcase/index.js
+++ b/showcase/index.js
@@ -23,6 +23,7 @@ import LineChart from './plot/line-chart';
 import LineChartCanvas from './plot/line-chart-canvas';
 import LineChartWithStyle from './plot/line-chart-with-style';
 import LineMarkChart from './plot/linemark-chart';
+import CustomLineMarkChart from './plot/custom-linemark-chart';
 import BarChart from './plot/bar-chart';
 import StackedVerticalBarChart from './plot/stacked-vertical-bar-chart';
 import StackedHorizontalBarChart from './plot/stacked-horizontal-bar-chart';
@@ -91,6 +92,7 @@ export const showCase = {
   LineChartCanvas,
   LineChartWithStyle,
   LineMarkChart,
+  CustomLineMarkChart,
   BarChart,
   StackedVerticalBarChart,
   StackedHorizontalBarChart,

--- a/showcase/plot/custom-linemark-chart.js
+++ b/showcase/plot/custom-linemark-chart.js
@@ -1,0 +1,66 @@
+// Copyright (c) 2016 - 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import React from 'react';
+
+import {
+  XYPlot,
+  XAxis,
+  YAxis,
+  VerticalGridLines,
+  HorizontalGridLines,
+  LineMarkSeries
+} from 'index';
+
+export default class Example extends React.Component {
+  render() {
+    return (
+      <XYPlot
+        width={300}
+        height={300}>
+        <VerticalGridLines />
+        <HorizontalGridLines />
+        <XAxis />
+        <YAxis />
+        <LineMarkSeries
+          className="linemark-series-example"
+          style={{
+            stroke: 'white'
+          }}
+          markType={({attrs: {size, x, y, ...attrs}, d}) => {
+            return <rect {...attrs} height={size * 2} width={size * 2} x={x - size} y={y - size} />;
+          }}
+          data={[
+            {x: 1, y: 10},
+            {x: 2, y: 5},
+            {x: 3, y: 15}
+          ]}/>
+        <LineMarkSeries
+          className="linemark-series-example-2"
+          curve={'curveMonotoneX'}
+          data={[
+            {x: 1, y: 11},
+            {x: 1.5, y: 29},
+            {x: 3, y: 7}
+          ]}/>
+      </XYPlot>
+    );
+  }
+}

--- a/showcase/plot/scatterplot.js
+++ b/showcase/plot/scatterplot.js
@@ -40,6 +40,7 @@ export default class Example extends React.Component {
         <XAxis />
         <YAxis />
         <MarkSeries
+          {...this.props}
           className="mark-series-example"
           strokeWidth={2}
           sizeRange={[5, 15]}

--- a/showcase/showcase-sections/plots-showcase.js
+++ b/showcase/showcase-sections/plots-showcase.js
@@ -17,6 +17,7 @@ const {
   LineChartWithStyle,
   LineChartCanvas,
   LineMarkChart,
+  CustomLineMarkChart,
   StackedVerticalBarChart,
   StackedHorizontalBarChart,
   StackedHistogram,
@@ -35,10 +36,14 @@ const PLOTS = [{
   name: 'Line Series with style',
   sourceLink: 'https://github.com/uber/react-vis/blob/master/src/plot/series/line-series.js',
   docsLink: 'http://uber.github.io/react-vis/#/documentation/xy-plot-series/line-series'
-},
-{
+}, {
   component: LineMarkChart,
   name: 'LineMark Series',
+  sourceLink: 'https://github.com/uber/react-vis/blob/master/src/plot/series/line-mark-series.js',
+  docsLink: 'http://uber.github.io/react-vis/#/documentation/xy-plot-series/line-series'
+}, {
+  component: CustomLineMarkChart,
+  name: 'LineMark Series With Custom Mark',
   sourceLink: 'https://github.com/uber/react-vis/blob/master/src/plot/series/line-mark-series.js',
   docsLink: 'http://uber.github.io/react-vis/#/documentation/xy-plot-series/line-series'
 }, {

--- a/src/plot/series/mark-series.js
+++ b/src/plot/series/mark-series.js
@@ -62,10 +62,11 @@ class MarkSeries extends AbstractSeries {
          ref="container"
          transform={`translate(${marginLeft},${marginTop})`}>
         {data.map((d, i) => {
+          const size = sizeFunctor ? sizeFunctor(d) : DEFAULT_SIZE;
+          const x = xFunctor(d);
+          const y = yFunctor(d);
+
           const attrs = {
-            r: sizeFunctor ? sizeFunctor(d) : DEFAULT_SIZE,
-            cx: xFunctor(d),
-            cy: yFunctor(d),
             style: {
               opacity: opacityFunctor ? opacityFunctor(d) : DEFAULT_OPACITY,
               stroke: strokeFunctor && strokeFunctor(d),
@@ -80,9 +81,9 @@ class MarkSeries extends AbstractSeries {
           };
 
           if (typeof markType === 'function') {
-            return markType({attrs, d});
+            return markType({attrs: {...attrs, size, x, y}, d});
           }
-          return <circle {...attrs} />;
+          return <circle {...attrs} cx={x} cy={y} r={size} />;
         })}
       </g>
     );

--- a/src/plot/series/mark-series.js
+++ b/src/plot/series/mark-series.js
@@ -35,7 +35,7 @@ class MarkSeries extends AbstractSeries {
 
   render() {
     const {
-      animation, className, data, marginLeft, marginTop, strokeWidth, style
+      animation, className, data, marginLeft, marginTop, markType, strokeWidth, style
     } = this.props;
     if (!data) {
       return null;
@@ -78,6 +78,10 @@ class MarkSeries extends AbstractSeries {
             onMouseOver: e => this._valueMouseOverHandler(d, e),
             onMouseOut: e => this._valueMouseOutHandler(d, e)
           };
+
+          if (typeof markType === 'function') {
+            return markType({attrs, d});
+          }
           return <circle {...attrs} />;
         })}
       </g>
@@ -88,6 +92,7 @@ class MarkSeries extends AbstractSeries {
 MarkSeries.displayName = 'MarkSeries';
 MarkSeries.propTypes = {
   ...AbstractSeries.propTypes,
+  markType: PropTypes.func,
   strokeWidth: PropTypes.number
 };
 export default MarkSeries;

--- a/tests/components/mark-series-tests.js
+++ b/tests/components/mark-series-tests.js
@@ -18,8 +18,8 @@ test('MarkSeries: Showcase Example - Scatterplot', t => {
 
 test('MarkSeries: Showcase Example - Scatterplot with custom markType', t => {
   const $ = mount(<Scatterplot markType={({attrs, d}) => <rect /> } />);
-  t.equal($.text(), '1.01.52.02.53.068101214', 'should fine the right text content');
-  t.equal($.find('.rv-xy-plot__series--mark rect').length, 5, 'should find the right number of rect');
+  t.equal($.text(), '1.01.52.02.53.068101214', 'should find the right text content');
+  t.equal($.find('.rv-xy-plot__series--mark rect').length, 5, 'should find the right number of rects');
   t.equal($.find('.mark-series-example').length, 1, 'should find the right number of custom named series');
   t.end();
 });

--- a/tests/components/mark-series-tests.js
+++ b/tests/components/mark-series-tests.js
@@ -16,6 +16,14 @@ test('MarkSeries: Showcase Example - Scatterplot', t => {
   t.end();
 });
 
+test('MarkSeries: Showcase Example - Scatterplot with custom markType', t => {
+  const $ = mount(<Scatterplot markType={({attrs, d}) => <rect /> } />);
+  t.equal($.text(), '1.01.52.02.53.068101214', 'should fine the right text content');
+  t.equal($.find('.rv-xy-plot__series--mark rect').length, 5, 'should find the right number of rect');
+  t.equal($.find('.mark-series-example').length, 1, 'should find the right number of custom named series');
+  t.end();
+});
+
 test('MarkSeries: Showcase Example - Dynamic Crosshair Scatterplot', t => {
   const $ = mount(<DynamicCrosshairScatterplot />);
   // NOTE: Point 0 (P0) and Point 1 (P1) are vertically aligned


### PR DESCRIPTION
Try 2 for #415.

The fact that `x` and `y` reference the centroid and `size` references the radius makes the API a little ugly when working with non-circle types, but it can probably be dealt with easily in userland.