### PR TITLE
Use component name as fallback for display name

### DIFF
--- a/src/make-vis-flexible.js
+++ b/src/make-vis-flexible.js
@@ -86,6 +86,15 @@ function removeSubscriber(cb) {
 }
 
 /**
+ * Helper for getting a display name for the child component
+ * @param {*} Component React class for the child component.
+ * @returns {String} The child components name
+ */
+function getDisplayName(Component) {
+  return Component.displayName || Component.name || 'Component';
+}
+
+/**
  * Add the ability to stretch the visualization on window resize.
  * @param {*} Component React class for the child component.
  * @returns {*} Flexible component.
@@ -164,7 +173,7 @@ function makeFlexible(Component, isWidthFlexible, isHeightFlexible) {
     }
   };
 
-  ResultClass.displayName = `Flexible${Component.displayName}`;
+  ResultClass.displayName = `Flexible${getDisplayName(Component)}`;
 
   return ResultClass;
 }

--- a/tests/components/make-vis-flexible.js
+++ b/tests/components/make-vis-flexible.js
@@ -1,0 +1,18 @@
+import test from 'tape';
+import {makeWidthFlexible} from 'make-vis-flexible';
+
+test('makeWidthFlexible: displayName given', t => {
+  function ChildComponent() {}
+  ChildComponent.displayName = 'ChildComponentWithDisplayName';
+  const FlexibleComponent = makeWidthFlexible(ChildComponent);
+  t.equal(FlexibleComponent.displayName, 'FlexibleChildComponentWithDisplayName', 'should use component display name');
+  t.end();
+});
+
+test('makeWidthFlexible: displayName not given', t => {
+  function ChildComponent() {}
+  const FlexibleComponent = makeWidthFlexible(ChildComponent);
+  t.equal(FlexibleComponent.displayName, 'FlexibleChildComponent', 'should default to component name');
+  t.end();
+});
+

--- a/tests/index.js
+++ b/tests/index.js
@@ -48,6 +48,7 @@ import './components/interaction-article-tests';
 import './components/legends-tests';
 import './components/label-series-tests';
 import './components/line-series-tests';
+import './components/make-vis-flexible';
 import './components/mark-series-tests';
 import './components/whisker-series-tests';
 import './components/polygon-series-tests';


### PR DESCRIPTION
When using the HOC `makeWidthFlexible` the resulting component will look like this:

```html
<Flexibleundefined ...>...</Flexibleundefined>
```

It can be fixed by explicitly setting a displayName:

```js
MyComponent.displayName = 'MyComponent';
makeWidthFlexible(MyComponent);
```

I think the `makeWidthFlexible` HOC should fallback to use the component name, if no display name is given. This will always be more useful than `undefined`