### PR TITLE
Modify prop types to remove error

### DIFF
--- a/src/plot/series/abstract-series.js
+++ b/src/plot/series/abstract-series.js
@@ -39,7 +39,7 @@ const propTypes = {
   ...getScalePropTypesByAttribute('color'),
   width: PropTypes.number,
   height: PropTypes.number,
-  data: PropTypes.array,
+  data: PropTypes.arrayOf(PropTypes.object),
   onValueMouseOver: PropTypes.func,
   onValueMouseOut: PropTypes.func,
   onValueClick: PropTypes.func,

--- a/src/plot/series/label-series.js
+++ b/src/plot/series/label-series.js
@@ -92,8 +92,10 @@ LabelSeries.propTypes = {
   allowOffsetToBeReversed: PropTypes.bool,
   className: PropTypes.string,
   data: PropTypes.arrayOf(PropTypes.shape({
-    x: PropTypes.number.isRequired,
-    y: PropTypes.number.isRequired,
+    x: PropTypes.number,
+    y: PropTypes.number,
+    angle: PropTypes.number,
+    radius: PropTypes.number,
     label: PropTypes.string.isRequired,
     xOffset: PropTypes.number,
     yOffset: PropTypes.number,

--- a/src/radial-chart/index.js
+++ b/src/radial-chart/index.js
@@ -161,7 +161,13 @@ RadialChart.propTypes = {
   animation: AnimationPropType,
   className: PropTypes.string,
   colorType: PropTypes.string,
-  data: PropTypes.array.isRequired,
+  data: PropTypes.arrayOf(PropTypes.shape({
+    angle: PropTypes.number.isRequired,
+    className: PropTypes.string,
+    label: PropTypes.string,
+    radius: PropTypes.number,
+    style: PropTypes.object
+  })).isRequired,
   height: PropTypes.number.isRequired,
   labelsAboveChildren: PropTypes.bool,
   margin: MarginPropType,


### PR DESCRIPTION
The LabelSeries used by RadialChart has been throwing console errors because RadialChart reports it's positions in polar coordinates (while LabelSeries was expecting cartesian!). This addresses #451 