### PR TITLE
Radar center label text by default

### DIFF
--- a/showcase/radar-chart/animated-radar-chart.js
+++ b/showcase/radar-chart/animated-radar-chart.js
@@ -72,6 +72,9 @@ export default class AnimatedRadar extends Component {
               text: {
                 opacity: 0
               }
+            },
+            labels: {
+              textAnchor: 'middle'
             }
           }}
           margin={{

--- a/src/radar-chart/index.js
+++ b/src/radar-chart/index.js
@@ -245,7 +245,8 @@ RadarChart.defaultProps = {
       text: {}
     },
     labels: {
-      fontSize: 10
+      fontSize: 10,
+      textAnchor: 'middle'
     },
     polygons: {
       strokeWidth: 0.5,


### PR DESCRIPTION
Before:
<img width="535" alt="screen shot 2017-06-30 at 2 00 29 pm" src="https://user-images.githubusercontent.com/3478203/27754907-b84416fa-5da1-11e7-97d6-5b68b2228a06.png">
After:
<img width="548" alt="screen shot 2017-06-30 at 2 10 35 pm" src="https://user-images.githubusercontent.com/3478203/27754914-c1adf616-5da1-11e7-9730-2bb64b37ce77.png">
