### PR TITLE
Allow radar chart to accept children

### DIFF
--- a/docs/markdown/radar-chart.md
+++ b/docs/markdown/radar-chart.md
@@ -30,7 +30,7 @@ const RADAR_PROPS = {
 };
 ```
 
-In such a case, there would be ONE polygon rendered for four variables (nice/explosions/wow/sickMoves), because those values are listed in the domains prop.
+In such a case, there would be ONE polygon rendered for four variables (nice/explosions/wow/sickMoves), because those values are listed in the domains prop. The radar chart accepts children if you wish to provide additional components, such as CircularGridLines.
 
 
 ## API Reference

--- a/showcase/radar-chart/animated-radar-chart.js
+++ b/showcase/radar-chart/animated-radar-chart.js
@@ -22,6 +22,7 @@ import React, {Component} from 'react';
 
 import ShowcaseButton from '../showcase-components/showcase-button';
 import RadarChart from 'radar-chart';
+import CircularGridLines from 'plot/circular-grid-lines';
 
 const DATA = [{
   explosions: 7,
@@ -81,7 +82,9 @@ export default class AnimatedRadar extends Component {
           }}
           tickFormat={t => ''}
           width={400}
-          height={300} />
+          height={300} >
+          <CircularGridLines tickValues={[...new Array(10)].map((v, i) => i / 10 - 1)}/>
+        </RadarChart>
         <ShowcaseButton
          onClick={() => this.setState({data: generateData()})}
          buttonContent={'UPDATE DATA'} />

--- a/src/radar-chart/index.js
+++ b/src/radar-chart/index.js
@@ -135,6 +135,7 @@ class RadarChart extends Component {
     const {
       animation,
       className,
+      children,
       data,
       domains,
       height,
@@ -157,6 +158,7 @@ class RadarChart extends Component {
         onMouseEnter={onMouseEnter}
         xDomain={[-1, 1]}
         yDomain={[-1, 1]}>
+        {children}
         {getAxes({domains, animation, style, tickFormat})
           .concat(getPolygons({
             animation,

--- a/tests/components/radar-chart-tests.js
+++ b/tests/components/radar-chart-tests.js
@@ -43,5 +43,6 @@ test('Radar: Showcase Example - Animated Radial ', t => {
   t.equal($.find('.rv-xy-manipulable-axis__ticks').length, 5, 'should find the right number of axes');
   t.equal($.find('.rv-radar-chart-polygon').length, 1, 'should find the right number of axes');
   t.equal($.find('.rv-radar-chart').text(), 'niceexplosionswowdogsickMoves', 'should find the right text content');
+  t.equal($.find('.rv-xy-plot__circular-grid-lines__line').length, 10, 'should find the correct number of rings');
   t.end();
 });


### PR DESCRIPTION
This PR enables the radar chart to accept children, this can be useful for adding axes, as below.

![Uploading Screen Shot 2017-06-26 at 3.55.41 PM.png…]()


Addresses #470 
