### PR TITLE
Arc series reporting incorrect mouse over values

### DIFF
--- a/docs/markdown/hint.md
+++ b/docs/markdown/hint.md
@@ -11,6 +11,13 @@
 </Hint>
 ```
 
+Hints can be placed in two ways
+a) around a data point in one of four quadrants (imagine the point bisected
+   by two axes -vertical, horizontal- creating 4 quadrants around a data
+   point).
+b) Pin to an edge of chart/plot area and position along that edge
+   using data point's other dimension value.
+
 #### value
 Type: `Object`
 The data point to show the value at. Hint component will automatically find the place where the data point is and put the hint there.

--- a/showcase/index.js
+++ b/showcase/index.js
@@ -116,6 +116,7 @@ import AnimatedRadarChart from './radar-chart/animated-radar-chart';
 import BasicSunburst from './sunbursts/basic-sunburst';
 import ClockExample from './sunbursts/clock-example';
 import AnimatedSunburst from './sunbursts/animated-sunburst';
+import SunburstWithTooltips from './sunbursts/sunburst-with-tooltips';
 
 import BasicSankeyExample from './sankey/basic';
 import VoronoiSankeyExample from './sankey/voronoi';
@@ -199,9 +200,10 @@ export const showCase = {
   SimpleTreemap,
   TreemapExample,
 
+  AnimatedSunburst,
   BasicSunburst,
   ClockExample,
-  AnimatedSunburst,
+  SunburstWithTooltips,
 
   SimpleRadialChart,
   DonutChartExample,

--- a/showcase/showcase-sections/sunburst-showcase.js
+++ b/showcase/showcase-sections/sunburst-showcase.js
@@ -6,7 +6,8 @@ const {
   AnimatedSunburst,
   ArcSeriesExample,
   BasicSunburst,
-  ClockExample
+  ClockExample,
+  SunburstWithTooltips
 } = showCase;
 
 const SUNBURSTS = [{
@@ -25,6 +26,9 @@ const SUNBURSTS = [{
 }, {
   name: 'Animated Sunburst',
   component: AnimatedSunburst
+}, {
+  name: 'Sunburst with tooltips',
+  component: SunburstWithTooltips
 }];
 
 class SunburstSection extends Component {

--- a/showcase/sunbursts/sunburst-with-tooltips.js
+++ b/showcase/sunbursts/sunburst-with-tooltips.js
@@ -56,9 +56,7 @@ const boxStyle = {height: '10px', width: '10px'};
 
 function buildValue(hoveredCell) {
   const {radius, angle, angle0} = hoveredCell;
-  // d3 insists on starting at 12 oclock and moving clockwise, rather than 3 oclock
-  // and moving counter clockwise
-  const truedAngle = -1 * (angle + angle0) / 2 + Math.PI / 2;
+  const truedAngle = (angle + angle0) / 2;
   return {
     x: radius * Math.cos(truedAngle),
     y: radius * Math.sin(truedAngle)
@@ -72,23 +70,21 @@ export default class SunburstWithTooltips extends React.Component {
   render() {
     const {hoveredCell} = this.state;
     return (
-      <div className="sunburst-with-tooltips-example-wrapper">
-        <Sunburst
-          data={DATA}
-          style={{stroke: '#fff'}}
-          onValueMouseOver={v => this.setState({hoveredCell: v.x && v.y ? v : false})}
-          onValueMouseOut={v => this.setState({hoveredCell: false})}
-          height={300}
-          margin={{top: 50, bottom: 50, left: 50, right: 50}}
-          width={350}>
-          {hoveredCell ? <Hint value={buildValue(hoveredCell)}>
-            <div style={tipStyle}>
-              <div style={{...boxStyle, background: hoveredCell.color}}/>
-              {hoveredCell.color}
-            </div>
-          </ Hint> : null}
-        </Sunburst>
-      </div>
+      <Sunburst
+        data={DATA}
+        style={{stroke: '#fff'}}
+        onValueMouseOver={v => this.setState({hoveredCell: v.x && v.y ? v : false})}
+        onValueMouseOut={v => this.setState({hoveredCell: false})}
+        height={300}
+        margin={{top: 50, bottom: 50, left: 50, right: 50}}
+        width={350}>
+        {hoveredCell ? <Hint value={buildValue(hoveredCell)}>
+          <div style={tipStyle}>
+            <div style={{...boxStyle, background: hoveredCell.color}}/>
+            {hoveredCell.color}
+          </div>
+        </ Hint> : null}
+      </Sunburst>
     );
   }
 

--- a/showcase/sunbursts/sunburst-with-tooltips.js
+++ b/showcase/sunbursts/sunburst-with-tooltips.js
@@ -1,0 +1,95 @@
+// Copyright (c) 2016 - 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import React from 'react';
+
+import {
+  Hint,
+  Sunburst
+} from 'index';
+
+import {
+  EXTENDED_DISCRETE_COLOR_RANGE
+} from 'theme';
+
+const DATA = {
+  children: [
+    {children: [
+      {size: 1, children: [], color: EXTENDED_DISCRETE_COLOR_RANGE[1]},
+      {size: 1, children: [], color: EXTENDED_DISCRETE_COLOR_RANGE[2]}
+    ], color: EXTENDED_DISCRETE_COLOR_RANGE[3]},
+    {size: 1, children: [], color: EXTENDED_DISCRETE_COLOR_RANGE[4]},
+    {size: 1, children: [], color: EXTENDED_DISCRETE_COLOR_RANGE[5]},
+    {size: 1, children: [], color: EXTENDED_DISCRETE_COLOR_RANGE[6]},
+    {children: [
+      {size: 1, children: [], color: EXTENDED_DISCRETE_COLOR_RANGE[7]},
+      {size: 1, children: [], color: EXTENDED_DISCRETE_COLOR_RANGE[8]}
+    ], color: EXTENDED_DISCRETE_COLOR_RANGE[9]}
+  ]
+};
+
+const tipStyle = {
+  display: 'flex',
+  color: '#fff',
+  background: '#000',
+  alignItems: 'center',
+  padding: '5px'
+};
+const boxStyle = {height: '10px', width: '10px'};
+
+function buildValue(hoveredCell) {
+  const {radius, angle, angle0} = hoveredCell;
+  // d3 insists on starting at 12 oclock and moving clockwise, rather than 3 oclock
+  // and moving counter clockwise
+  const truedAngle = -1 * (angle + angle0) / 2 + Math.PI / 2;
+  return {
+    x: radius * Math.cos(truedAngle),
+    y: radius * Math.sin(truedAngle)
+  };
+}
+
+export default class SunburstWithTooltips extends React.Component {
+  state = {
+    hoveredCell: false
+  }
+  render() {
+    const {hoveredCell} = this.state;
+    return (
+      <div className="sunburst-with-tooltips-example-wrapper">
+        <Sunburst
+          data={DATA}
+          style={{stroke: '#fff'}}
+          onValueMouseOver={v => this.setState({hoveredCell: v.x && v.y ? v : false})}
+          onValueMouseOut={v => this.setState({hoveredCell: false})}
+          height={300}
+          margin={{top: 50, bottom: 50, left: 50, right: 50}}
+          width={350}>
+          {hoveredCell ? <Hint value={buildValue(hoveredCell)}>
+            <div style={tipStyle}>
+              <div style={{...boxStyle, background: hoveredCell.color}}/>
+              {hoveredCell.color}
+            </div>
+          </ Hint> : null}
+        </Sunburst>
+      </div>
+    );
+  }
+
+}

--- a/src/plot/series/arc-series.js
+++ b/src/plot/series/arc-series.js
@@ -44,6 +44,27 @@ const defaultProps = {
   style: {}
 };
 
+/**
+ * Prepare the internal representation of row for real use.
+ * This is necessary because d3 insists on starting at 12 oclock and moving
+ * clockwise, rather than starting at 3 oclock and moving counter clockwise
+ * as one might expect from polar
+ * @param {Object} row - coordinate object to be modifed
+ * @return {Object} angle corrected object
+ */
+function modifyRow(row) {
+  const {radius, angle, angle0} = row;
+  const truedAngle = -1 * angle + Math.PI / 2;
+  const truedAngle0 = -1 * angle0 + Math.PI / 2;
+  return {
+    ...row,
+    x: radius * Math.cos(truedAngle),
+    y: radius * Math.sin(truedAngle),
+    angle: truedAngle,
+    angle0: truedAngle0
+  };
+}
+
 class ArcSeries extends AbstractSeries {
   constructor(props) {
     super(props);
@@ -158,9 +179,9 @@ class ArcSeries extends AbstractSeries {
               ...style,
               ...rowStyle
             },
-            onClick: e => this._valueClickHandler(row, e),
-            onMouseOver: e => this._valueMouseOverHandler(row, e),
-            onMouseOut: e => this._valueMouseOutHandler(row, e),
+            onClick: e => this._valueClickHandler(modifyRow(row), e),
+            onMouseOver: e => this._valueMouseOverHandler(modifyRow(row), e),
+            onMouseOut: e => this._valueMouseOutHandler(modifyRow(row), e),
             key: i,
             className: `${arcClassName} ${rowClassName}`,
             d: arcedData(arcArg)

--- a/tests/components/radial-tests.js
+++ b/tests/components/radial-tests.js
@@ -55,7 +55,7 @@ test('RadialChart: Showcase Example - DonutChart', t => {
   t.equal($.find('.rv-xy-plot__series--label-text').length, 0, 'should find no label wrappers, as labels is turned off');
   t.equal($.text(), '', 'should find no text');
   $.find('.rv-radial-chart__series--pie__slice').at(1).simulate('mouseOver');
-  t.equal($.text(), 'angle: 5.834386356666759angle0: 4.487989505128276radius0: 0radius: 1color: 1x: 0.900968867902419y: -0.43388373911755834', 'should find appropriate hover text');
+  t.equal($.text(), 'angle: -4.263590029871862angle0: -2.9171931783333793radius0: 0radius: 1color: 1x: -0.4338837391175583y: 0.900968867902419', 'should find appropriate hover text');
   t.end();
 });
 

--- a/tests/components/sunburst-tests.js
+++ b/tests/components/sunburst-tests.js
@@ -3,6 +3,7 @@ import React from 'react';
 import {mount} from 'enzyme';
 import Sunburst from 'sunburst';
 import BasicSunburst from '../../showcase/sunbursts/basic-sunburst';
+import SunburstWithTooltips from '../../showcase/sunbursts/sunburst-with-tooltips';
 
 import {testRenderWithProps} from '../test-utils';
 
@@ -72,5 +73,14 @@ test('Sunburst: Flare Demo', t => {
   t.deepEqual($.state().pathValue, false, 'should initially find no hover path');
   $.find('.rv-xy-plot__series--arc path').at(200).simulate('mouseover');
   t.deepEqual($.state().pathValue, 'root > vis > events > DataEvent', 'should find the correct path hovered');
+  t.end();
+});
+
+test('Sunburst: SunburstWithTooltips', t => {
+  const $ = mount(<SunburstWithTooltips />);
+  t.equal($.find('.rv-xy-plot__series--arc path').length, 10, 'should find the right number of children');
+  $.find('.rv-xy-plot__series--arc path').at(1).simulate('mouseOver');
+  t.equal($.text(), '#FF991F', 'should find appropriate hover text');
+
   t.end();
 });


### PR DESCRIPTION
An unfortunate fact about life is that d3's polar coordinate system is not the same as the usual polar coordinate system. Specifically, d3 does clockwise starting at 12, while convention goes counter clockwise starting at 3. This difference caused frequent mis-reporting of mouseover values for charts that made use of the arc-series. This PR adds assurance that the number reported onMouseOver/onMouseOut/onClick is the correct one.

Before
![screen shot 2017-06-30 at 1 50 41 pm](https://user-images.githubusercontent.com/6854312/27753603-22c19d56-5d9b-11e7-9ca3-9b0df0190e39.png)

After
![screen shot 2017-06-30 at 1 50 21 pm](https://user-images.githubusercontent.com/6854312/27753602-22b99066-5d9b-11e7-993e-c498399a0f4f.png)

This bug was not that noticeable on radial charts (see above), though it was there. It was significantly more pronounced on sunbursts. The new example I added to show how to use tooltips on sunbursts shows the a good way to deal with this:

![screen shot 2017-06-30 at 1 53 51 pm](https://user-images.githubusercontent.com/6854312/27753732-a29eb680-5d9b-11e7-82a9-0e1ba13ad1a4.png)

This addresses #483 