### PR TITLE
Intro a startingAngle parameter to the radarChart

### DIFF
--- a/docs/markdown/radar-chart.md
+++ b/docs/markdown/radar-chart.md
@@ -105,3 +105,7 @@ Provide an additional class name for the series.
 #### colorType (optional)
 Type: `string`
 Specify the type of color scale to be used on the radar chart, please refer to [Scales and data](scales-and-data.md) for more information.
+
+#### startingAngle (optional)
+Type: `number`
+The angle of the first axis in radians. Defaults to PI / 2.

--- a/showcase/radar-chart/basic-radar-chart.js
+++ b/showcase/radar-chart/basic-radar-chart.js
@@ -33,6 +33,7 @@ export default class BasicRadarChart extends Component {
     return (
       <RadarChart
         data={DATA}
+        startingAngle={0}
         domains={[
           {name: 'mileage', domain: [0, 10]},
           {name: 'price', domain: [2, 16]},

--- a/src/radar-chart/index.js
+++ b/src/radar-chart/index.js
@@ -40,12 +40,13 @@ const DEFAULT_FORMAT = format('.2r');
  - props.domains {Array} array of object specifying the way each axis is to be plotted
  - props.style {object} style object for the whole chart
  - props.tickFormat {Function} formatting function for axes
+ - props.startingAngle {number} the initial angle offset
  * @return {Array} the plotted axis components
  */
 function getAxes(props) {
-  const {animation, domains, style, tickFormat} = props;
+  const {animation, domains, startingAngle, style, tickFormat} = props;
   return domains.map((domain, index) => {
-    const angle = index / domains.length * Math.PI * 2;
+    const angle = index / domains.length * Math.PI * 2 + startingAngle;
     const sortedDomain = domain.domain.sort();
 
     return (
@@ -68,13 +69,14 @@ function getAxes(props) {
  * Generate labels for the ends of the axes
  * @param {Object} props
  - props.domains {Array} array of object specifying the way each axis is to be plotted
+  - props.startingAngle {number} the initial angle offset
  - props.style {object} style object for just the labels
  * @return {Array} the prepped data for the labelSeries
  */
 function getLabels(props) {
-  const {domains, style} = props;
+  const {domains, startingAngle, style} = props;
   return domains.map((domain, index) => {
-    const angle = index / domains.length * Math.PI * 2;
+    const angle = index / domains.length * Math.PI * 2 + startingAngle;
     const radius = 1.2;
     return {
       x: radius * Math.cos(angle),
@@ -91,6 +93,7 @@ function getLabels(props) {
  - props.animation {Boolean}
  - props.data {Array} array of object specifying what values are to be plotted
  - props.domains {Array} array of object specifying the way each axis is to be plotted
+ - props.startingAngle {number} the initial angle offset
  - props.style {object} style object for the whole chart
  * @return {Array} the plotted axis components
  */
@@ -99,7 +102,8 @@ function getPolygons(props) {
     animation,
     domains,
     data,
-    style
+    style,
+    startingAngle
   } = props;
   const scales = domains.reduce((acc, domain) => {
     acc[domain.name] = scaleLinear().domain(domain.domain).range([0, 1]);
@@ -110,7 +114,7 @@ function getPolygons(props) {
     const mappedData = domains.map((domain, index) => {
       const dataPoint = row[domain.name];
       // error handling if point doesn't exisit
-      const angle = index / domains.length * Math.PI * 2;
+      const angle = index / domains.length * Math.PI * 2 + startingAngle;
       // dont let the radius become negative
       const radius = Math.max(scales[domain.name](dataPoint), 0);
       return {x: radius * Math.cos(angle), y: radius * Math.sin(angle)};
@@ -144,6 +148,7 @@ class RadarChart extends Component {
       onMouseLeave,
       onMouseEnter,
       tickFormat,
+      startingAngle,
       style
     } = this.props;
 
@@ -158,12 +163,12 @@ class RadarChart extends Component {
         onMouseEnter={onMouseEnter}
         xDomain={[-1, 1]}
         yDomain={[-1, 1]}>
-        {children}
-        {getAxes({domains, animation, style, tickFormat})
+        {getAxes({domains, animation, startingAngle, style, tickFormat})
           .concat(getPolygons({
             animation,
             domains,
             data,
+            startingAngle,
             style
           }))
           .concat(
@@ -171,7 +176,7 @@ class RadarChart extends Component {
               animation
               key={className}
               className={`${predefinedClassName}-label`}
-              data={getLabels({domains, style: style.labels})} />
+              data={getLabels({domains, style: style.labels, startingAngle})} />
           )
         }
       </XYPlot>
@@ -194,6 +199,7 @@ RadarChart.propTypes = {
   ).isRequired,
   height: PropTypes.number.isRequired,
   margin: MarginPropType,
+  startingAngle: PropTypes.number,
   style: PropTypes.shape({
     axes: PropTypes.object,
     labels: PropTypes.object,
@@ -206,6 +212,7 @@ RadarChart.defaultProps = {
   className: '',
   colorType: 'category',
   colorRange: DISCRETE_COLOR_RANGE,
+  startingAngle: Math.PI / 2,
   style: {
     axes: {
       line: {},

--- a/src/radar-chart/index.js
+++ b/src/radar-chart/index.js
@@ -163,6 +163,7 @@ class RadarChart extends Component {
         onMouseEnter={onMouseEnter}
         xDomain={[-1, 1]}
         yDomain={[-1, 1]}>
+        {children}
         {getAxes({domains, animation, startingAngle, style, tickFormat})
           .concat(getPolygons({
             animation,


### PR DESCRIPTION
This PR adds a new prop to radar chart, startingAngle. Like the name suggests it allows the user to specify what the initial angle for the first axis is. Addresses #469 


![screen shot 2017-06-26 at 3 45 01 pm](https://user-images.githubusercontent.com/6854312/27563434-7ceaf65a-5a86-11e7-87f7-6171d96aa254.png)
