### PR TITLE
fixes issue #492

### DIFF
--- a/showcase/plot/histogram.js
+++ b/showcase/plot/histogram.js
@@ -46,7 +46,7 @@ export default class Example extends React.Component {
   render() {
     return (
       <XYPlot
-        xDomain={[timestamp, timestamp + 30 * ONE_DAY]}
+        xDomain={[timestamp - 2 * ONE_DAY, timestamp + 30 * ONE_DAY]}
         yDomain={[0.1, 2.1]}
         xType="time"
         width={300}

--- a/showcase/plot/stacked-histogram.js
+++ b/showcase/plot/stacked-histogram.js
@@ -44,6 +44,7 @@ export default class Example extends React.Component {
           onClick={() => this.setState({useCanvas: !useCanvas})}
           buttonContent={content}/>
         <XYPlot
+          xDomain={[0, 7]}
           width={300}
           height={300}
           stackBy="y">

--- a/src/plot/series/horizontal-rect-series-canvas.js
+++ b/src/plot/series/horizontal-rect-series-canvas.js
@@ -31,7 +31,7 @@ class HorizontalRectSeriesCanvas extends AbstractSeries {
   }
 
   static getParentConfig(attr) {
-    const isDomainAdjustmentNeeded = attr === 'y';
+    const isDomainAdjustmentNeeded = false;
     const zeroBaseValue = attr === 'x';
     return {
       isDomainAdjustmentNeeded,

--- a/src/plot/series/horizontal-rect-series.js
+++ b/src/plot/series/horizontal-rect-series.js
@@ -26,7 +26,7 @@ import RectSeries from './rect-series';
 class HorizontalRectSeries extends AbstractSeries {
 
   static getParentConfig(attr) {
-    const isDomainAdjustmentNeeded = attr === 'y';
+    const isDomainAdjustmentNeeded = false;
     const zeroBaseValue = attr === 'x';
     return {
       isDomainAdjustmentNeeded,

--- a/src/plot/series/vertical-rect-series-canvas.js
+++ b/src/plot/series/vertical-rect-series-canvas.js
@@ -31,7 +31,7 @@ class HorizontalRectSeriesCanvas extends AbstractSeries {
   }
 
   static getParentConfig(attr) {
-    const isDomainAdjustmentNeeded = attr === 'x';
+    const isDomainAdjustmentNeeded = false;
     const zeroBaseValue = attr === 'y';
     return {
       isDomainAdjustmentNeeded,

--- a/src/plot/series/vertical-rect-series.js
+++ b/src/plot/series/vertical-rect-series.js
@@ -26,7 +26,7 @@ import RectSeries from './rect-series';
 class VerticalRectSeries extends AbstractSeries {
 
   static getParentConfig(attr) {
-    const isDomainAdjustmentNeeded = attr === 'x';
+    const isDomainAdjustmentNeeded = false;
     const zeroBaseValue = attr === 'y';
     return {
       isDomainAdjustmentNeeded,


### PR DESCRIPTION
For rect series one of the scales can get adjusted, just like for bar series, even though the user has control on both sides of the rectangle.
For instance (as highlighted in issue 492) for vertical bar series, x scale gets adjusted, even though user can control the position of the left and right edge of each mark. 
(likewise for horizontal rect series, y scale could get adjusted.)
