### PR TITLE
Enable customComponent to be defined at root level

### DIFF
--- a/showcase/index.js
+++ b/showcase/index.js
@@ -36,6 +36,7 @@ import AreaChartElevated from './plot/area-chart-elevated';
 import ScatterplotChart from './plot/scatterplot';
 import WhiskerChart from './plot/whisker-chart.js';
 import CustomSVGExample from './plot/custom-svg-example';
+import CustomSVGRootLevel from './plot/custom-svg-root-level';
 import CustomSVGAllTheMarks from './plot/custom-svg-all-the-marks';
 import FauxScatterplotChart from './plot/faux-radial-scatterplot';
 import ScatterplotCanvas from './plot/scatterplot-canvas';
@@ -157,6 +158,7 @@ export const showCase = {
   AreaChartElevated,
   FauxScatterplotChart,
   CustomSVGExample,
+  CustomSVGRootLevel,
   CustomSVGAllTheMarks,
   ScatterplotChart,
   ScatterplotCanvas,

--- a/showcase/plot/custom-svg-root-level.js
+++ b/showcase/plot/custom-svg-root-level.js
@@ -1,0 +1,65 @@
+// Copyright (c) 2016 - 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import React from 'react';
+
+import {
+  XYPlot,
+  XAxis,
+  YAxis,
+  VerticalGridLines,
+  HorizontalGridLines,
+  CustomSVGSeries
+} from 'index';
+
+export default class CustomSVGRootLevelComponent extends React.Component {
+  render() {
+    return (
+      <XYPlot
+        width={300}
+        height={300}>
+        <VerticalGridLines />
+        <HorizontalGridLines />
+        <XAxis />
+        <YAxis />
+        <CustomSVGSeries
+          className="custom-marking"
+          customComponent={(row, positionInPixels) => {
+            return (
+              <g className="inner-inner-component">
+                <circle cx="0" cy="0" r={row.size || 10} fill="green"/>
+                <text x={0} y={0}>
+                  <tspan x="0" y="0">{`x: ${positionInPixels.x}`}</tspan>
+                  <tspan x="0" y="1em">{`y: ${positionInPixels.y}`}</tspan>
+                </text>
+              </g>
+            );
+          }}
+          data={[
+            {x: 1, y: 10, size: 3},
+            {x: 1.7, y: 12, size: 20, style: {stroke: 'red', fill: 'orange'}},
+            {x: 2, y: 5},
+            {x: 3, y: 15},
+            {x: 2.5, y: 7}
+          ]}/>
+      </XYPlot>
+    );
+  }
+}

--- a/showcase/showcase-sections/plots-showcase.js
+++ b/showcase/showcase-sections/plots-showcase.js
@@ -13,6 +13,7 @@ const {
   CustomScales,
   CustomSVGExample,
   CustomSVGAllTheMarks,
+  CustomSVGRootLevel,
   FauxScatterplotChart,
   GridLinesChart,
   HeatmapChart,
@@ -111,6 +112,9 @@ const PLOTS = [{
 }, {
   name: 'Custom SVG - All The Mark',
   component: CustomSVGAllTheMarks
+}, {
+  name: 'Custom SVG - Root Level Function Definition',
+  component: CustomSVGRootLevel
 }];
 
 const BASIC_COMPONENTS = [{

--- a/src/plot/series/custom-svg-series.js
+++ b/src/plot/series/custom-svg-series.js
@@ -76,7 +76,7 @@ function getInnerComponent({
   }
   // if default component is a function
   if (!innerComponent) {
-    return innerComponent(defaultType, positionInPixels, aggStyle);
+    return defaultType(customComponent, positionInPixels, aggStyle);
   }
   if (typeof innerComponent === 'string') {
     return predefinedComponents(innerComponent || defaultType, size, aggStyle);
@@ -148,7 +148,7 @@ class CustomSVGSeries extends AbstractSeries {
 CustomSVGSeries.propTypes = {
   animation: PropTypes.bool,
   className: PropTypes.string,
-  customComponent: PropTypes.string,
+  customComponent: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   data: PropTypes.arrayOf(PropTypes.shape({
     x: PropTypes.number.isRequired,
     y: PropTypes.number.isRequired

--- a/tests/components/custom-svg-series-tests.js
+++ b/tests/components/custom-svg-series-tests.js
@@ -5,6 +5,7 @@ import CustomSVGSeries from 'plot/series/custom-svg-series';
 import {testRenderWithProps, GENERIC_XYPLOT_SERIES_PROPS} from '../test-utils';
 import CustomSVGExample from '../../showcase/plot/custom-svg-example';
 import CustomSVGAllTheMarks from '../../showcase/plot/custom-svg-all-the-marks';
+import CustomSVGRootLevelComponent from '../../showcase/plot/custom-svg-root-level';
 
 testRenderWithProps(CustomSVGSeries, GENERIC_XYPLOT_SERIES_PROPS);
 
@@ -15,6 +16,17 @@ test('CustomSVGSeries: Showcase Example - CustomSVGExample', t => {
   t.equal($.find('.rv-xy-plot__series--custom-svg polygon').length, 0, 'should find the right number of polygons');
   t.equal($.find('.rv-xy-plot__series--custom-svg circle').length, 2, 'should find the right number of circle');
   t.equal($.find('.rv-xy-plot__series--custom-svg rect').length, 3, 'should find the right number of rects');
+  t.end();
+});
+
+test('CustomSVGSeries: Showcase Example - CustomSVGRootLevelComponent', t => {
+  const $ = mount(<CustomSVGRootLevelComponent />);
+  t.equal($.text(), '1.01.52.02.53.068101214x: 0y: 125x: 87.5y: 75x: 125y: 250x: 250y: 0x: 187.5y: 200', 'should fine the right text content');
+  t.equal($.find('.rv-xy-plot__series--custom-svg').length, 5, 'should find the right number of gs');
+  t.equal($.find('.rv-xy-plot__series--custom-svg polygon').length, 0, 'should find the right number of polygons');
+  t.equal($.find('.rv-xy-plot__series--custom-svg circle').length, 5, 'should find the right number of circle');
+  t.equal($.find('.rv-xy-plot__series--custom-svg rect').length, 0, 'should find the right number of rects');
+  t.equal($.find('.rv-xy-plot__series--custom-svg text').length, 5, 'should find the right number of texts');
   t.end();
 });
 


### PR DESCRIPTION
This PR enables custom-svg-series to accept a root level function to describe the custom component for the entire series. Like all good PRs it comes with a new example

![screen shot 2017-09-08 at 11 05 03 am](https://user-images.githubusercontent.com/6854312/30224975-9d1b7d94-9485-11e7-961a-5d7763331ba0.png)
