### PR TITLE
add missing orientation prop to DiscreteColorLegend documentation

### DIFF
--- a/docs/markdown/legends.md
+++ b/docs/markdown/legends.md
@@ -21,8 +21,8 @@ Currently following types of legends are supported:
 Type: `Array<string|{title: string, color: String, disabled: boolean}|react element>`
 Array of items that should be shown on the legend. The array should consist from either objects (`title`, optional `color` and optional `disabled` flag) or strings (treated as titles).
 
-#### orientation
-Type: `string`
+#### orientation (optional)
+Type: `(vertical|horizontal)`
 Default: `'vertical'`
 String either `horizontal` or `vertical` representing which direction the legend elements are rendered.
 

--- a/docs/markdown/legends.md
+++ b/docs/markdown/legends.md
@@ -21,6 +21,11 @@ Currently following types of legends are supported:
 Type: `Array<string|{title: string, color: String, disabled: boolean}|react element>`
 Array of items that should be shown on the legend. The array should consist from either objects (`title`, optional `color` and optional `disabled` flag) or strings (treated as titles).
 
+#### orientation
+Type: `string`
+Default: `'vertical'`
+String either `horizontal` or `vertical` representing which direction the legend elements are rendered.
+
 #### onItemClick
 Type: `function(Object, number): void`
 Default: noop


### PR DESCRIPTION
Looks like in https://github.com/uber/react-vis/pull/135/files#diff-54315c7bb8c76d7c2bdbdd4debd1bb53R28 the option for horizontal legends was added. I've confirmed it does indeed work:

<img width="900" alt="screen shot 2017-08-13 at 11 40 30 am" src="https://user-images.githubusercontent.com/4411118/29251064-9fcad35a-801c-11e7-9050-1a17831005fe.png">
<img width="1012" alt="screen shot 2017-08-13 at 11 40 42 am" src="https://user-images.githubusercontent.com/4411118/29251065-9fffceac-801c-11e7-92cf-15cdbd3d93e7.png">
