### PR TITLE
Enable SVG mode on treemap

### DIFF
--- a/docs/markdown/treemap.md
+++ b/docs/markdown/treemap.md
@@ -109,6 +109,9 @@ Each point consists of following properties:
 * `color` (optional)  
   Type: `number` or `string`
   The value to visualize the color with.
+* `style` (optional)  
+  Type: `object`
+  style object to be added to the inline styles of the array
 * `children` (optional)  
   Type: `Array`  
   The children for the leaf.
@@ -140,3 +143,8 @@ Type: `string`
 - One of squarify, resquarify, slice, dice, slicedice, binary, circlePack, partition, partition-pivot
 
 This modifies the tiling strategy for the treemap, for more information see the [d3 hierarchy docs](https://github.com/d3/d3-hierarchy).
+
+##### colorDomain, colorRange, colorType
+
+Scale properties for the `color` scale. If `color` property is not passed in the data object, each new section of the chart gets the next color (e. g. the `'category'` scale is applied).
+Please refer to [Scales and Data](scales-and-data.md) for more information about scales.

--- a/showcase/treemap/dynamic-treemap.js
+++ b/showcase/treemap/dynamic-treemap.js
@@ -63,8 +63,7 @@ export default class DynamicTreemapExample extends React.Component {
       onLeafClick: () => this.setState({treemapData: _getRandomData()}),
       height: 300,
       mode: this.state.useCirclePacking ? 'circlePack' : 'squarify',
-      width: 350,
-      renderMode: 'SVG'
+      width: 350
     };
     return (
       <div className="dynamic-treemap-example">

--- a/showcase/treemap/dynamic-treemap.js
+++ b/showcase/treemap/dynamic-treemap.js
@@ -26,18 +26,14 @@ import ShowcaseButton from '../showcase-components/showcase-button';
 function _getRandomData(total) {
   const totalLeaves = total || Math.random() * 20;
   const leaves = [];
-  let title;
   for (let i = 0; i < totalLeaves; i++) {
-    title = Math.random();
-    if (!Math.random() > 0.5) {
-      title = (
-        <b>{title}</b>
-      );
-    }
     leaves.push({
-      title: total ? '123' : total,
+      title: total ? total : String(Math.random()).slice(0, 3),
       size: Math.random() * 1000,
-      color: Math.random()
+      color: Math.random(),
+      style: {
+        border: 'thin solid red'
+      }
     });
   }
   return {
@@ -67,7 +63,8 @@ export default class DynamicTreemapExample extends React.Component {
       onLeafClick: () => this.setState({treemapData: _getRandomData()}),
       height: 300,
       mode: this.state.useCirclePacking ? 'circlePack' : 'squarify',
-      width: 350
+      width: 350,
+      renderMode: 'SVG'
     };
     return (
       <div className="dynamic-treemap-example">

--- a/showcase/treemap/simple-treemap.js
+++ b/showcase/treemap/simple-treemap.js
@@ -39,7 +39,8 @@ const MODE = [
 
 export default class SimpleTreemapExample extends React.Component {
   state = {
-    modeIndex: 0
+    modeIndex: 0,
+    useSVG: true
   }
 
   updateModeIndex = increment => () => {
@@ -49,9 +50,15 @@ export default class SimpleTreemapExample extends React.Component {
   }
 
   render() {
-    const {modeIndex} = this.state;
+    const {modeIndex, useSVG} = this.state;
+
     return (
       <div className="centered-and-flexed">
+        <div className="centered-and-flexed-controls">
+          <ShowcaseButton
+            onClick={() => this.setState({useSVG: !useSVG})}
+            buttonContent={useSVG ? 'USE DOM' : 'USE SVG'} />
+        </div>
         <div className="centered-and-flexed-controls">
           <ShowcaseButton onClick={this.updateModeIndex(false)} buttonContent={'PREV MODE'} />
           <div> {MODE[modeIndex]} </div>
@@ -64,8 +71,13 @@ export default class SimpleTreemapExample extends React.Component {
           colorRange: ['#88572C'],
           data: D3FlareData,
           mode: MODE[modeIndex],
+          renderMode: useSVG ? 'SVG' : 'DOM',
           height: 300,
-          width: 350
+          width: 350,
+          margin: 10,
+          style: {
+            border: 'thin solid rgba(#ddd, .5)'
+          }
         }}/>
       </div>
     );

--- a/showcase/treemap/simple-treemap.js
+++ b/showcase/treemap/simple-treemap.js
@@ -37,6 +37,17 @@ const MODE = [
   'binary'
 ];
 
+const STYLES = {
+  SVG: {
+    stroke: '#ddd',
+    strokeWidth: '0.25',
+    strokeOpacity: 0.5
+  },
+  DOM: {
+    border: 'thin solid #ddd'
+  }
+};
+
 export default class SimpleTreemapExample extends React.Component {
   state = {
     modeIndex: 0,
@@ -75,9 +86,7 @@ export default class SimpleTreemapExample extends React.Component {
           height: 300,
           width: 350,
           margin: 10,
-          style: {
-            border: 'thin solid rgba(#ddd, .5)'
-          }
+          style: STYLES[useSVG ? 'SVG' : 'DOM']
         }}/>
       </div>
     );

--- a/src/styles/examples.scss
+++ b/src/styles/examples.scss
@@ -366,10 +366,6 @@ article {
   justify-content: center;
   padding: 0 10px;
 
-  .rv-treemap__leaf {
-    border: thin solid rgba(#ddd, .5);
-  }
-
   .centered-and-flexed-controls {
     align-items: center;
     display: flex;

--- a/src/treemap/index.js
+++ b/src/treemap/index.js
@@ -163,11 +163,8 @@ class Treemap extends React.Component {
     const {renderMode} = this.props;
     const {scales} = this.state;
     const nodes = this._getNodesToRender();
-
-    if (renderMode === 'SVG') {
-      return <TreemapSVG {...this.props} nodes={nodes} scales={scales}/>;
-    }
-    return <TreemapDOM {...this.props} nodes={nodes} scales={scales}/>;
+    const TreemapElement = renderMode === 'SVG' ? TreemapSVG : TreemapDOM;
+    return <TreemapElement {...this.props} nodes={nodes} scales={scales}/>;
   }
 
 }

--- a/src/treemap/index.js
+++ b/src/treemap/index.js
@@ -36,8 +36,10 @@ import {
 import {CONTINUOUS_COLOR_RANGE, DEFAULT_COLOR, DEFAULT_OPACITY, OPACITY_TYPE} from 'theme';
 import {AnimationPropType} from 'animation';
 import {getAttributeFunctor, getMissingScaleProps} from 'utils/scales-utils';
+import {MarginPropType, getInnerDimensions} from 'utils/chart-utils';
 
-import TreemapLeaf from './treemap-leaf';
+import TreemapDOM from './treemap-dom';
+import TreemapSVG from './treemap-svg';
 
 const TREEMAP_TILE_MODES = {
   squarify: treemapSquarify,
@@ -57,6 +59,13 @@ const TREEMAP_LAYOUT_MODES = [
 const NOOP = d => d;
 
 const ATTRIBUTES = ['opacity', 'color'];
+
+const DEFAULT_MARGINS = {
+  left: 40,
+  right: 10,
+  top: 10,
+  bottom: 40
+};
 
 /**
  * Get the map of scale functions from the given props.
@@ -82,50 +91,19 @@ function _getScaleFns(props) {
 }
 
 class Treemap extends React.Component {
-
-  static get propTypes() {
-    return {
-      animation: AnimationPropType,
-      className: PropTypes.string,
-      data: PropTypes.object.isRequired,
-      height: PropTypes.number.isRequired,
-      mode: PropTypes.oneOf(
-        Object.keys(TREEMAP_TILE_MODES).concat(TREEMAP_LAYOUT_MODES)
-      ),
-      onLeafClick: PropTypes.func,
-      onLeafMouseOver: PropTypes.func,
-      onLeafMouseOut: PropTypes.func,
-      useCirclePacking: PropTypes.bool,
-      padding: PropTypes.number.isRequired,
-      width: PropTypes.number.isRequired
-    };
-  }
-
-  static get defaultProps() {
-    return {
-      className: '',
-      colorRange: CONTINUOUS_COLOR_RANGE,
-      _colorValue: DEFAULT_COLOR,
-      data: {
-        children: []
-      },
-      mode: 'squarify',
-      onLeafClick: NOOP,
-      onLeafMouseOver: NOOP,
-      onLeafMouseOut: NOOP,
-      opacityType: OPACITY_TYPE,
-      _opacityValue: DEFAULT_OPACITY,
-      padding: 1
-    };
-  }
-
   constructor(props) {
     super(props);
-    this.state = {scales: _getScaleFns(props)};
+    this.state = {
+      scales: _getScaleFns(props),
+      ...getInnerDimensions(props, DEFAULT_MARGINS)
+    };
   }
 
   componentWillReceiveProps(props) {
-    this.setState({scales: _getScaleFns(props)});
+    this.setState({
+      scales: _getScaleFns(props),
+      ...getInnerDimensions(props, DEFAULT_MARGINS)
+    });
   }
 
   /**
@@ -134,10 +112,12 @@ class Treemap extends React.Component {
    * @private
    */
   _getNodesToRender() {
-    const {data, height, width, mode, padding} = this.props;
+    const {innerWidth, innerHeight} = this.state;
+    const {data, mode, padding} = this.props;
+
     if (data && (mode === 'partition' || mode === 'partition-pivot')) {
       const partitionFunction = partition()
-          .size([width, height])
+          .size([innerWidth, innerHeight])
           .padding(padding);
       const structuredInput = hierarchy(data)
         .sum(d => d.size);
@@ -155,7 +135,7 @@ class Treemap extends React.Component {
     }
     if (data && mode === 'circlePack') {
       const packingFunction = pack()
-          .size([width, height])
+          .size([innerWidth, innerHeight])
           .padding(padding);
       const structuredInput = hierarchy(data)
         .sort((a, b) => a.size - b.size)
@@ -166,7 +146,7 @@ class Treemap extends React.Component {
       const tileFn = TREEMAP_TILE_MODES[mode];
       const treemapingFunction = treemap(tileFn)
         .tile(tileFn)
-        .size([width, height])
+        .size([innerWidth, innerHeight])
         .padding(padding);
       const structuredInput = hierarchy(data)
         .sort((a, b) => a.size - b.size)
@@ -178,41 +158,55 @@ class Treemap extends React.Component {
   }
 
   render() {
-    const {animation, className, height, mode, width} = this.props;
+    const {renderMode} = this.props;
+    const {scales} = this.state;
     const nodes = this._getNodesToRender();
-    const useCirclePacking = mode === 'circlePack';
-    return (
-      <div
-        className={`rv-treemap ${useCirclePacking ? 'rv-treemap-circle-packed' : ''} ${className}`}
-        style={{
-          width: `${width}px`,
-          height: `${height}px`
-        }}>
-        {nodes.map((node, index) => {
-          // throw out the rootest node
-          if (!useCirclePacking && !index) {
-            return null;
-          }
 
-          const nodeProps = {
-            animation,
-            node,
-            ...this.props,
-            x0: useCirclePacking ? node.x : node.x0,
-            x1: useCirclePacking ? node.x : node.x1,
-            y0: useCirclePacking ? node.y : node.y0,
-            y1: useCirclePacking ? node.y : node.y1,
-            r: useCirclePacking ? node.r : 1,
-            scales: this.state.scales
-          };
-          return (<TreemapLeaf {...nodeProps} key={`leaf-${index}`} />);
-        })}
-      </div>
-    );
+    if (renderMode === 'SVG') {
+      return <TreemapSVG {...this.props} nodes={nodes} scales={scales}/>;
+    }
+    return <TreemapDOM {...this.props} nodes={nodes} scales={scales}/>;
   }
 
 }
 
 Treemap.displayName = 'Treemap';
+Treemap.propTypes = {
+  animation: AnimationPropType,
+  className: PropTypes.string,
+  data: PropTypes.object.isRequired,
+  height: PropTypes.number.isRequired,
+  margin: MarginPropType,
+  mode: PropTypes.oneOf(
+    Object.keys(TREEMAP_TILE_MODES).concat(TREEMAP_LAYOUT_MODES)
+  ),
+  onLeafClick: PropTypes.func,
+  onLeafMouseOver: PropTypes.func,
+  onLeafMouseOut: PropTypes.func,
+  useCirclePacking: PropTypes.bool,
+  padding: PropTypes.number.isRequired,
+  width: PropTypes.number.isRequired
+};
 
+Treemap.defaultProps = {
+  className: '',
+  colorRange: CONTINUOUS_COLOR_RANGE,
+  _colorValue: DEFAULT_COLOR,
+  data: {
+    children: []
+  },
+  margin: {
+    bottom: 50,
+    left: 50,
+    top: 50,
+    right: 50
+  },
+  mode: 'squarify',
+  onLeafClick: NOOP,
+  onLeafMouseOver: NOOP,
+  onLeafMouseOut: NOOP,
+  opacityType: OPACITY_TYPE,
+  _opacityValue: DEFAULT_OPACITY,
+  padding: 1
+};
 export default Treemap;

--- a/src/treemap/index.js
+++ b/src/treemap/index.js
@@ -114,8 +114,11 @@ class Treemap extends React.Component {
   _getNodesToRender() {
     const {innerWidth, innerHeight} = this.state;
     const {data, mode, padding} = this.props;
+    if (!data) {
+      return [];
+    }
 
-    if (data && (mode === 'partition' || mode === 'partition-pivot')) {
+    if ((mode === 'partition' || mode === 'partition-pivot')) {
       const partitionFunction = partition()
           .size([innerWidth, innerHeight])
           .padding(padding);
@@ -133,7 +136,7 @@ class Treemap extends React.Component {
       }
       return mappedNodes;
     }
-    if (data && mode === 'circlePack') {
+    if (mode === 'circlePack') {
       const packingFunction = pack()
           .size([innerWidth, innerHeight])
           .padding(padding);
@@ -142,19 +145,18 @@ class Treemap extends React.Component {
         .sum(d => d.size);
       return packingFunction(structuredInput).descendants();
     }
-    if (data) {
-      const tileFn = TREEMAP_TILE_MODES[mode];
-      const treemapingFunction = treemap(tileFn)
-        .tile(tileFn)
-        .size([innerWidth, innerHeight])
-        .padding(padding);
-      const structuredInput = hierarchy(data)
-        .sort((a, b) => a.size - b.size)
-        .sum(d => d.size);
 
-      return treemapingFunction(structuredInput).descendants();
-    }
-    return [];
+    const tileFn = TREEMAP_TILE_MODES[mode];
+    const treemapingFunction = treemap(tileFn)
+      .tile(tileFn)
+      .size([innerWidth, innerHeight])
+      .padding(padding);
+    const structuredInput = hierarchy(data)
+      .sort((a, b) => a.size - b.size)
+      .sum(d => d.size);
+
+    return treemapingFunction(structuredInput).descendants();
+
   }
 
   render() {

--- a/src/treemap/treemap-dom.js
+++ b/src/treemap/treemap-dom.js
@@ -28,10 +28,7 @@ class TreemapDOM extends React.Component {
     return (
       <div
         className={`rv-treemap ${useCirclePacking ? 'rv-treemap-circle-packed' : ''} ${className}`}
-        style={{
-          width: `${width}px`,
-          height: `${height}px`
-        }}>
+        style={{height, width}}>
         {nodes.map((node, index) => {
           // throw out the rootest node
           if (!useCirclePacking && !index) {

--- a/src/treemap/treemap-dom.js
+++ b/src/treemap/treemap-dom.js
@@ -1,0 +1,62 @@
+// Copyright (c) 2016 - 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+import React from 'react';
+
+import TreemapLeaf from './treemap-leaf';
+
+class TreemapDOM extends React.Component {
+  render() {
+    const {animation, className, height, mode, nodes, width, scales, style} = this.props;
+    const useCirclePacking = mode === 'circlePack';
+    return (
+      <div
+        className={`rv-treemap ${useCirclePacking ? 'rv-treemap-circle-packed' : ''} ${className}`}
+        style={{
+          width: `${width}px`,
+          height: `${height}px`
+        }}>
+        {nodes.map((node, index) => {
+          // throw out the rootest node
+          if (!useCirclePacking && !index) {
+            return null;
+          }
+
+          const nodeProps = {
+            animation,
+            node,
+            ...this.props,
+            x0: useCirclePacking ? node.x : node.x0,
+            x1: useCirclePacking ? node.x : node.x1,
+            y0: useCirclePacking ? node.y : node.y0,
+            y1: useCirclePacking ? node.y : node.y1,
+            r: useCirclePacking ? node.r : 1,
+            scales,
+            style
+          };
+          return (<TreemapLeaf {...nodeProps} key={`leaf-${index}`} />);
+        })}
+      </div>
+    );
+  }
+
+}
+
+TreemapDOM.displayName = 'TreemapDOM';
+export default TreemapDOM;

--- a/src/treemap/treemap-leaf.js
+++ b/src/treemap/treemap-leaf.js
@@ -61,6 +61,17 @@ class TreemapLeaf extends React.Component {
     const opacity = scales.opacity(node);
     const color = getFontColorFromBackground(background);
     const {data: {title}} = node;
+    const leafStyle = {
+      top: useCirclePacking ? (y0 - r) : y0,
+      left: useCirclePacking ? (x0 - r) : x0,
+      width: useCirclePacking ? r * 2 : x1 - x0,
+      height: useCirclePacking ? r * 2 : y1 - y0,
+      background,
+      opacity,
+      color,
+      ...style,
+      ...node.data.style
+    };
 
     return (
       <div
@@ -68,17 +79,7 @@ class TreemapLeaf extends React.Component {
         onMouseEnter={event => onLeafMouseOver(node, event)}
         onMouseLeave={event => onLeafMouseOut(node, event)}
         onClick={event => onLeafClick(node, event)}
-        style={{
-          top: useCirclePacking ? (y0 - r) : y0,
-          left: useCirclePacking ? (x0 - r) : x0,
-          width: useCirclePacking ? r * 2 : x1 - x0,
-          height: useCirclePacking ? r * 2 : y1 - y0,
-          background,
-          opacity,
-          color,
-          ...style,
-          ...node.data.style
-        }}>
+        style={leafStyle}>
         <div className="rv-treemap__leaf__content">{title}</div>
       </div>
     );

--- a/src/treemap/treemap-leaf.js
+++ b/src/treemap/treemap-leaf.js
@@ -32,26 +32,6 @@ const ANIMATED_PROPS = [
 ];
 
 class TreemapLeaf extends React.Component {
-
-  static get propTypes() {
-    return {
-      animation: AnimationPropType,
-      height: PropTypes.number.isRequired,
-      mode: PropTypes.string,
-      node: PropTypes.object.isRequired,
-      onLeafClick: PropTypes.func,
-      onLeafMouseOver: PropTypes.func,
-      onLeafMouseOut: PropTypes.func,
-      scales: PropTypes.object.isRequired,
-      width: PropTypes.number.isRequired,
-      r: PropTypes.number.isRequired,
-      x0: PropTypes.number.isRequired,
-      x1: PropTypes.number.isRequired,
-      y0: PropTypes.number.isRequired,
-      y1: PropTypes.number.isRequired
-    };
-  }
-
   render() {
     const {
       animation,
@@ -65,7 +45,8 @@ class TreemapLeaf extends React.Component {
       x0,
       x1,
       y0,
-      y1
+      y1,
+      style
     } = this.props;
 
     if (animation) {
@@ -80,6 +61,7 @@ class TreemapLeaf extends React.Component {
     const opacity = scales.opacity(node);
     const color = getFontColorFromBackground(background);
     const {data: {title}} = node;
+
     return (
       <div
         className={`rv-treemap__leaf ${useCirclePacking ? 'rv-treemap__leaf--circle' : ''}`}
@@ -93,12 +75,29 @@ class TreemapLeaf extends React.Component {
           height: useCirclePacking ? r * 2 : y1 - y0,
           background,
           opacity,
-          color
+          color,
+          ...style,
+          ...node.data.style
         }}>
         <div className="rv-treemap__leaf__content">{title}</div>
       </div>
     );
   }
 }
-
+TreemapLeaf.propTypes = {
+  animation: AnimationPropType,
+  height: PropTypes.number.isRequired,
+  mode: PropTypes.string,
+  node: PropTypes.object.isRequired,
+  onLeafClick: PropTypes.func,
+  onLeafMouseOver: PropTypes.func,
+  onLeafMouseOut: PropTypes.func,
+  scales: PropTypes.object.isRequired,
+  width: PropTypes.number.isRequired,
+  r: PropTypes.number.isRequired,
+  x0: PropTypes.number.isRequired,
+  x1: PropTypes.number.isRequired,
+  y0: PropTypes.number.isRequired,
+  y1: PropTypes.number.isRequired
+};
 export default TreemapLeaf;

--- a/src/treemap/treemap-svg.js
+++ b/src/treemap/treemap-svg.js
@@ -1,0 +1,160 @@
+// Copyright (c) 2016 - 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import React from 'react';
+
+import XYPlot from 'plot/xy-plot';
+import PolygonSeries from 'plot/series/polygon-series';
+import MarkSeries from 'plot/series/mark-series';
+import LabelSeries from 'plot/series/label-series';
+
+class TreemapSVG extends React.Component {
+  getCircularNodes() {
+    const {
+      animation,
+      nodes,
+      onLeafMouseOver,
+      onLeafMouseOut,
+      onLeafClick,
+      scales
+    } = this.props;
+
+    const {rows, minY, maxY} = nodes.reduce((acc, node, index) => {
+      const {x, y, r} = node;
+      acc.maxY = Math.max(y + r, acc.maxY);
+      acc.minY = Math.min(y - r, acc.minY);
+      acc.rows = acc.rows.concat([{
+        x,
+        y,
+        size: r,
+        color: scales.color(node)
+      }]);
+      return acc;
+    }, {rows: [], maxY: -Infinity, minY: Infinity});
+    return {
+      updatedNodes: (
+        <MarkSeries
+          animation={animation}
+          className="rv-treemap__leaf rv-treemap__leaf--circle"
+          onSeriesMouseEnter={onLeafMouseOver}
+          onSeriesMouseLeave={onLeafMouseOut}
+          onSeriesClick={onLeafClick}
+          data={rows}
+          colorType="literal"
+          sizeType="literal"/>
+      ),
+      minY,
+      maxY
+    };
+  }
+
+  getNonCircularNodes() {
+    const {
+      animation,
+      nodes,
+      onLeafMouseOver,
+      onLeafMouseOut,
+      onLeafClick,
+      scales
+    } = this.props;
+    const {color} = scales;
+    return nodes.reduce((acc, node, index) => {
+      if (!index) {
+        return acc;
+      }
+      const {x0, x1, y1, y0, style} = node;
+      const x = x0;
+      const y = y0;
+      const nodeHeight = y1 - y0;
+      const nodeWidth = x1 - x0;
+
+      acc.maxY = Math.max(y + nodeHeight, acc.maxY);
+      acc.minY = Math.min(y, acc.minY);
+
+      const data = [
+        {x, y},
+        {x, y: y + nodeHeight},
+        {x: x + nodeWidth, y: y + nodeHeight},
+        {x: x + nodeWidth, y}
+      ];
+
+      acc.updatedNodes = acc.updatedNodes.concat([
+        (<PolygonSeries
+          animation={animation}
+          className="rv-treemap__leaf"
+          key={index}
+          color={color(node)}
+          type="literal"
+          onSeriesMouseEnter={onLeafMouseOver}
+          onSeriesMouseLeave={onLeafMouseOut}
+          onSeriesClick={onLeafClick}
+          data={data}
+          style={style}
+          />)
+      ]);
+      return acc;
+    }, {updatedNodes: [], maxY: -Infinity, minY: Infinity});
+  }
+
+  render() {
+    const {
+      className,
+      height,
+      mode,
+      nodes,
+      width
+    } = this.props;
+    const useCirclePacking = mode === 'circlePack';
+
+    const {minY, maxY, updatedNodes} = useCirclePacking ?
+      this.getCircularNodes() :
+      this.getNonCircularNodes();
+
+    const labels = nodes.reduce((acc, node) => {
+      if (!node.data.title) {
+        return acc;
+      }
+      return acc.concat({
+        ...node.data,
+        x: node.x0 || node.x,
+        y: node.y0 || node.y,
+        label: node.data.title
+      });
+    }, []);
+
+    return (
+      <XYPlot
+        className={`rv-treemap ${useCirclePacking ? 'rv-treemap-circle-packed' : ''} ${className}`}
+        width={width}
+        height={height}
+        yDomain={[maxY, minY]}
+        colorType="literal"
+        {...this.props}
+        >
+        {updatedNodes}
+        <LabelSeries data={labels} />
+      </XYPlot>
+    );
+  }
+}
+
+TreemapSVG.displayName = 'TreemapSVG';
+
+export default TreemapSVG;

--- a/tests/components/treemap-tests.js
+++ b/tests/components/treemap-tests.js
@@ -107,7 +107,7 @@ test('Treemap: SimpleTreemap', t => {
 test('Treemap: DynamicTreemap', t => {
   const $ = mount(<DynamicTreemap />);
   t.equal($.find('.rv-treemap__leaf').length, 20, 'should find the right number of children');
-  t.equal($.find('.rv-treemap').text(), '123123123123123123123123123123123123123123123123123123123123', 'should find the correct text shown');
+  t.equal($.find('.rv-treemap').text(), '2020202020202020202020202020202020202020', 'should find the correct text shown');
 
   t.end();
 });

--- a/tests/components/treemap-tests.js
+++ b/tests/components/treemap-tests.js
@@ -75,10 +75,31 @@ test('Treemap: Empty treemap', t => {
 
 test('Treemap: SimpleTreemap', t => {
   const $ = mount(<SimpleTreemap />);
-  t.equal($.find('.rv-treemap__leaf').length, 252, 'should find the right number of children');
-  t.equal($.find('.rv-treemap').text(), '', 'should find the correct text shown');
+  [
+    'circlePack',
+    'partition',
+    'partition-pivot',
+    'squarify',
+    'resquarify',
+    'slice',
+    'dice',
+    'slicedice',
+    'binary'
+  ].forEach(mode => {
+    const selector = mode === 'circlePack' ? '.rv-treemap__leaf circle' : '.rv-treemap__leaf';
+    // circle pack includes the root node, while the other modes do not
+    const numberOfElements = mode === 'circlePack' ? 252 : 251;
+    t.equal($.find(selector).length, numberOfElements, `${mode}: should find the right number of SVG children`);
+    t.equal($.text(), `USE DOMPREV MODE ${mode} NEXT MODE`, `${mode}: should find the correct text shown`);
+    // switch to svg
+    $.find('.showcase-button').at(0).simulate('click');
+    t.equal($.find('.rv-treemap__leaf').length, numberOfElements, `${mode}: should find the right number of DOM children`);
+    t.equal($.text(), `USE SVGPREV MODE ${mode} NEXT MODE`, `${mode}: should find the correct text shown`);
 
-  $.find('.showcase-button').at(1).simulate('click');
+    // switch back to dom and go to next mode
+    $.find('.showcase-button').at(0).simulate('click');
+    $.find('.showcase-button').at(2).simulate('click');
+  });
 
   t.end();
 });


### PR DESCRIPTION
An occasionally frustrating thing about the treemap is that it is the only chart type in react-vis that doesn't support SVG. This PR adds a SVG mode to tree map (#431) which could also be trivially extended to be canvas. 

Additionally this PR enables some inline style options which hadn't made their way to Treemap yet (#541)