### PR TITLE
Dont let labels interpolate

### DIFF
--- a/showcase/misc/label-series-example.js
+++ b/showcase/misc/label-series-example.js
@@ -55,6 +55,8 @@ export default class Example extends React.Component {
       <div>
         <ShowcaseButton onClick={() => this.setState({data: generateData()})} buttonContent="UPDATE"/>
         <XYPlot
+          yDomain={[-1, 22]}
+          xDomain={[-1, 5]}
           width={300}
           height={300}>
           <XAxis />

--- a/showcase/misc/label-series-example.js
+++ b/showcase/misc/label-series-example.js
@@ -34,8 +34,8 @@ function generateData() {
     {x: Math.random() * 3, y: Math.random() * 20, label: 'Wigglytuff', size: 30, style: {fontSize: 20}},
     {x: Math.random() * 3, y: Math.random() * 20, label: 'Psyduck', size: 10},
     {x: Math.random() * 3, y: Math.random() * 20, label: 'Geodude', size: 1},
-    {x: Math.random() * 3, y: Math.random() * 20, label: 'Ditto', size: 12, rotation: 45},
-    {x: Math.random() * 3, y: Math.random() * 20, label: 'Snorlax', size: 4}
+    {x: Math.random() * 3, y: Math.random() * 20, label: 'red', size: 12, rotation: 45},
+    {x: Math.random() * 3, y: Math.random() * 20, label: 'blue', size: 4}
   ];
 }
 

--- a/src/plot/series/label-series.js
+++ b/src/plot/series/label-series.js
@@ -33,6 +33,7 @@ class LabelSeries extends AbstractSeries {
       allowOffsetToBeReversed,
       className,
       data,
+      _data,
       marginLeft,
       marginTop,
       rotation,
@@ -47,7 +48,7 @@ class LabelSeries extends AbstractSeries {
     if (animation) {
       return (
         <Animation {...this.props} animatedProps={ANIMATED_SERIES_PROPS}>
-          <LabelSeries {...this.props} animation={null}/>
+          <LabelSeries {...this.props} animation={null} _data={data}/>
         </Animation>
       );
     }
@@ -85,7 +86,7 @@ class LabelSeries extends AbstractSeries {
             transform: `rotate(${d.rotation || rotation},${x},${y})`,
             ...style
           };
-          return res.concat([<text {...attrs} >{label}</text>]);
+          return res.concat([<text {...attrs} >{_data ? _data[i].label : label}</text>]);
         }, [])}
       </g>
     );

--- a/tests/components/label-series-tests.js
+++ b/tests/components/label-series-tests.js
@@ -9,13 +9,12 @@ testRenderWithProps(LabelSeries, GENERIC_XYPLOT_SERIES_PROPS);
 
 test('LabelSeries: Showcase Example - LabelSeriesExample', t => {
   const $ = mount(<LabelSeriesExample />);
-  t.equal($.text(), 'UPDATE1.01.52.02.53.03.54.05101520WigglytuffPsyduckGeodudeDittoSnorlax', 'should find the right text content');
+  t.equal($.text(), 'UPDATE-101234505101520WigglytuffPsyduckGeodudeDittoSnorlax', 'should find the right text content');
   t.equal($.find('.rv-xy-plot__series--label text').length, 5, 'should find the right number of text boxes');
 
-  const postAnimationText = 'UPDATE0.51.01.52.02.551015WigglytuffPsyduckGeoduderedblue';
   $.find('.showcase-button').simulate('click');
-  t.equal($.text(), postAnimationText, 'should find the right text content');
+  t.equal($.text(), 'UPDATE-101234505101520WigglytuffPsyduckGeoduderedblue', 'should find the right text content');
   $.find('.showcase-button').simulate('click');
-  t.equal($.text(), postAnimationText, 'should find the right text content');
+  t.equal($.text(), 'UPDATE-101234505101520WigglytuffPsyduckGeoduderedblue', 'should find the right text content');
   t.end();
 });

--- a/tests/components/label-series-tests.js
+++ b/tests/components/label-series-tests.js
@@ -11,5 +11,11 @@ test('LabelSeries: Showcase Example - LabelSeriesExample', t => {
   const $ = mount(<LabelSeriesExample />);
   t.equal($.text(), 'UPDATE1.01.52.02.53.03.54.05101520WigglytuffPsyduckGeodudeDittoSnorlax', 'should find the right text content');
   t.equal($.find('.rv-xy-plot__series--label text').length, 5, 'should find the right number of text boxes');
+
+  const postAnimationText = 'UPDATE0.51.01.52.02.551015WigglytuffPsyduckGeoduderedblue';
+  $.find('.showcase-button').simulate('click');
+  t.equal($.text(), postAnimationText, 'should find the right text content');
+  $.find('.showcase-button').simulate('click');
+  t.equal($.text(), postAnimationText, 'should find the right text content');
   t.end();
 });


### PR DESCRIPTION
This PR addresses #579, in that it prevents the label series from interpolating it's labels. They simply jump from one to the text. This PR is a little bit hacky and is not the only time we've run into weirdness around d3-interpolate, so I've opened an issue with d3-interpolate (which generates our interpolations), https://github.com/d3/d3-interpolate/issues/42 