### PR TITLE
handle right clicks to series and marks

### DIFF
--- a/docs/markdown/arc-series.md
+++ b/docs/markdown/arc-series.md
@@ -173,6 +173,20 @@ This handler fires when the user mouses over a series, and provides the correspo
   }}
 ```
 
+#### onSeriesRightClick
+Type: `function`  
+Default: none  
+This handler fires when the user right-clicks somewhere on a series, and provides the corresponding event. Unlike onClick, it doesn't pass a specific datapoint.
+
+```jsx
+<ArcSeries
+...
+  onSeriesRightClick={(event)=>{
+    // does something on right click
+    // you can access the value of the event
+  }}
+```
+
 #### onValueClick
 Type: `function`  
 Default: none  
@@ -211,6 +225,20 @@ The handler passes two arguments, the corresponding datapoint and the actual eve
 ...
   onValueMouseOver={(datapoint, event)=>{
     // does something on click
+    // you can access the value of the event
+  }}
+```
+
+#### onValueRightClick
+Type: `function`  
+Default: none  
+This handler is triggered either when the user right-clicks on a mark.
+The handler passes two arguments, the corresponding datapoint and the actual event.
+```jsx
+<ArcSeries
+...
+  onValueRightClick={(datapoint, event)=>{
+    // does something on right click
     // you can access the value of the event
   }}
 ```

--- a/docs/markdown/bar-series.md
+++ b/docs/markdown/bar-series.md
@@ -152,6 +152,20 @@ This handler fires when the user mouses over a series, and provides the correspo
   }}
 ```
 
+#### onSeriesRightClick
+Type: `function`  
+Default: none  
+This handler fires when the user right-clicks somewhere on a series, and provides the corresponding event. Unlike onClick, it doesn't pass a specific datapoint.
+
+```jsx
+<BarSeries
+...
+  onSeriesRightClick={(event)=>{
+    // does something on click
+    // you can access the value of the event
+  }}
+```
+
 #### onValueClick
 Type: `function`  
 Default: none  
@@ -190,6 +204,20 @@ The handler passes two arguments, the corresponding datapoint and the actual eve
 ...
   onValueMouseOver={(datapoint, event)=>{
     // does something on click
+    // you can access the value of the event
+  }}
+```
+
+#### onValueRightClick
+Type: `function`  
+Default: none  
+This handler is triggered either when the user right-clicks on a mark.
+The handler passes two arguments, the corresponding datapoint and the actual event.
+```jsx
+<BarSeries
+...
+  onValueClick={(datapoint, event)=>{
+    // does something on right click
     // you can access the value of the event
   }}
 ```

--- a/docs/markdown/heatmap-series.md
+++ b/docs/markdown/heatmap-series.md
@@ -134,6 +134,10 @@ Callback is triggered with two arguments. `value` is the data point, `info` obje
 - `event` is the event object.
 See [interaction](interaction.md)
 
+#### onValueClick (optional)
+Type: `function(d, {event})`  
+`click` event handler for the elements corresponding separate data points. First argument received is, `d`, the relevant data point, and second an object with the only `event` property.  
+
 #### onValueMouseOver (optional)
 Type: `function(d, {event})`  
 `mouseover` event handler for the elements corresponding separate data points. First argument received is, `d`, the relevant data point, and second an object with the only `event` property.
@@ -142,7 +146,6 @@ Type: `function(d, {event})`
 Type: `function(d, {event})`  
 `mouseout` event handler for the elements corresponding separate data points. First argument received is, `d`, the relevant data point, and second an object with the only `event` property.  
 
-#### onValueClick (optional)
+#### onValueRightClick (optional)
 Type: `function(d, {event})`  
-`click` event handler for the elements corresponding separate data points. First argument received is, `d`, the relevant data point, and second an object with the only `event` property.  
-
+`right-click` event handler for the elements corresponding separate data points. First argument received is, `d`, the relevant data point, and second an object with the only `event` property. 

--- a/docs/markdown/interaction.md
+++ b/docs/markdown/interaction.md
@@ -12,19 +12,20 @@ These events can be implemented either at the XYPlot level or at the plot level:
 
 ### What handlers are implemented by series type
 
-| Series                                | onNearestX | onNearestY | onSeriesClick | onSeriesMouseOut | onSeriesMouseOver | onValueClick | onValueMouseOut | onValueMouseOver |
-|---------------------------------------|------------|------------|---------------|------------------|-------------------|--------------|-----------------|------------------|
-| [ArcSeries](arc-series.md)            | ✔︎          | ✔︎          |               |                  |                   | ✔︎            | ✔︎               | ✔︎                |
-| [AreaSeries](area-series.md)          | ✔︎          | ✔︎          | ✔︎             | ✔︎                | ✔︎                 |              |                 |                  |
-| [BarSeries](bar-series.md)            | ✔︎          | ✔︎          |               |                  |                   | ✔︎            | ✔︎               | ✔︎                |
-| [ContourSeries](contour-series.md)    | ✔︎          | ✔︎          |               |                  |                   |              |                 |                  |
-| [HeatmapSeries](heatmap-series.md)    | ✔︎          | ✔︎          |               |                  |                   | ✔︎            | ✔︎               | ✔︎                |
-| [LabelSeries](label-series.md)        | ✔︎          | ✔︎          |               |                  |                   | ✔︎            | ✔︎               | ✔︎                |
-| [LineSeries](line-series.md)          | ✔︎          | ✔︎          | ✔︎             | ✔︎                | ✔︎                 |              |                 |                  |
-| [LineMarkSeries](line-mark-series.md) | ✔︎          | ✔︎          | ✔︎             | ✔︎                | ✔︎                 | ✔︎            | ✔︎               | ✔︎                |
-| [MarkSeries](mark-series.md)           | ✔︎          | ✔︎          |               |                  |                   | ✔︎            | ✔︎               | ✔︎                |
-| [PolygonSeries](polygon-series.md)    | ✔︎          | ✔︎          | ✔︎             | ✔︎                | ✔︎                 |              |                 |                  |
-| [RectSeries](rect-series.md)                            | ✔︎          | ✔︎          |               |                  |                   | ✔︎            | ✔︎               | ✔︎                |
+| Series                                | Proximity handlers (onNearestX, onNearestY) | series level handlers (onSeriesClick, onSeriesRightClick, onSeriesMouseOver, onSeriesMouseOut) | mark-level handlers (onValueClick, onValueRightClick, onValueMouseOver, onValueMouseOut) |
+|---------------------------------------|---------------------------------------------|------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------|
+| [ArcSeries](arc-series.md)            |                      ✔︎                      |                                                ✔︎                                               |                                             ✔︎                                            |
+| [AreaSeries](area-series.md)          |                      ✔︎                      |                                                ✔︎                                               |                                                                                          |
+| [BarSeries](bar-series.md)            |                      ✔︎                      |                                                ✔︎                                               |                                             ✔︎                                            |
+| [ContourSeries](contour-series.md)    |                      ✔︎                      |                                                                                                |                                                                                          |
+| [HeatmapSeries](heatmap-series.md)    |                      ✔︎                      |                                                ✔︎                                               |                                             ✔︎                                            |
+| [LabelSeries](label-series.md)        |                      ✔︎                      |                                                ✔︎                                               |                                             ✔︎                                            |
+| [LineSeries](line-series.md)          |                      ✔︎                      |                                                ✔︎                                               |                                                                                          |
+| [LineMarkSeries](line-mark-series.md) |                      ✔︎                      |                                                ✔︎                                               |                                             ✔︎                                            |
+| [MarkSeries](mark-series.md)          |                      ✔︎                      |                                                ✔︎                                               |                                             ✔︎                                            |
+| [PolygonSeries](polygon-series.md)    |                      ✔︎                      |                                                ✔︎                                               |                                                                                          |
+| [RectSeries](rect-series.md)          |                      ✔︎                      |                                                ✔︎                                               |                                             ✔︎                                            |
+| [WhiskerSeries](whisker-series.md)    |                      ✔︎                      |                                                ✔︎                                               |                                             ✔︎                                            |
 
 How to read this table:
 For some series types (Arc, Bar, Rect, Label, Mark) - onValueClick, onValueMouseOut and onValueMouseOver handlers will work at the mark type. When the user clicks on the series, or moves their mouse on our out of it, an event handler will be fired and will pass the datapoint corresponding to the mark that the user interacted with.
@@ -103,7 +104,7 @@ onNearestXY is at the series level, not at the plot level. If you attach onNeare
 #### onSeriesClick
 Type: `function`  
 Default: none  
-This handler fires when the user clicks somewhere on a series, and provides the corresponding event. Unlike onClick, it doesn't pass a specific datapoint.
+This handler fires when the user clicks somewhere on a series, and provides the corresponding event. Unlike onValueClick, it doesn't pass a specific datapoint.
 
 ```jsx
 <AreaSeries
@@ -113,6 +114,21 @@ This handler fires when the user clicks somewhere on a series, and provides the 
   	// you can access the value of the event
   }}
 ```
+
+#### onSeriesRightClick
+Type: `function`  
+Default: none  
+This handler fires when the user right-clicks somewhere on a series, and provides the corresponding event. Unlike onValueRightClick, it doesn't pass a specific datapoint.
+
+```jsx
+<AreaSeries
+...
+  onSeriesRightClick={(event)=>{
+    // does something on right click
+    // you can access the value of the event
+  }}
+```
+
 
 #### onSeriesMouseOut
 Type: `function`  
@@ -153,6 +169,20 @@ The handler passes two arguments, the corresponding datapoint and the actual eve
   onValueClick={(datapoint, event)=>{
   	// does something on click
   	// you can access the value of the event
+  }}
+```
+
+#### onValueRightClick
+Type: `function`  
+Default: none  
+This handler is triggered either when the user right-clicks on a mark.
+The handler passes two arguments, the corresponding datapoint and the actual event.
+```jsx
+<MarkSeries
+...
+  onValueRightClick={(datapoint, event)=>{
+    // does something on right click
+    // you can access the value of the event
   }}
 ```
 

--- a/docs/markdown/label-series.md
+++ b/docs/markdown/label-series.md
@@ -94,6 +94,10 @@ Callback is triggered with two arguments. `value` is the data point, `info` obje
 - `event` is the event object.
 See [interaction](interaction.md)
 
+#### onValueClick (optional)
+Type: `function(d, {event})`  
+`click` event handler for the elements corresponding separate data points. First argument received is, `d`, the relevant data point, and second an object with the only `event` property.  
+
 #### onValueMouseOver (optional)
 Type: `function(d, {event})`  
 `mouseover` event handler for the elements corresponding separate data points. First argument received is, `d`, the relevant data point, and second an object with the only `event` property.
@@ -102,6 +106,6 @@ Type: `function(d, {event})`
 Type: `function(d, {event})`  
 `mouseout` event handler for the elements corresponding separate data points. First argument received is, `d`, the relevant data point, and second an object with the only `event` property.  
 
-#### onValueClick (optional)
+#### onValueRightClick (optional)
 Type: `function(d, {event})`  
-`click` event handler for the elements corresponding separate data points. First argument received is, `d`, the relevant data point, and second an object with the only `event` property.  
+`right-click` event handler for the elements corresponding separate data points. First argument received is, `d`, the relevant data point, and second an object with the only `event` property.  

--- a/docs/markdown/line-mark-series.md
+++ b/docs/markdown/line-mark-series.md
@@ -156,6 +156,20 @@ This handler fires when the user mouses over a series, and provides the correspo
   }}
 ```
 
+#### onSeriesRightClick
+Type: `function`  
+Default: none  
+This handler fires when the user right-clicks somewhere on a series, and provides the corresponding event. Unlike onClick, it doesn't pass a specific datapoint.
+
+```jsx
+<LineMarkSeries
+...
+  onSeriesRightClick={(event)=>{
+    // does something on right click
+    // you can access the value of the event
+  }}
+```
+
 #### onValueClick
 Type: `function`  
 Default: none  
@@ -197,3 +211,16 @@ The handler passes two arguments, the corresponding datapoint and the actual eve
     // you can access the value of the event
   }}
 ```
+
+#### onValueRightClick
+Type: `function`  
+Default: none  
+This handler is triggered either when the user right-clicks on a mark.
+The handler passes two arguments, the corresponding datapoint and the actual event.
+```jsx
+<LineMarkSeries
+...
+  onValueRightClick={(datapoint, event)=>{
+    // does something on right click
+    // you can access the value of the event
+  }}

--- a/docs/markdown/line-series.md
+++ b/docs/markdown/line-series.md
@@ -78,6 +78,11 @@ An object which holds CSS properties that will be applied to the SVG element(s) 
 
 ### Interaction handlers
 
+Note - interacting with a line may be difficult especially with the standard width. To address that, consider:
+- the proximity handlers - onNearestX, onNearestXY;
+- increasing the width of your line to make it easier to reach with the mouse,
+- creating a near-transparent line series with extra width to catch mouse events. 
+
 #### onNearestX (optional)
 Type: `function(value, {event, innerX, index})`  
 A callback function which is triggered each time the mouse pointer moves. It can access the datapoint of the mark whose x position is the closest to that of the cursor. 
@@ -136,5 +141,19 @@ This handler fires when the user mouses over a LineSeries, and provides the corr
   onSeriesMouseOver={(event)=>{
   	// does something on mouse over
   	// you can access the value of the event
+  }}
+```
+
+#### onSeriesRightClick
+Type: `function`  
+Default: none  
+This handler fires when the user right-clicks somewhere on a LineSeries, and provides the corresponding event. See [interaction](interaction.nd)
+
+```jsx
+<LineSeries
+...
+  onSeriesRightClick={(event)=>{
+    // does something on click
+    // you can access the value of the event
   }}
 ```

--- a/docs/markdown/mark-series.md
+++ b/docs/markdown/mark-series.md
@@ -171,6 +171,20 @@ This handler fires when the user mouses over a series, and provides the correspo
   }}
 ```
 
+#### onSeriesClick
+Type: `function`
+Default: none
+This handler fires when the user right-clicks somewhere on a series, and provides the corresponding event. Unlike onClick, it doesn't pass a specific datapoint.
+
+```jsx
+<MarkSeries
+...
+  onSeriesRightClick={(event)=>{
+    // does something on right click
+    // you can access the value of the event
+  }}
+```
+
 #### onValueClick
 Type: `function`
 Default: none
@@ -209,6 +223,20 @@ The handler passes two arguments, the corresponding datapoint and the actual eve
 ...
   onValueMouseOver={(datapoint, event)=>{
     // does something on click
+    // you can access the value of the event
+  }}
+```
+
+#### onValueRightClick
+Type: `function`
+Default: none
+This handler is triggered either when the user right-clicks on a mark.
+The handler passes two arguments, the corresponding datapoint and the actual event.
+```jsx
+<MarkSeries
+...
+  onValueRightClick={(datapoint, event)=>{
+    // does something on right click
     // you can access the value of the event
   }}
 ```

--- a/docs/markdown/polygon-series.md
+++ b/docs/markdown/polygon-series.md
@@ -85,15 +85,19 @@ Callback is triggered with two arguments. `value` is the data point, `info` obje
 - `event` is the event object.
 See [interaction](interaction.md)
 
-#### onSeriesMouseOver (optional)
-Type: `function(d, {event})`  
-`mouseover` event handler for the elements corresponding separate data points. First argument received is, `d`, the relevant data point, and second an object with the only `event` property. See [interaction](interaction.md)
-
-#### onSeriesMouseOut (optional)
-Type: `function(d, {event})`  
-`mouseout` event handler for the elements corresponding separate data points. First argument received is, `d`, the relevant data point, and second an object with the only `event` property. See [interaction](interaction.md)
-
 #### onSeriesClick (optional)
 Type: `function(d, {event})`  
 `click` event handler for the elements corresponding separate data points. First argument received is, `d`, the relevant data point, and second an object with the only `event` property. See [interaction](interaction.md)
 
+#### onSeriesMouseOut (optional)
+Type: `function(d, {event})`  
+`mouseout` event handler for the elements corresponding separate data points. First argument received is, `d`, the relevant data point, and second an 
+
+#### onSeriesMouseOver (optional)
+Type: `function(d, {event})`  
+`mouseover` event handler for the elements corresponding separate data points. First argument received is, `d`, the relevant data point, and second an object with the only `event` property. See [interaction](interaction.md)
+object with the only `event` property. See [interaction](interaction.md)
+
+#### onSeriesRightClick (optional)
+Type: `function(d, {event})`  
+`right-click` event handler for the elements corresponding separate data points. First argument received is, `d`, the relevant data point, and second an object with the only `event` property. See [interaction](interaction.md)

--- a/docs/markdown/rect-series.md
+++ b/docs/markdown/rect-series.md
@@ -140,26 +140,34 @@ Callback is triggered with two arguments. `value` is the data point, `info` obje
 - `event` is the event object.
 See [interaction](interaction.md)
 
-#### onValueMouseOver (optional)
+#### onValueClick (optional)
 Type: `function(d, {event})`  
-`mouseover` event handler for the elements corresponding separate data points. First argument received is, `d`, the relevant data point, and second an object with the only `event` property.
+`click` event handler for the elements corresponding separate data points. First argument received is, `d`, the relevant data point, and second an object with the only `event` property.  
 
 #### onValueMouseOut (optional)
 Type: `function(d, {event})`  
 `mouseout` event handler for the elements corresponding separate data points. First argument received is, `d`, the relevant data point, and second an object with the only `event` property.  
 
-#### onValueClick (optional)
+#### onValueMouseOver (optional)
 Type: `function(d, {event})`  
-`click` event handler for the elements corresponding separate data points. First argument received is, `d`, the relevant data point, and second an object with the only `event` property.  
+`mouseover` event handler for the elements corresponding separate data points. First argument received is, `d`, the relevant data point, and second an object with the only `event` property.
 
-#### onSeriesMouseOver (optional)
+#### onValueRightClick (optional)
+Type: `function(d, {event})`  
+`right-click` event handler for the elements corresponding separate data points. First argument received is, `d`, the relevant data point, and second an object with the only `event` property.  
+
+#### onSeriesClick (optional)
 Type: `function({event})`  
-`mouseover` event handler for the entire series. Receives an object as argument with the `event` property.
+`click` event handler for the entire series. Receives an object as argument with the `event` property.
 
 #### onSeriesMouseOut (optional)
 Type: `function({event})`  
 `mouseout` event handler for the entire series. Receives an object as argument with the `event` property.
 
-#### onSeriesClick (optional)
+#### onSeriesMouseOver (optional)
 Type: `function({event})`  
-`click` event handler for the entire series. Receives an object as argument with the `event` property.
+`mouseover` event handler for the entire series. Receives an object as argument with the `event` property.
+
+#### onSeriesRightClick (optional)
+Type: `function({event})`  
+`right-click` event handler for the entire series. Receives an object as argument with the `event` property.

--- a/docs/markdown/sunburst.md
+++ b/docs/markdown/sunburst.md
@@ -139,6 +139,12 @@ Type: `function`
 
 Pass in a function that will be called on click on a given arc.
 
+#### onValueRightClick (optional)
+Type: `function`
+- Should accept arguments (arc node, domEvent)
+
+Pass in a function that will be called on right click on a given arc.
+
 #### onValueMouseOver (optional)
 Type: `function`
 - Should accept arguments (arc node, domEvent)

--- a/docs/markdown/whisker-series.md
+++ b/docs/markdown/whisker-series.md
@@ -146,7 +146,7 @@ See [interaction](interaction.md)
 #### onSeriesClick
 Type: `function`
 Default: none
-This handler fires when the user clicks somewhere on a series, and provides the corresponding event. Unlike onClick, it doesn't pass a specific datapoint.
+This handler fires when the user clicks somewhere on a series, and provides the corresponding event. Unlike onValueClick, it doesn't pass a specific datapoint.
 
 ```jsx
 <WhiskerSeries
@@ -181,6 +181,20 @@ This handler fires when the user mouses over a series, and provides the correspo
 ...
   onSeriesMouseOver={(event)=>{
     // does something on mouse over
+    // you can access the value of the event
+  }}
+```
+
+#### onSeriesRightClick
+Type: `function`
+Default: none
+This handler fires when the user right-clicks somewhere on a series, and provides the corresponding event. Unlike onValueRightClick, it doesn't pass a specific datapoint.
+
+```jsx
+<WhiskerSeries
+...
+  onSeriesRightClick={(event)=>{
+    // does something on click
     // you can access the value of the event
   }}
 ```
@@ -223,6 +237,20 @@ The handler passes two arguments, the corresponding datapoint and the actual eve
 ...
   onValueMouseOver={(datapoint, event)=>{
     // does something on click
+    // you can access the value of the event
+  }}
+```
+
+#### onValueRightClick
+Type: `function`
+Default: none
+This handler is triggered either when the user right-clicks on a mark.
+The handler passes two arguments, the corresponding datapoint and the actual event.
+```jsx
+<WhiskerSeries
+...
+  onValueClick={(datapoint, event)=>{
+    // does something on right click
     // you can access the value of the event
   }}
 ```

--- a/src/plot/series/abstract-series.js
+++ b/src/plot/series/abstract-series.js
@@ -43,9 +43,11 @@ const propTypes = {
   onValueMouseOver: PropTypes.func,
   onValueMouseOut: PropTypes.func,
   onValueClick: PropTypes.func,
+  onValueRightClick: PropTypes.func,
   onSeriesMouseOver: PropTypes.func,
   onSeriesMouseOut: PropTypes.func,
   onSeriesClick: PropTypes.func,
+  onSeriesRightClick: PropTypes.func,
   onNearestX: PropTypes.func,
   onNearestXY: PropTypes.func,
   style: PropTypes.object,
@@ -82,6 +84,8 @@ class AbstractSeries extends PureComponent {
     this._valueMouseOutHandler = this._valueMouseOutHandler.bind(this);
     this._seriesClickHandler = this._seriesClickHandler.bind(this);
     this._valueClickHandler = this._valueClickHandler.bind(this);
+    this._seriesRightClickHandler = this._seriesRightClickHandler.bind(this);
+    this._valueRightClickHandler = this._valueRightClickHandler.bind(this);
   }
 
   /**
@@ -157,6 +161,22 @@ class AbstractSeries extends PureComponent {
   }
 
   /**
+   * Right Click handler for the specific series' value.
+   * @param {Object} d Value object
+   * @param {Object} event Event.
+   * @protected
+   */
+  _valueRightClickHandler(d, event) {
+    const {onValueRightClick, onSeriesRightClick} = this.props;
+    if (onValueRightClick) {
+      onValueRightClick(d, {event});
+    }
+    if (onSeriesRightClick) {
+      onSeriesRightClick({event});
+    }
+  }
+
+  /**
    * Click handler for the entire series.
    * @param {Object} event Event.
    * @protected
@@ -165,6 +185,18 @@ class AbstractSeries extends PureComponent {
     const {onSeriesClick} = this.props;
     if (onSeriesClick) {
       onSeriesClick({event});
+    }
+  }
+
+   /**
+   * Right Click handler for the entire series.
+   * @param {Object} event Event.
+   * @protected
+   */
+  _seriesRightClickHandler(event) {
+    const {onSeriesRightClick} = this.props;
+    if (onSeriesRightClick) {
+      onSeriesRightClick({event});
     }
   }
 

--- a/src/plot/series/arc-series.js
+++ b/src/plot/series/arc-series.js
@@ -166,6 +166,7 @@ class ArcSeries extends AbstractSeries {
         onMouseOver={this._seriesMouseOverHandler}
         onMouseOut={this._seriesMouseOutHandler}
         onClick={this._seriesClickHandler}
+        onContextMenu={this._seriesRightClickHandler}
         ref="container"
         opacity={hideSeries ? 0 : 1}
         pointerEvents={disableSeries ? 'none' : 'all'}
@@ -190,6 +191,7 @@ class ArcSeries extends AbstractSeries {
               ...rowStyle
             },
             onClick: e => this._valueClickHandler(modifyRow(row), e),
+            onContextMenu: e => this._valueRightClickHandler(modifyRow(row), e),
             onMouseOver: e => this._valueMouseOverHandler(modifyRow(row), e),
             onMouseOut: e => this._valueMouseOutHandler(modifyRow(row), e),
             key: i,

--- a/src/plot/series/area-series.js
+++ b/src/plot/series/area-series.js
@@ -76,6 +76,7 @@ class AreaSeries extends AbstractSeries {
         onMouseOver={this._seriesMouseOverHandler}
         onMouseOut={this._seriesMouseOutHandler}
         onClick={this._seriesClickHandler}
+        onContextMenu={this._seriesRightClickHandler}
         style={{
           opacity,
           stroke,

--- a/src/plot/series/bar-series.js
+++ b/src/plot/series/bar-series.js
@@ -100,6 +100,7 @@ class BarSeries extends AbstractSeries {
             [valuePosAttr]: Math.min(value0Functor(d), valueFunctor(d)),
             [valueSizeAttr]: Math.abs(-value0Functor(d) + valueFunctor(d)),
             onClick: e => this._valueClickHandler(d, e),
+            onContextMenu: e => this._valueRightClickHandler(d, e),
             onMouseOver: e => this._valueMouseOverHandler(d, e),
             onMouseOut: e => this._valueMouseOutHandler(d, e),
             key: i

--- a/src/plot/series/heatmap-series.js
+++ b/src/plot/series/heatmap-series.js
@@ -76,6 +76,7 @@ class HeatmapSeries extends AbstractSeries {
             height: yDistance,
             key: i,
             onClick: e => this._valueClickHandler(d, e),
+            onContextMenu: e => this._valueRightClickHandler(d, e),
             onMouseOver: e => this._valueMouseOverHandler(d, e),
             onMouseOut: e => this._valueMouseOutHandler(d, e)
           };

--- a/src/plot/series/label-series.js
+++ b/src/plot/series/label-series.js
@@ -76,6 +76,7 @@ class LabelSeries extends AbstractSeries {
             className: 'rv-xy-plot__series--label-text',
             key: i,
             onClick: e => this._valueClickHandler(d, e),
+            onContextMenu: e => this._valueRightClickHandler(d, e),
             onMouseOver: e => this._valueMouseOverHandler(d, e),
             onMouseOut: e => this._valueMouseOutHandler(d, e),
             textAnchor: leftOfMiddle ? 'start' : 'end',

--- a/src/plot/series/line-series.js
+++ b/src/plot/series/line-series.js
@@ -100,6 +100,7 @@ class LineSeries extends AbstractSeries {
         onMouseOver={this._seriesMouseOverHandler}
         onMouseOut={this._seriesMouseOutHandler}
         onClick={this._seriesClickHandler}
+        onContextMenu={this._seriesRightClickHandler}
         style={{
           opacity,
           strokeDasharray: STROKE_STYLES[strokeStyle] || strokeDasharray,

--- a/src/plot/series/mark-series.js
+++ b/src/plot/series/mark-series.js
@@ -75,6 +75,7 @@ class MarkSeries extends AbstractSeries {
             },
             key: i,
             onClick: e => this._valueClickHandler(d, e),
+            onContextMenu: e => this._valueRightClickHandler(d, e),
             onMouseOver: e => this._valueMouseOverHandler(d, e),
             onMouseOut: e => this._valueMouseOutHandler(d, e)
           };

--- a/src/plot/series/polygon-series.js
+++ b/src/plot/series/polygon-series.js
@@ -70,6 +70,7 @@ class PolygonSeries extends AbstractSeries {
         onMouseOver: this._seriesMouseOverHandler,
         onMouseOut: this._seriesMouseOutHandler,
         onClick: this._seriesClickHandler,
+        onContextMenu: this._seriesRightClickHandler,
         fill: color || DEFAULT_COLOR,
         style,
         d: generatePath(data, xFunctor, yFunctor),

--- a/src/plot/series/rect-series.js
+++ b/src/plot/series/rect-series.js
@@ -94,6 +94,7 @@ class RectSeries extends AbstractSeries {
             [valuePosAttr]: Math.min(value0Functor(d), valueFunctor(d)),
             [valueSizeAttr]: Math.abs(-value0Functor(d) + valueFunctor(d)),
             onClick: e => this._valueClickHandler(d, e),
+            onContextMenu: e => this._valueRightClickHandler(d, e),
             onMouseOver: e => this._valueMouseOverHandler(d, e),
             onMouseOut: e => this._valueMouseOutHandler(d, e),
             key: i

--- a/src/plot/series/whisker-series.js
+++ b/src/plot/series/whisker-series.js
@@ -39,8 +39,9 @@ const DEFAULT_CROSS_BAR_WIDTH = 6;
  */
 const renderWhiskerMark = (whiskerMarkProps) => (d, i) => {
   const {
-    crossBarWidth, opacityFunctor, sizeFunctor, strokeFunctor, strokeWidth, style,
-    valueClickHandler, valueMouseOutHandler, valueMouseOverHandler, xFunctor, yFunctor
+    crossBarWidth, opacityFunctor, sizeFunctor, strokeFunctor, strokeWidth,
+    style, valueClickHandler, valueMouseOutHandler, valueMouseOverHandler,
+    valueRightClickHandler, xFunctor, yFunctor
   } = whiskerMarkProps;
 
   const r = sizeFunctor ? sizeFunctor(d) : 0;
@@ -130,6 +131,7 @@ const renderWhiskerMark = (whiskerMarkProps) => (d, i) => {
   return (
     <g className="mark-whiskers" key={i}
       onClick={e => valueClickHandler(d, e)}
+      onContextMenu={e => valueRightClickHandler(d, e)}
       onMouseOver={e => valueMouseOverHandler(d, e)}
       onMouseOut={e => valueMouseOutHandler(d, e)}
     >
@@ -158,8 +160,8 @@ const renderWhiskerMark = (whiskerMarkProps) => (d, i) => {
 class WhiskerSeries extends AbstractSeries {
   render() {
     const {
-      animation, className, crossBarWidth, data, marginLeft, marginTop, strokeWidth,
-      style
+      animation, className, crossBarWidth, data, marginLeft, marginTop,
+      strokeWidth, style
     } = this.props;
     if (!data) {
       return null;
@@ -183,6 +185,7 @@ class WhiskerSeries extends AbstractSeries {
       xFunctor: this._getAttributeFunctor('x'),
       yFunctor: this._getAttributeFunctor('y'),
       valueClickHandler: this._valueClickHandler,
+      valueRightClickHandler: this._valueRightClickHandler,
       valueMouseOverHandler: this._valueMouseOverHandler,
       valueMouseOutHandler: this._valueMouseOutHandler
     };

--- a/src/sunburst/index.js
+++ b/src/sunburst/index.js
@@ -43,9 +43,11 @@ const LISTENERS_TO_OVERWRITE = [
   'onValueMouseOver',
   'onValueMouseOut',
   'onValueClick',
+  'onValueRightClick',
   'onSeriesMouseOver',
   'onSeriesMouseOut',
-  'onSeriesClick'
+  'onSeriesClick',
+  'onSeriesRightClick'
 ];
 
 /**

--- a/tests/test-utils.js
+++ b/tests/test-utils.js
@@ -24,9 +24,11 @@ export const GENERIC_XYPLOT_SERIES_PROPS = {
   onSeriesMouseOver: NOOP,
   onSeriesMouseOut: NOOP,
   onSeriesClick: NOOP,
+  onSeriesRightClick: NOOP,
   onValueMouseOver: NOOP,
   onValueMouseOut: NOOP,
-  onValueClick: NOOP
+  onValueClick: NOOP,
+  onValueRightClick: NOOP
 };
 
 export const testRenderWithProps = (Component, props) =>


### PR DESCRIPTION
this PR allows users to handle right clicks to either marks or series. Each time a vis can handle an onValueClick, there is now an onValueRightClick; likewise, every series that supported onSeriesClick now supports onSeriesRightClick. 

documentation updated. 
no new tests are provided, since onValueClick wasn't tested per se, but it doesn't break existing tests. 