### PR TITLE
Add d3-format to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "d3-collection": "^1.0.3",
     "d3-color": "^1.0.3",
     "d3-contour": "^1.1.0",
+    "d3-format": "^1.2.0",
     "d3-geo": "^1.6.4",
     "d3-hierarchy": "^1.1.4",
     "d3-interpolate": "^1.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1598,7 +1598,7 @@ d3-contour@^1.1.0:
   dependencies:
     d3-array "^1.1.1"
 
-d3-format@1:
+d3-format@1, d3-format@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.2.0.tgz#6b480baa886885d4651dc248a8f4ac9da16db07a"
 


### PR DESCRIPTION
As reported in #560, we explicitly use d3-format in a few places but do not have it listed as an explicit dependency.