### PR TITLE
Add labels to sunburst nodes

### DIFF
--- a/docs/markdown/sunburst.md
+++ b/docs/markdown/sunburst.md
@@ -91,9 +91,17 @@ Each point consists of following properties:
 * `color` (optional)  
   Type: `number` or `string`
   The value to visualize the color with.
+* `label` (optional)  
+  Type: `string`
+  The label to be attached for the current node.
+* `labelStyle` (optional)  
+  Type: `string`
+  The style of the attached label.
 * `children` (optional)  
   Type: `Array`  
   The children for the leaf.
+
+<!-- INJECT:"SunburstWithTooltips" -->
 
 #### hideRootNode (optional)
 Type: `boolean`

--- a/showcase/sunbursts/animated-sunburst.js
+++ b/showcase/sunbursts/animated-sunburst.js
@@ -20,7 +20,7 @@
 
 import React from 'react';
 
-import Sunburst from 'sunburst';
+import {Sunburst} from 'index';
 import ShowcaseButton from '../showcase-components/showcase-button';
 
 function randomLeaf() {
@@ -56,7 +56,6 @@ export default class AnimatedSunburst extends React.Component {
 
   render() {
     const {data} = this.state;
-
     return (
       <div className="animated-sunburst-example-wrapper">
         <ShowcaseButton

--- a/showcase/sunbursts/sunburst-with-tooltips.js
+++ b/showcase/sunbursts/sunburst-with-tooltips.js
@@ -26,22 +26,31 @@ import {
 } from 'index';
 
 import {
-  EXTENDED_DISCRETE_COLOR_RANGE
+  EXTENDED_DISCRETE_COLOR_RANGE as COLORS
 } from 'theme';
 
 const DATA = {
   children: [
     {children: [
-      {size: 1, children: [], color: EXTENDED_DISCRETE_COLOR_RANGE[1]},
-      {size: 1, children: [], color: EXTENDED_DISCRETE_COLOR_RANGE[2]}
-    ], color: EXTENDED_DISCRETE_COLOR_RANGE[3]},
-    {size: 1, children: [], color: EXTENDED_DISCRETE_COLOR_RANGE[4]},
-    {size: 1, children: [], color: EXTENDED_DISCRETE_COLOR_RANGE[5]},
-    {size: 1, children: [], color: EXTENDED_DISCRETE_COLOR_RANGE[6]},
+      {size: 1, children: [], color: COLORS[1]},
+      {size: 1, children: [], color: COLORS[2]}
+    ], color: COLORS[3]},
+    {
+      size: 1,
+      children: [],
+      color: COLORS[4],
+      label: 'cool',
+      labelStyle: {
+        fontSize: 15,
+        fontWeight: 'bold'
+      }
+    },
+    {size: 1, children: [], color: COLORS[5], label: 'dogs'},
+    {size: 1, children: [], color: COLORS[6], label: 'sunglasses'},
     {children: [
-      {size: 1, children: [], color: EXTENDED_DISCRETE_COLOR_RANGE[7]},
-      {size: 1, children: [], color: EXTENDED_DISCRETE_COLOR_RANGE[8]}
-    ], color: EXTENDED_DISCRETE_COLOR_RANGE[9]}
+      {size: 1, children: [], color: COLORS[7]},
+      {size: 1, children: [], color: COLORS[8]}
+    ], color: COLORS[9]}
   ]
 };
 

--- a/tests/components/sunburst-tests.js
+++ b/tests/components/sunburst-tests.js
@@ -78,9 +78,10 @@ test('Sunburst: Flare Demo', t => {
 
 test('Sunburst: SunburstWithTooltips', t => {
   const $ = mount(<SunburstWithTooltips />);
+  t.equal($.text(), 'cooldogssunglasses', 'should find the right text');
   t.equal($.find('.rv-xy-plot__series--arc path').length, 10, 'should find the right number of children');
   $.find('.rv-xy-plot__series--arc-path').at(1).simulate('mouseOver');
-  t.equal($.text(), '#FF991F', 'should find appropriate hover text');
+  t.equal($.text(), 'cooldogssunglasses#FF991F', 'should find appropriate hover text');
 
   t.end();
 });


### PR DESCRIPTION
![screen shot 2017-08-07 at 10 20 12 am](https://user-images.githubusercontent.com/6854312/29037793-0605375e-7b5a-11e7-9a2c-2dcf834321b7.png)

Adds potential for tooltips on sunburst, as requested in #529 