### PR TITLE
Only try to clean data when asked

### DIFF
--- a/docs/xy-plot.md
+++ b/docs/xy-plot.md
@@ -119,6 +119,10 @@ Height of the component. The height should be passed.
 Type: `string`  
 DOM classNames to be added to the wrapper component.
 
+#### hasTreeStructure (optional)
+Type: `Boolean`
+Flag declaring whether or not react-vis should try to remove potential cyclic deps from tree structures created by d3. Specifically references to "parent" are removed. This is generally used as an internal prop, checkout the treemap or sunburst if you are curious.
+
 #### margin (optional)
 Type: `Object`  
 Default: `{left: 40, right: 10, top: 10, bottom: 40}`

--- a/src/plot/xy-plot.js
+++ b/src/plot/xy-plot.js
@@ -75,16 +75,17 @@ function cleanseData(data) {
  * Wrapper on the deep-equal method for checking equality of next props vs current props
  * @param {Object} scaleMixins - Scale object.
  * @param {Object} nextScaleMixins - Scale object.
+ * @param {Boolean} hasTreeStructure - Whether or not to cleanse the data of possible cyclic structures
  * @returns {Boolean} whether or not the two mixins objects are equal
  */
-function checkIfMixinsAreEqual(nextScaleMixins, scaleMixins) {
+function checkIfMixinsAreEqual(nextScaleMixins, scaleMixins, hasTreeStructure) {
   const newMixins = {
     ...nextScaleMixins,
-    _allData: cleanseData(nextScaleMixins._allData)
+    _allData: hasTreeStructure ? cleanseData(nextScaleMixins._allData) : nextScaleMixins._allData
   };
   const oldMixins = {
     ...scaleMixins,
-    _allData: cleanseData(scaleMixins._allData)
+    _allData: hasTreeStructure ? cleanseData(scaleMixins._allData) : scaleMixins._allData
   };
   // it's hard to say if this function is reasonable?
   return equal(newMixins, oldMixins);
@@ -141,7 +142,7 @@ class XYPlot extends React.Component {
     const nextData = getStackedData(children, nextProps.stackBy);
     const {scaleMixins} = this.state;
     const nextScaleMixins = this._getScaleMixins(nextData, nextProps);
-    if (!checkIfMixinsAreEqual(nextScaleMixins, scaleMixins)) {
+    if (!checkIfMixinsAreEqual(nextScaleMixins, scaleMixins, nextProps.hasTreeStructure)) {
       this.setState({
         scaleMixins: nextScaleMixins,
         data: nextData

--- a/src/sunburst/index.js
+++ b/src/sunburst/index.js
@@ -142,6 +142,7 @@ class Sunburst extends React.Component {
     return (
       <XYPlot
         height={height}
+        hasTreeStructure
         width={width}
         className={`${predefinedClassName} ${className}`}
         margin={margin}

--- a/src/treemap/treemap-svg.js
+++ b/src/treemap/treemap-svg.js
@@ -174,6 +174,7 @@ class TreemapSVG extends React.Component {
         yDomain={[maxY, minY]}
         xDomain={[minX, maxX]}
         colorType="literal"
+        hasTreeStructure
         {...this.props}
         >
         {updatedNodes}


### PR DESCRIPTION
When building the sunburst I added a function called cleanseData which makes a copy of every element under consideration in the xy-plot. This is useful for sunburst and treemap as it allows us to remove cyclic structures in the json, however as noted in #593, this can cause some serious performance bottle neck. This PR delegates that functionality under a flag to keep things moving quickly unless necessary.