### PR TITLE
Add a naive canvas animation system

### DIFF
--- a/showcase/plot/contour-series-example.js
+++ b/showcase/plot/contour-series-example.js
@@ -22,7 +22,7 @@ import React, {Component} from 'react';
 
 import ShowcaseButton from '../showcase-components/showcase-button';
 
-import {XYPlot, XAxis, YAxis, ContourSeries, MarkSeries, Borders} from 'index';
+import {XYPlot, XAxis, YAxis, ContourSeries, MarkSeriesCanvas, Borders} from 'index';
 
 import DATA from './old-faithful.json';
 const MAPPED_DATA = DATA.map(row => ({
@@ -61,7 +61,7 @@ export default class ContourSeriesExample extends Component {
               '#FF9833'
             ]}
             data={data}/>
-          <MarkSeries animation data={data} size={1} color={'#125C77'}/>
+          <MarkSeriesCanvas animation data={data} size={1} color={'#125C77'}/>
           <Borders style={{all: {fill: '#fff'}}}/>
           <XAxis />
           <YAxis />

--- a/showcase/plot/line-chart-canvas.js
+++ b/showcase/plot/line-chart-canvas.js
@@ -103,12 +103,13 @@ export default class Example extends React.Component {
             buttonContent={'UPDATE DATA'} />
           <ShowcaseButton
             onClick={() => this.setState({colorType: nextType[colorType]})}
-            buttonContent={'TOGGLE COLOR'} />
+            buttonContent={`TOGGLE COLOR to ${nextType[colorType]}`} />
           <ShowcaseButton
             onClick={() => this.setState({strokeWidth: strokeWidth === 1 ? 2 : 1})}
             buttonContent={'TOGGLE STROKEWIDTH'} />
         </div>
         <XYPlot
+          onMouseLeave={() => this.setState({value: false})}
           width={600}
           height={300}>
           <VerticalGridLines />

--- a/showcase/plot/line-chart-canvas.js
+++ b/showcase/plot/line-chart-canvas.js
@@ -68,11 +68,20 @@ export default class Example extends React.Component {
     colorType: 'typeA',
     strokeWidth: 1,
     showMarks: true,
-    value: false
+    value: false,
+    hideComponent: false
   }
 
   render() {
-    const {drawMode, data, colorType, strokeWidth, value, showMarks} = this.state;
+    const {
+      colorType,
+      drawMode,
+      data,
+      hideComponent,
+      strokeWidth,
+      showMarks,
+      value
+    } = this.state;
     const lineSeriesProps = {
       animation: true,
       className: 'mark-series-example',
@@ -107,8 +116,11 @@ export default class Example extends React.Component {
           <ShowcaseButton
             onClick={() => this.setState({strokeWidth: strokeWidth === 1 ? 2 : 1})}
             buttonContent={'TOGGLE STROKEWIDTH'} />
+          <ShowcaseButton
+            onClick={() => this.setState({hideComponent: !hideComponent})}
+            buttonContent={hideComponent ? 'SHOW' : 'HDE'} />
         </div>
-        <XYPlot
+        {!hideComponent && <XYPlot
           onMouseLeave={() => this.setState({value: false})}
           width={600}
           height={300}>
@@ -121,7 +133,7 @@ export default class Example extends React.Component {
           {mode === 'svg' &&
             <SVGComponent {...lineSeriesProps}/>}
           {value && <Crosshair values={[value]} />}
-        </XYPlot>
+        </XYPlot>}
       </div>
     );
   }

--- a/showcase/plot/scatterplot-canvas.js
+++ b/showcase/plot/scatterplot-canvas.js
@@ -96,6 +96,7 @@ export default class Example extends React.Component {
             buttonContent={'UPDATE COLOR'} />
         </div>
         <XYPlot
+          onMouseLeave={() => this.setState({value: false})}
           width={600}
           height={300}>
           <VerticalGridLines />

--- a/src/animation.js
+++ b/src/animation.js
@@ -44,7 +44,7 @@ function getAnimationStyle(animationStyle = presets.noWobble) {
  */
 export function extractAnimatedPropValues(props) {
   const {animatedProps, ...otherProps} = props;
-  // console.log(animatedProps)
+
   return animatedProps.reduce((result, animatedPropName) => {
     if (otherProps.hasOwnProperty(animatedPropName)) {
       result[animatedPropName] = otherProps[animatedPropName];

--- a/src/animation.js
+++ b/src/animation.js
@@ -37,6 +37,22 @@ function getAnimationStyle(animationStyle = presets.noWobble) {
   };
 }
 
+/**
+ * Extract the animated props from the entire props object.
+ * @param {Object} props Props.
+ * @returns {Object} Object of animated props.
+ */
+export function extractAnimatedPropValues(props) {
+  const {animatedProps, ...otherProps} = props;
+  // console.log(animatedProps)
+  return animatedProps.reduce((result, animatedPropName) => {
+    if (otherProps.hasOwnProperty(animatedPropName)) {
+      result[animatedPropName] = otherProps[animatedPropName];
+    }
+    return result;
+  }, {});
+}
+
 class Animation extends PureComponent {
   constructor(props) {
     super(props);
@@ -60,25 +76,9 @@ class Animation extends PureComponent {
    */
   _updateInterpolator(oldProps, newProps) {
     this._interpolator = interpolate(
-      this._extractAnimatedPropValues(oldProps),
-      newProps ? this._extractAnimatedPropValues(newProps) : null
+      extractAnimatedPropValues(oldProps),
+      newProps ? extractAnimatedPropValues(newProps) : null
     );
-  }
-
-  /**
-   * Extract the animated props from the entire props object.
-   * @param {Object} props Props.
-   * @returns {Object} Object of animated props.
-   * @private
-   */
-  _extractAnimatedPropValues(props) {
-    const {animatedProps, ...otherProps} = props;
-    return animatedProps.reduce((result, animatedPropName) => {
-      if (otherProps.hasOwnProperty(animatedPropName)) {
-        result[animatedPropName] = otherProps[animatedPropName];
-      }
-      return result;
-    }, {});
   }
 
   /**

--- a/src/plot/series/bar-series-canvas.js
+++ b/src/plot/series/bar-series-canvas.js
@@ -44,7 +44,9 @@ class BarSeriesCanvas extends AbstractSeries {
       data,
       linePosAttr,
       lineSizeAttr,
-      valuePosAttr
+      valuePosAttr,
+      marginTop,
+      marginBottom
     } = props;
     if (!data || data.length === 0) {
       return;
@@ -77,7 +79,7 @@ class BarSeriesCanvas extends AbstractSeries {
       const width = lineSizeAttr === 'width' ? lineSize : valueSize;
 
       ctx.beginPath();
-      ctx.rect(x, y, width, height);
+      ctx.rect(x + marginBottom, y + marginTop, width, height);
       ctx.fillStyle = `rgba(${fillColor.r}, ${fillColor.g}, ${fillColor.b}, ${rowOpacity})`;
       ctx.fill();
       ctx.strokeStyle = `rgba(${strokeColor.r}, ${strokeColor.g}, ${strokeColor.b}, ${rowOpacity})`;

--- a/src/plot/series/canvas-wrapper.js
+++ b/src/plot/series/canvas-wrapper.js
@@ -151,7 +151,6 @@ class CanvasWrapper extends Component {
 
   render() {
     const {
-      children,
       marginBottom,
       marginLeft,
       marginRight,
@@ -167,7 +166,6 @@ class CanvasWrapper extends Component {
           height={innerHeight + marginTop + marginBottom}
           width={innerWidth + marginLeft + marginRight}
           ref="canvas" />
-        {children}
       </div>
     );
   }

--- a/src/plot/series/canvas-wrapper.js
+++ b/src/plot/series/canvas-wrapper.js
@@ -21,48 +21,153 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 
+import {interpolate} from 'd3-interpolate';
+import {extractAnimatedPropValues} from 'animation';
+import {ANIMATED_SERIES_PROPS} from 'utils/series-utils';
+
+const MAX_DRAWS = 30;
+
+/**
+ * Draw loop draws each of the layers until it should draw more
+ * @param {CanvasContext} ctx - the context where the drawing will take place
+ * @param {Number} height - height of the canvas
+ * @param {Number} width - width of the canvas
+ * @param {Array} layers - the layer objects to render
+ */
+function engageDrawLoop(ctx, height, width, layers) {
+  let drawIteration = 0;
+  const drawCycle = setInterval(() => {
+    drawLayers(ctx, height, width, layers, drawIteration);
+    if (drawIteration > MAX_DRAWS) {
+      clearInterval(drawCycle);
+    }
+    drawIteration += 1;
+  }, 1);
+}
+
+/**
+ * Determine whether the children for the wrapper at this point require animation
+ * @param {Object} children the children to be checked.
+ * @returns {Boolean} whether or not to animate
+ */
+function checkChildrenForAnimation(children) {
+  return children.reduce((any, child) => {
+    if (any) {
+      return any;
+    }
+    return child.props.animation;
+  }, false);
+}
+
+/**
+ * Loops across each of the layers to be drawn and draws them
+ * @param {CanvasContext} ctx - the context where the drawing will take place
+ * @param {Number} height - height of the canvas
+ * @param {Number} width - width of the canvas
+ * @param {Array} layers - the layer objects to render
+ * @param {Number} drawIteration - width of the canvas
+ */
+function drawLayers(ctx, height, width, layers, drawIteration) {
+  ctx.clearRect(0, 0, width, height);
+  layers.forEach(layer => {
+    const {interpolator, newProps, animation} = layer;
+    // return an empty object if dont need to be animating
+    const interpolatedProps = animation ?
+      (interpolator ? interpolator(drawIteration / MAX_DRAWS) : interpolator) :
+      () => ({});
+    layer.renderLayer({
+      ...newProps,
+      ...interpolatedProps
+    }, ctx);
+  });
+}
+
+/**
+ * Build an array of layer of objects the contain the method for drawing each series
+ * as well as an interpolar (specifically a d3-interpolate interpolator)
+ * @param {Object} newChildren the new children to be rendered.
+ * @param {Object} oldChildren the old children to be rendered.
+ * @returns {Array} Object for rendering
+ */
+function buildLayers(newChildren, oldChildren) {
+  return newChildren.map((child, index) => {
+    const oldProps = oldChildren[index] ? oldChildren[index].props : {};
+    const newProps = child.props;
+
+    const oldAnimatedProps = extractAnimatedPropValues({
+      ...oldProps,
+      animatedProps: ANIMATED_SERIES_PROPS
+    });
+    const newAnimatedProps = newProps ? extractAnimatedPropValues({
+      ...newProps,
+      animatedProps: ANIMATED_SERIES_PROPS
+    }) : null;
+    const interpolator = interpolate(oldAnimatedProps, newAnimatedProps);
+
+    return {
+      renderLayer: child.type.renderLayer,
+      newProps: child.props,
+      animation: child.props.animation,
+      interpolator
+    };
+  });
+}
 class CanvasWrapper extends Component {
   componentDidMount() {
-    this.drawChildren(this.props, this.refs.canvas.getContext('2d'));
+    this.drawChildren(this.props, null, this.refs.canvas.getContext('2d'));
   }
 
   componentWillUpdate(nextProps) {
-    this.drawChildren(nextProps, this.refs.canvas.getContext('2d'));
+    this.drawChildren(nextProps, this.props, this.refs.canvas.getContext('2d'));
   }
 
-  drawChildren(props, ctx) {
+  drawChildren(newProps, oldProps, ctx) {
     const {
       children,
       innerHeight,
-      innerWidth
-    } = props;
+      innerWidth,
+      marginBottom,
+      marginLeft,
+      marginRight,
+      marginTop
+    } = newProps;
     if (!ctx) {
       return;
     }
-    ctx.clearRect(0, 0, innerWidth, innerHeight);
-    children.forEach(layer => layer.type.renderLayer(layer.props, ctx));
+
+    const childrenShouldAnimate = checkChildrenForAnimation(children);
+
+    const height = innerHeight + marginTop + marginBottom;
+    const width = innerWidth + marginLeft + marginRight;
+    const layers = buildLayers(newProps.children, oldProps ? oldProps.children : []);
+    // if we don't need to be animating, dont! cut short
+    if (!childrenShouldAnimate) {
+      drawLayers(ctx, height, width, layers);
+      return;
+    }
+
+    engageDrawLoop(ctx, height, width, layers);
   }
 
   render() {
     const {
+      children,
+      marginBottom,
       marginLeft,
+      marginRight,
       marginTop,
       innerHeight,
       innerWidth
     } = this.props;
 
     return (
-      <div
-        style={{
-          left: marginLeft,
-          top: marginTop
-        }}
-        className="rv-xy-canvas">
+      <div style={{left: 0, top: 0}} className="rv-xy-canvas">
         <canvas
           className="rv-xy-canvas-element"
-          height={innerHeight}
-          width={innerWidth}
+          height={innerHeight + marginTop + marginBottom}
+          width={innerWidth + marginLeft + marginRight}
           ref="canvas" />
+        {children}
       </div>
     );
   }
@@ -70,7 +175,9 @@ class CanvasWrapper extends Component {
 
 CanvasWrapper.displayName = 'CanvasWrapper';
 CanvasWrapper.propTypes = {
+  marginBottom: PropTypes.number.isRequired,
   marginLeft: PropTypes.number.isRequired,
+  marginRight: PropTypes.number.isRequired,
   marginTop: PropTypes.number.isRequired,
   innerHeight: PropTypes.number.isRequired,
   innerWidth: PropTypes.number.isRequired

--- a/src/plot/series/canvas-wrapper.js
+++ b/src/plot/series/canvas-wrapper.js
@@ -36,27 +36,18 @@ const MAX_DRAWS = 30;
  */
 function engageDrawLoop(ctx, height, width, layers) {
   let drawIteration = 0;
+  // using setInterval because request animation frame goes too fast
   const drawCycle = setInterval(() => {
+    if (!ctx) {
+      clearInterval(drawCycle);
+      return;
+    }
     drawLayers(ctx, height, width, layers, drawIteration);
     if (drawIteration > MAX_DRAWS) {
       clearInterval(drawCycle);
     }
     drawIteration += 1;
   }, 1);
-}
-
-/**
- * Determine whether the children for the wrapper at this point require animation
- * @param {Object} children the children to be checked.
- * @returns {Boolean} whether or not to animate
- */
-function checkChildrenForAnimation(children) {
-  return children.reduce((any, child) => {
-    if (any) {
-      return any;
-    }
-    return child.props.animation;
-  }, false);
 }
 
 /**
@@ -117,10 +108,17 @@ class CanvasWrapper extends Component {
     this.drawChildren(this.props, null, this.refs.canvas.getContext('2d'));
   }
 
-  componentWillUpdate(nextProps) {
+  componentDidUpdate(nextProps) {
     this.drawChildren(nextProps, this.props, this.refs.canvas.getContext('2d'));
   }
 
+  /**
+   * Check that we can and should be animating, then kick off animations as apporpriate
+   * @param {Object} newProps the new props to be interpolated to
+   * @param {Object} oldProps the old props to be interpolated against
+   * @param {DomRef} ctx the canvas context to be drawn on.
+   * @returns {Array} Object for rendering
+   */
   drawChildren(newProps, oldProps, ctx) {
     const {
       children,
@@ -135,7 +133,7 @@ class CanvasWrapper extends Component {
       return;
     }
 
-    const childrenShouldAnimate = checkChildrenForAnimation(children);
+    const childrenShouldAnimate = children.find(child => child.props.animation);
 
     const height = innerHeight + marginTop + marginBottom;
     const width = innerWidth + marginLeft + marginRight;

--- a/src/plot/series/line-series-canvas.js
+++ b/src/plot/series/line-series-canvas.js
@@ -35,7 +35,13 @@ class LineSeriesCanvas extends AbstractSeries {
   }
 
   static renderLayer(props, ctx) {
-    const {data, strokeWidth, strokeDasharray} = props;
+    const {
+      data,
+      marginLeft,
+      marginTop,
+      strokeWidth,
+      strokeDasharray
+    } = props;
     if (!data || data.length === 0) {
       return;
     }
@@ -48,8 +54,8 @@ class LineSeriesCanvas extends AbstractSeries {
     const opacity = Number.isFinite(newOpacity) ? newOpacity : DEFAULT_OPACITY;
 
     ctx.beginPath();
-    ctx.moveTo(x(data[0]), y(data[0]));
-    data.forEach(row => ctx.lineTo(x(row), y(row)));
+    ctx.moveTo(x(data[0]) + marginLeft, y(data[0]) + marginTop);
+    data.forEach(row => ctx.lineTo(x(row) + marginLeft, y(row) + marginTop));
 
     ctx.strokeStyle = `rgba(${strokeColor.r}, ${strokeColor.g}, ${strokeColor.b}, ${opacity})`;
     ctx.lineWidth = strokeWidth;
@@ -68,13 +74,13 @@ class LineSeriesCanvas extends AbstractSeries {
 
 LineSeriesCanvas.displayName = 'LineSeriesCanvas';
 LineSeriesCanvas.defaultProps = {
-  strokeWidth: PropTypes.number,
-  strokeDasharray: PropTypes.string
+  strokeWidth: 1,
+  strokeDasharray: ''
 };
 
 LineSeriesCanvas.propTypes = {
   ...AbstractSeries.propTypes,
-  strokeWidth: 1
+  strokeWidth: PropTypes.number
 };
 
 export default LineSeriesCanvas;

--- a/src/plot/series/mark-series-canvas.js
+++ b/src/plot/series/mark-series-canvas.js
@@ -18,6 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+import React from 'react';
+
 import {rgb} from 'd3-color';
 
 import {DEFAULT_SIZE, DEFAULT_OPACITY} from 'theme';
@@ -35,7 +37,7 @@ class MarkSeriesCanvas extends AbstractSeries {
   }
 
   static renderLayer(props, ctx) {
-    const {data} = props;
+    const {data, marginLeft, marginTop} = props;
 
     const x = getAttributeFunctor(props, 'x');
     const y = getAttributeFunctor(props, 'y');
@@ -49,7 +51,7 @@ class MarkSeriesCanvas extends AbstractSeries {
       const strokeColor = rgb(stroke(row));
       const rowOpacity = opacity(row) || DEFAULT_OPACITY;
       ctx.beginPath();
-      ctx.arc(x(row), y(row), size(row), 0, 2 * Math.PI);
+      ctx.arc(x(row) + marginLeft, y(row) + marginTop, size(row), 0, 2 * Math.PI);
       ctx.fillStyle = `rgba(${fillColor.r}, ${fillColor.g}, ${fillColor.b}, ${rowOpacity})`;
       ctx.fill();
       ctx.strokeStyle = `rgba(${strokeColor.r}, ${strokeColor.g}, ${strokeColor.b}, ${rowOpacity})`;
@@ -58,7 +60,8 @@ class MarkSeriesCanvas extends AbstractSeries {
   }
 
   render() {
-    return null;
+
+    return <div className="mark-series-shadow" />;
   }
 }
 

--- a/src/plot/series/mark-series-canvas.js
+++ b/src/plot/series/mark-series-canvas.js
@@ -18,8 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import React from 'react';
-
 import {rgb} from 'd3-color';
 
 import {DEFAULT_SIZE, DEFAULT_OPACITY} from 'theme';
@@ -60,8 +58,7 @@ class MarkSeriesCanvas extends AbstractSeries {
   }
 
   render() {
-
-    return <div className="mark-series-shadow" />;
+    return null;
   }
 }
 

--- a/src/plot/series/rect-series-canvas.js
+++ b/src/plot/series/rect-series-canvas.js
@@ -38,6 +38,8 @@ class RectSeriesCanvas extends AbstractSeries {
       data,
       linePosAttr,
       lineSizeAttr,
+      marginLeft,
+      marginTop,
       valuePosAttr
     } = props;
     if (!data || data.length === 0) {
@@ -68,7 +70,7 @@ class RectSeriesCanvas extends AbstractSeries {
       const width = lineSizeAttr === 'width' ? lineSize : valueSize;
 
       ctx.beginPath();
-      ctx.rect(x, y, width, height);
+      ctx.rect(x + marginLeft, y + marginTop, width, height);
       ctx.fillStyle = `rgba(${fillColor.r}, ${fillColor.g}, ${fillColor.b}, ${rowOpacity})`;
       ctx.fill();
       ctx.strokeStyle = `rgba(${strokeColor.r}, ${strokeColor.g}, ${strokeColor.b}, ${rowOpacity})`;

--- a/src/plot/xy-plot.js
+++ b/src/plot/xy-plot.js
@@ -417,7 +417,7 @@ class XYPlot extends React.Component {
           {components.filter(c => c && c.type.requiresSVG)}
         </svg>
         {this.renderCanvasComponents(components, this.props)}
-        {components.filter(c => c && !c.type.requiresSVG)}
+        {components.filter(c => c && !c.type.requiresSVG && !c.type.isCanvas)}
       </div>
     );
   }


### PR DESCRIPTION
This PR adds an animated canvas drawing system for the canvas components. Similarly to the regular animation system it runs on d3-interpolate, however we have to do the animation work ourself, because we are directly manipulating the canvas. This addresses #417 

![canvas-animation](https://user-images.githubusercontent.com/6854312/27882823-19e5e368-6183-11e7-88bd-280aa8d2dd6d.gif)

![canvas-animation2](https://user-images.githubusercontent.com/6854312/27882942-9934cc92-6183-11e7-97b6-e8de7ded99a1.gif)

It runs a little clumsily when there are multiple animations running at once. Would be delighted to hear what someone who knows this stuff better has to say. That said, when it runs well, it runs significantly more smoothly than the same svg animations for medium volume data

(This PR Also update canvas so that there is a margin on the canvas itself.)