### PR TITLE
Add global styles for custom svg series

### DIFF
--- a/docs/markdown/custom-svg-series.md
+++ b/docs/markdown/custom-svg-series.md
@@ -47,7 +47,7 @@ There are currently four types of string accessible custom marks: **star**, **sq
 
 <!-- INJECT:"CustomSVGAllTheMarks" -->
 
-If using a function to defined your mark, it is important to note that the function receives two arguments (customComponent, positionInPixels), where customComponent is the row of data as you have defined it. Thus if you are defining a function for the series as a whole you can make modifications based on the individual row as you go!
+If using a function to defined your mark, it is important to note that the function receives three arguments (customComponent, positionInPixels, globalStyle), where customComponent is the row of data as you have defined it. Thus if you are defining a function for the series as a whole you can make modifications based on the individual row as you go!
 
 ## API reference
 

--- a/showcase/plot/custom-svg-all-the-marks.js
+++ b/showcase/plot/custom-svg-all-the-marks.js
@@ -43,7 +43,6 @@ function generateData(reversed) {
         x: index,
         y: reversed ? (5 - rowIndex) * 5 : rowIndex * 5,
         size: (index + 1) * 3,
-        style: {stroke: 'red', fill: 'orange'},
         customComponent: row
       });
     });
@@ -74,7 +73,10 @@ export default class Example extends React.Component {
           <HorizontalGridLines />
           <XAxis />
           <YAxis />
-          <CustomSVGSeries animation data={reverse ? REVERSED_DATA : DATA}/>
+          <CustomSVGSeries
+            animation
+            style={{stroke: 'red', fill: 'orange'}}
+            data={reverse ? REVERSED_DATA : DATA}/>
         </XYPlot>
       </div>
     );

--- a/showcase/plot/custom-svg-example.js
+++ b/showcase/plot/custom-svg-example.js
@@ -47,7 +47,7 @@ export default class Example extends React.Component {
             {x: 1.7, y: 12, size: 20, style: {stroke: 'red', fill: 'orange'}},
             {x: 2, y: 5},
             {x: 3, y: 15},
-            {x: 2.5, y: 7, customComponent: (row, positionInPixels) => {
+            {x: 2.5, y: 7, customComponent: (row, positionInPixels, globalStyle) => {
               return (
                 <g className="inner-inner-component">
                   <circle cx="0" cy="0" r={10} fill="green"/>

--- a/src/plot/series/custom-svg-series.js
+++ b/src/plot/series/custom-svg-series.js
@@ -61,21 +61,28 @@ function predefinedComponents(type, size = 2, style = DEFAULT_STYLE) {
   }
 }
 
-function getInnerComponent({customComponent, positionInPixels, defaultType, positionFunctions}) {
-  const {size, style} = customComponent;
+function getInnerComponent({
+  customComponent,
+  defaultType,
+  positionInPixels,
+  positionFunctions,
+  style
+}) {
+  const {size} = customComponent;
+  const aggStyle = {...style, ...(customComponent.style || {})};
   const innerComponent = customComponent.customComponent;
   if (!innerComponent && typeof defaultType === 'string') {
-    return predefinedComponents(defaultType, size, style);
+    return predefinedComponents(defaultType, size, aggStyle);
   }
   // if default component is a function
   if (!innerComponent) {
-    return innerComponent(defaultType, positionInPixels);
+    return innerComponent(defaultType, positionInPixels, aggStyle);
   }
   if (typeof innerComponent === 'string') {
-    return predefinedComponents(innerComponent || defaultType, size, style);
+    return predefinedComponents(innerComponent || defaultType, size, aggStyle);
   }
   // if inner component is a function
-  return innerComponent(customComponent, positionInPixels);
+  return innerComponent(customComponent, positionInPixels, aggStyle);
 }
 
 class CustomSVGSeries extends AbstractSeries {
@@ -115,7 +122,8 @@ class CustomSVGSeries extends AbstractSeries {
         customComponent: seriesComponent,
         positionInPixels,
         defaultType: customComponent,
-        positionFunctions: {x, y}
+        positionFunctions: {x, y},
+        style
       });
       return (
         <g
@@ -130,8 +138,7 @@ class CustomSVGSeries extends AbstractSeries {
     return (
       <g className={`${predefinedClassName} ${className}`}
          ref="container"
-         transform={`translate(${marginLeft},${marginTop})`}
-         style={style}>
+         transform={`translate(${marginLeft},${marginTop})`}>
         {contents}
       </g>
     );


### PR DESCRIPTION
The style prop on custom-svg-series was not using the style prop effectively, so I moved it around so that it is applied to each element, rather than the containing g. This PR addresses #594 