### PR TITLE
Make arc listeners respect mouse events during animation

### DIFF
--- a/showcase/sunbursts/animated-sunburst.js
+++ b/showcase/sunbursts/animated-sunburst.js
@@ -51,24 +51,28 @@ const DIVERGING_COLOR_SCALE = ['#00939C', '#85C4C8', '#EC9370', '#C22E00'];
 
 export default class AnimatedSunburst extends React.Component {
   state = {
-    data: updateData()
+    data: updateData(),
+    hovering: false
   }
 
   render() {
-    const {data} = this.state;
+    const {data, hovering} = this.state;
     return (
       <div className="animated-sunburst-example-wrapper">
         <ShowcaseButton
           onClick={() => this.setState({data: updateData()})}
           buttonContent={'UPDATE'} />
+        <div>{hovering ? 'CURRENTLY HOVERING' : 'NOT HOVERED'}</div>
         <Sunburst
           animation={{damping: 20, stiffness: 300}}
           data={data}
           colorType={'category'}
           colorRange={DIVERGING_COLOR_SCALE}
           style={{stroke: '#fff'}}
+          onValueMouseOver={() => this.setState({hovering: true})}
+          onValueMouseOut={() => this.setState({hovering: false})}
           height={300}
-          width={350}/>
+          width={350} />
       </div>
     );
   }

--- a/showcase/sunbursts/basic-sunburst.js
+++ b/showcase/sunbursts/basic-sunburst.js
@@ -83,6 +83,7 @@ export default class BasicSunburst extends React.Component {
     return (
       <div className="basic-sunburst-example-wrapper">
         <Sunburst
+          animation
           className="basic-sunburst-example"
           hideRootNode
           onValueMouseOver={node => {

--- a/showcase/sunbursts/basic-sunburst.js
+++ b/showcase/sunbursts/basic-sunburst.js
@@ -75,18 +75,23 @@ export default class BasicSunburst extends React.Component {
   state = {
     pathValue: false,
     data: decoratedData,
-    finalValue: 'SUNBURST'
+    finalValue: 'SUNBURST',
+    clicked: false
   }
 
   render() {
-    const {data, finalValue, pathValue} = this.state;
+    const {clicked, data, finalValue, pathValue} = this.state;
     return (
       <div className="basic-sunburst-example-wrapper">
+        <div>{clicked ? 'click to unlock selection' : 'click to lock selection'}</div>
         <Sunburst
           animation
           className="basic-sunburst-example"
           hideRootNode
           onValueMouseOver={node => {
+            if (clicked) {
+              return;
+            }
             const path = getKeyPath(node).reverse();
             const pathAsMap = path.reduce((res, row) => {
               res[row] = true;
@@ -98,11 +103,12 @@ export default class BasicSunburst extends React.Component {
               data: updateData(decoratedData, pathAsMap)
             });
           }}
-          onValueMouseOut={() => this.setState({
+          onValueMouseOut={() => clicked ? () => {} : this.setState({
             pathValue: false,
             finalValue: false,
             data: updateData(decoratedData, false)
           })}
+          onValueClick={() => this.setState({clicked: !clicked})}
           style={{
             stroke: '#ddd',
             strokeOpacity: 0.3,

--- a/src/plot/series/arc-series.js
+++ b/src/plot/series/arc-series.js
@@ -122,6 +122,7 @@ class ArcSeries extends AbstractSeries {
       className,
       center,
       data,
+      disableSeries,
       hideSeries,
       marginLeft,
       marginTop,
@@ -167,7 +168,7 @@ class ArcSeries extends AbstractSeries {
         onClick={this._seriesClickHandler}
         ref="container"
         opacity={hideSeries ? 0 : 1}
-        pointerEvents={this.props.disableSeries ? 'none' : 'all'}
+        pointerEvents={disableSeries ? 'none' : 'all'}
         transform={`translate(${marginLeft + x(center)},${marginTop + y(center)})`}>
         {data.map((row, i) => {
           const noRadius = radiusDomain[1] === radiusDomain[0];

--- a/src/plot/series/arc-series.js
+++ b/src/plot/series/arc-series.js
@@ -122,6 +122,7 @@ class ArcSeries extends AbstractSeries {
       className,
       center,
       data,
+      hideSeries,
       marginLeft,
       marginTop,
       style
@@ -132,12 +133,17 @@ class ArcSeries extends AbstractSeries {
     }
 
     if (animation) {
+      const cloneData = data.map(d => ({...d}));
       return (
-        <Animation {...this.props} animatedProps={ANIMATED_SERIES_PROPS}>
-          <ArcSeries {...this.props} animation={null}/>
-        </Animation>
+        <g className="rv-xy-plot__series--arc__animation-wrapper">
+          <Animation {...this.props} animatedProps={ANIMATED_SERIES_PROPS} data={cloneData}>
+            <ArcSeries {...this.props} animation={null} disableSeries={true} data={cloneData}/>
+          </Animation>
+          <ArcSeries {...this.props} animation={null} hideSeries style={{stroke: 'red'}}/>
+        </g>
       );
     }
+
     const {scaleProps} = this.state;
     const {radiusDomain} = scaleProps;
     // need to generate our own functors as abstract series doesnt have anythign for us
@@ -160,6 +166,8 @@ class ArcSeries extends AbstractSeries {
         onMouseOut={this._seriesMouseOutHandler}
         onClick={this._seriesClickHandler}
         ref="container"
+        opacity={hideSeries ? 0 : 1}
+        pointerEvents={this.props.disableSeries ? 'none' : 'all'}
         transform={`translate(${marginLeft + x(center)},${marginTop + y(center)})`}>
         {data.map((row, i) => {
           const noRadius = radiusDomain[1] === radiusDomain[0];

--- a/tests/components/arc-series-tests.js
+++ b/tests/components/arc-series-tests.js
@@ -10,8 +10,9 @@ testRenderWithProps(ArcSeries, GENERIC_XYPLOT_SERIES_PROPS);
 test('ArcSeries: Showcase Example - ArcSeriesExample', t => {
   const $ = mount(<ArcSeriesExample />);
   t.equal($.text(), 'UPDATE-4-2024-4-2024', 'should find the right text content');
-  t.equal($.find('.rv-xy-plot__series--arc').length, 2, 'should find the right number of series');
-  t.equal($.find('.rv-xy-plot__series--arc path').length, 8, 'with the right number of arc in them');
+  // multiplied by two to account for shadow listeners
+  t.equal($.find('.rv-xy-plot__series--arc').length, 4, 'should find the right number of series');
+  t.equal($.find('.rv-xy-plot__series--arc path').length, 2 * 8, 'with the right number of arc in them');
 
   t.end();
 });

--- a/tests/components/radial-tests.js
+++ b/tests/components/radial-tests.js
@@ -63,7 +63,8 @@ test('RadialChart: Showcase Example - Custom radius example', t => {
   const $ = mount(<CustomRadiusRadialChart />);
   $.find('.rv-radial-chart__series--pie__slice').at(1).simulate('mouseEnter');
   $.find('.rv-radial-chart__series--pie__slice').at(1).simulate('mouseLeave');
-  t.equal($.find('.rv-radial-chart__series--pie__slice').length, 5, 'should find the same number of slices as data entries');
+  // multiplied by two to account for the shadow listeners
+  t.equal($.find('.rv-radial-chart__series--pie__slice').length, 2 * 5, 'should find the same number of slices as data entries');
   t.equal($.find('.rv-xy-plot__series--label-text').length, 4, 'should find the right number of label wrappers');
   t.equal($.text(), 'Sub Label onlyAlt LabelSuper Custom labelWith annotation', 'should find appropriate text');
   t.end();

--- a/tests/components/sunburst-tests.js
+++ b/tests/components/sunburst-tests.js
@@ -67,7 +67,8 @@ test('Sunburst: Empty', t => {
 
 test('Sunburst: Flare Demo', t => {
   const $ = mount(<BasicSunburst />);
-  t.equal($.find('.rv-xy-plot__series--arc path').length, 251, 'should find the right number of children');
+  // multiplied by two to account for the shadow listeners
+  t.equal($.find('.rv-xy-plot__series--arc path').length, 251 * 2, 'should find the right number of children');
   t.equal($.text(), 'SUNBURST', 'should find the correct text inside of the chart');
   // check hover state
   t.deepEqual($.state().pathValue, false, 'should initially find no hover path');

--- a/tests/components/sunburst-tests.js
+++ b/tests/components/sunburst-tests.js
@@ -4,6 +4,7 @@ import {mount} from 'enzyme';
 import Sunburst from 'sunburst';
 import BasicSunburst from '../../showcase/sunbursts/basic-sunburst';
 import SunburstWithTooltips from '../../showcase/sunbursts/sunburst-with-tooltips';
+import AnimatedSunburst from '../../showcase/sunbursts/animated-sunburst';
 
 import {testRenderWithProps} from '../test-utils';
 
@@ -65,15 +66,22 @@ test('Sunburst: Empty', t => {
   t.end();
 });
 
-test('Sunburst: Flare Demo', t => {
+test('Sunburst: BasicSunburst', t => {
   const $ = mount(<BasicSunburst />);
   // multiplied by two to account for the shadow listeners
   t.equal($.find('.rv-xy-plot__series--arc path').length, 251 * 2, 'should find the right number of children');
-  t.equal($.text(), 'SUNBURST', 'should find the correct text inside of the chart');
+  t.equal($.text(), 'click to lock selectionSUNBURST', 'should find the correct text inside of the chart');
   // check hover state
   t.deepEqual($.state().pathValue, false, 'should initially find no hover path');
   $.find('.rv-xy-plot__series--arc-path').at(200).simulate('mouseover');
   t.deepEqual($.state().pathValue, 'root > vis > events > DataEvent', 'should find the correct path hovered');
+
+  $.find('.rv-xy-plot__series--arc-path').at(1).simulate('click');
+  t.equal($.text(), 'click to unlock selectionDataEventroot > vis > events > DataEvent', 'should find the right text');
+  $.find('.rv-xy-plot__series--arc-path').at(1).simulate('mouseLeave');
+  $.find('.rv-xy-plot__series--arc-path').at(10).simulate('mouseEnter');
+
+  t.equal($.text(), 'click to unlock selectionDataEventroot > vis > events > DataEvent', 'should find the right text');
   t.end();
 });
 
@@ -83,6 +91,16 @@ test('Sunburst: SunburstWithTooltips', t => {
   t.equal($.find('.rv-xy-plot__series--arc path').length, 10, 'should find the right number of children');
   $.find('.rv-xy-plot__series--arc-path').at(1).simulate('mouseOver');
   t.equal($.text(), 'cooldogssunglasses#FF991F', 'should find appropriate hover text');
+
+  t.end();
+});
+
+test('Sunburst: AnimatedSunburst', t => {
+  const $ = mount(<AnimatedSunburst />);
+  t.equal($.text(), 'UPDATENOT HOVERED', 'should find the right text');
+  t.ok($.find('.rv-xy-plot__series--arc path').length > 2, 'should find a minimum number of elements');
+  $.find('.rv-xy-plot__series--arc-path').at(1).simulate('mouseOver');
+  t.equal($.text(), 'UPDATECURRENTLY HOVERING', 'should find the sunburst is now hovered');
 
   t.end();
 });


### PR DESCRIPTION
This PR Addresses #510 and provides a technique for addressing #381. 

It is often the case that the animation component clobbers listeners. This can be super confusing! One solution is to slightly modify the way that we call animation to lay a shadow "listener layer" on top of the render SVG. This allows us to separate the concerns between calling events and making good animation. 