### PR TITLE
Enforce a hierarchy of tickFormats

### DIFF
--- a/docs/markdown/radar-chart.md
+++ b/docs/markdown/radar-chart.md
@@ -105,3 +105,7 @@ Provide an additional class name for the series.
 #### colorType (optional)
 Type: `string`
 Specify the type of color scale to be used on the radar chart, please refer to [Scales and data](scales-and-data.md) for more information.
+
+#### tickFormat (optional)
+Type: 'function'
+Specify the tick format for all axes. Will be over-ridden by tickFormats specified on single domains.

--- a/showcase/radar-chart/basic-radar-chart.js
+++ b/showcase/radar-chart/basic-radar-chart.js
@@ -19,6 +19,7 @@
 // THE SOFTWARE.
 
 import React, {Component} from 'react';
+import {format} from 'd3-format';
 
 import RadarChart from 'radar-chart';
 
@@ -28,14 +29,18 @@ const DATA = [
   {name: 'Chevrolet', mileage: 5, price: 4, safety: 6, performance: 4, interior: 5, warranty: 6}
 ];
 
+const basicFormat = format('.2r');
+const wideFormat = format('.3r');
+
 export default class BasicRadarChart extends Component {
   render() {
     return (
       <RadarChart
         data={DATA}
+        tickFormat={t => wideFormat(t)}
         domains={[
           {name: 'mileage', domain: [0, 10]},
-          {name: 'price', domain: [2, 16]},
+          {name: 'price', domain: [2, 16], tickFormat: t => `$${basicFormat(t)}`},
           {name: 'safety', domain: [5, 10]},
           {name: 'performance', domain: [0, 10]},
           {name: 'interior', domain: [0, 7]},

--- a/src/radar-chart/index.js
+++ b/src/radar-chart/index.js
@@ -48,6 +48,10 @@ function getAxes(props) {
     const angle = index / domains.length * Math.PI * 2;
     const sortedDomain = domain.domain.sort();
 
+    const domainTickFormat = t =>
+      domain.tickFormat ? domain.tickFormat(t) :
+      tickFormat ? tickFormat(t) :
+      t === sortedDomain[0] ? '' : DEFAULT_FORMAT(t);
     return (
       <DecorativeAxis
         animation={animation}
@@ -56,8 +60,7 @@ function getAxes(props) {
         axisEnd={{x: Math.cos(angle), y: Math.sin(angle)}}
         axisDomain={sortedDomain}
         numberOfTicks={5}
-        tickValue={t => tickFormat ? tickFormat(t) :
-            t === sortedDomain[0] ? '' : DEFAULT_FORMAT(t)}
+        tickValue={domainTickFormat}
         style={style.axes}
         />
     );

--- a/tests/components/radar-chart-tests.js
+++ b/tests/components/radar-chart-tests.js
@@ -33,7 +33,7 @@ test('Radar: Showcase Example - Basic Radar Chart', t => {
   t.equal($.find('.rv-radar-chart').length, 1, 'should find a radar chart');
   t.equal($.find('.rv-xy-manipulable-axis__ticks').length, 6, 'should find the right number of axes');
   t.equal($.find('.rv-radar-chart-polygon').length, 3, 'should find the right number of axes');
-  t.equal($.find('.rv-radar-chart').text(), '2.04.06.08.01013107.64.82.09.08.07.06.05.02.04.06.08.0101.42.84.25.67.03.04.05.06.07.0mileagepricesafetyperformanceinteriorwarranty', 'should find the right text content');
+  t.equal($.find('.rv-radar-chart').text(), '0.002.004.006.008.0010.0$16$13$10$7.6$4.8$2.010.09.008.007.006.005.000.002.004.006.008.0010.00.001.402.804.205.607.002.003.004.005.006.007.00mileagepricesafetyperformanceinteriorwarranty', 'should find the right text content');
   t.end();
 });
 


### PR DESCRIPTION
This PR ensures that tickFormat can be specified at any level in the Radar chart. Addresses #468 