### PR TITLE
Dont sort radar domains

### DIFF
--- a/docs/markdown/radar-chart.md
+++ b/docs/markdown/radar-chart.md
@@ -98,6 +98,11 @@ Most generally, there are three top level components `axes`, `labels`, and `poly
 Type: `boolean|Object`
 Please refer to [Animation](animation.md) doc for more information.
 
+#### hideInnerMostValues (optional)
+Type: `boolean`
+defaults to true
+Whether or not to hide the inner most tick values of the radar chart. This attempts to ensure that the ticks do not run over each other.
+
 #### className (optional)
 Type: `string`
 Provide an additional class name for the series.

--- a/showcase/radar-chart/basic-radar-chart.js
+++ b/showcase/radar-chart/basic-radar-chart.js
@@ -45,7 +45,7 @@ export default class BasicRadarChart extends Component {
           {name: 'safety', domain: [5, 10]},
           {name: 'performance', domain: [0, 10]},
           {name: 'interior', domain: [0, 7]},
-          {name: 'warranty', domain: [2, 7]}
+          {name: 'warranty', domain: [10, 2]}
         ]}
         width={400}
         height={300} />

--- a/tests/components/radar-chart-tests.js
+++ b/tests/components/radar-chart-tests.js
@@ -33,7 +33,7 @@ test('Radar: Showcase Example - Basic Radar Chart', t => {
   t.equal($.find('.rv-radar-chart').length, 1, 'should find a radar chart');
   t.equal($.find('.rv-xy-manipulable-axis__ticks').length, 6, 'should find the right number of axes');
   t.equal($.find('.rv-radar-chart-polygon').length, 3, 'should find the right number of axes');
-  t.equal($.find('.rv-radar-chart').text(), '0.002.004.006.008.0010.0$16$13$10$7.6$4.8$2.010.09.008.007.006.005.000.002.004.006.008.0010.00.001.402.804.205.607.002.003.004.005.006.007.00mileagepricesafetyperformanceinteriorwarranty', 'should find the right text content');
+  t.equal($.find('.rv-radar-chart').text(), '2.004.006.008.0010.0$4.8$7.6$10$13$166.007.008.009.0010.02.004.006.008.0010.01.402.804.205.607.008.406.805.203.602.00mileagepricesafetyperformanceinteriorwarranty', 'should find the right text content');
   t.end();
 });
 


### PR DESCRIPTION
Previously we were pre-sorting the domains for the decorative-axes. This had the effect that half of the axes would be weirdly labeled. The radar chart should now respect the prescribed domain.

![screen shot 2017-06-29 at 5 09 11 pm](https://user-images.githubusercontent.com/6854312/27715707-d5bfab72-5ced-11e7-849a-9d9443e4de05.png)

(Note that the warranty axis is intentionally flipped, to show that order matter). This addressed #477 