### PR TITLE
Accessors

### DIFF
--- a/docs/parallel-coordinates.md
+++ b/docs/parallel-coordinates.md
@@ -13,7 +13,7 @@ Just like every other chart and series ParallelCoordinates expects an array of d
 ```javascript
 const PARALLEL_COORDINATES_PROPS = {
   data: [{
-    explosions: 7,
+    neatExplosions: 7,
     wow: 10,
     dog: 8,
     sickMoves: 9,
@@ -21,7 +21,7 @@ const PARALLEL_COORDINATES_PROPS = {
   }],
   domains: [
     {name: 'nice', domain: [0, 100]},
-    {name: 'explosions', domain: [6.9, 7.1]},
+    {name: 'explosions', domain: [6.9, 7.1], getValue: d => d.neatExplosions},
     {name: 'wow', domain: [0, 11]},
     {name: 'sickMoves', domain: [0, 20]}
   ],
@@ -44,6 +44,7 @@ The domains allow the user to specify the nature of the variables being plotted.
 ```javascript
 PropTypes.shape({
   name: PropTypes.string.isRequired,
+  getValue: PropTypes.func,
   domain: PropTypes.arrayOf([PropTypes.number]).isRequired,
   tickFormat: PropTypes.func
 })
@@ -52,6 +53,7 @@ PropTypes.shape({
 Let's looks at each member of the object
 
 - name: generates a member of a labelSeries that shows at the end of the corresponding axis
+- getValue: an accessor function that grabs a value from the row being accessed, if this is not provided a default one that uses the name property is used.
 - domain: a pair of numbers that are interpolated between. Setting these values correctly is essential for making your graphic legible! Because it is often the case that there will only be one or two data rows in a parallel coordinates, react-vis requires the user to specify the exact domain for each variable. Without which we would be unable to plot the variables well.
 - tickFormat: allows the user to provide a formatting function for prettifiying the the way that axis interpolates between the domain values.
 

--- a/docs/radar-chart.md
+++ b/docs/radar-chart.md
@@ -13,7 +13,7 @@ Just like every other chart and series RadarChart expects an array of data, each
 ```javascript
 const RADAR_PROPS = {
   data: [{
-    explosions: 7,
+    neatExplosions: 7,
     wow: 10,
     dog: 8,
     sickMoves: 9,
@@ -21,7 +21,7 @@ const RADAR_PROPS = {
   }],
   domains: [
     {name: 'nice', domain: [0, 100]},
-    {name: 'explosions', domain: [6.9, 7.1]},
+    {name: 'explosions', domain: [6.9, 7.1], getValue: d => d.neatExplosions},
     {name: 'wow', domain: [0, 11]},
     {name: 'sickMoves', domain: [0, 20]}
   ],
@@ -46,6 +46,7 @@ The domains allow the user to specify the nature of the variables being plotted.
 ```javascript
 PropTypes.shape({
   name: PropTypes.string.isRequired,
+  getValue: PropTypes.func,
   domain: PropTypes.arrayOf([PropTypes.number]).isRequired,
   tickFormat: PropTypes.func
 })
@@ -54,6 +55,7 @@ PropTypes.shape({
 Let's looks at each member of the object
 
 - name: generates a member of a labelSeries that shows at the end of the corresponding axis
+- getValue: an accessor function that grabs a value from the row being accessed, if this is not provided a default one that uses the name property is used.
 - domain: a pair of numbers that are interpolated between. Setting these values correctly is essential for making your graphic legible! Because it is often the case that there will only be one or two data rows in a radar chart, react-vis requires the user to specify the exact domain for each variable. Without which we would be unable to plot the variables well.
 - tickFormat: allows the user to provide a formatting function for prettifiying the the way that axis interpolates between the domain values.
 

--- a/docs/scales-and-data.md
+++ b/docs/scales-and-data.md
@@ -93,6 +93,9 @@ This table is also meant to be used for derived series. Canvas series have the s
 
 To redefine a scale, you must pass a prop to the series that uses that scale. The prop names are based on the name of the attribute: name + Domain, name + Range, name + Type, name + Padding (for instance: yDomain, colorType, xRange).
 
+* `get[name]` (optional)  
+  Type: `function`  
+  A accessir function that gets the value to be compute from the data. For instance if you were keeping your data as rows like {a: 1, b: 2, c: 3}, you could define an x accessor like `getX: d => d.a`.
 * `[name]Domain` (optional)  
   Type: `Array`  
   Array of values to visualize from. If domain is not passed, it will be calculated from the values which are passed to component.

--- a/showcase/misc/time-chart.js
+++ b/showcase/misc/time-chart.js
@@ -33,7 +33,7 @@ const MSEC_DAILY = 86400000;
 
 export default class Example extends React.Component {
   render() {
-    const timestamp = Date.now();
+    const timestamp = new Date('September 9 2017').getTime();
     return (
       <XYPlot
         xType="time"

--- a/showcase/parallel-coordinates/basic-parallel-coordinates.js
+++ b/showcase/parallel-coordinates/basic-parallel-coordinates.js
@@ -43,11 +43,11 @@ export default class BasicParallelCoordinates extends Component {
         colorRange={['#172d47', '#911116', '#998965']}
         domains={[
           {name: 'mileage', domain: [0, 10]},
-          {name: 'price', domain: [2, 16], tickFormat: t => `$${basicFormat(t)}`, accessor: d => d.price},
-          {name: 'safety', domain: [5, 10], accessor: d => d.safety},
-          {name: 'performance', domain: [0, 10], accessor: d => d.performance},
-          {name: 'interior', domain: [0, 7], accessor: d => d.interior},
-          {name: 'warranty', domain: [10, 2], accessor: d => d.warranty}
+          {name: 'price', domain: [2, 16], tickFormat: t => `$${basicFormat(t)}`, getValue: d => d.price},
+          {name: 'safety', domain: [5, 10], getValue: d => d.safety},
+          {name: 'performance', domain: [0, 10], getValue: d => d.performance},
+          {name: 'interior', domain: [0, 7], getValue: d => d.interior},
+          {name: 'warranty', domain: [10, 2], getValue: d => d.warranty}
         ]}
         showMarks
         width={400}

--- a/showcase/parallel-coordinates/basic-parallel-coordinates.js
+++ b/showcase/parallel-coordinates/basic-parallel-coordinates.js
@@ -43,11 +43,11 @@ export default class BasicParallelCoordinates extends Component {
         colorRange={['#172d47', '#911116', '#998965']}
         domains={[
           {name: 'mileage', domain: [0, 10]},
-          {name: 'price', domain: [2, 16], tickFormat: t => `$${basicFormat(t)}`},
-          {name: 'safety', domain: [5, 10]},
-          {name: 'performance', domain: [0, 10]},
-          {name: 'interior', domain: [0, 7]},
-          {name: 'warranty', domain: [10, 2]}
+          {name: 'price', domain: [2, 16], tickFormat: t => `$${basicFormat(t)}`, accessor: d => d.price},
+          {name: 'safety', domain: [5, 10], accessor: d => d.safety},
+          {name: 'performance', domain: [0, 10], accessor: d => d.performance},
+          {name: 'interior', domain: [0, 7], accessor: d => d.interior},
+          {name: 'warranty', domain: [10, 2], accessor: d => d.warranty}
         ]}
         showMarks
         width={400}

--- a/showcase/plot/complex-chart.js
+++ b/showcase/plot/complex-chart.js
@@ -167,8 +167,8 @@ export default class Example extends React.Component {
         <div className="chart">
           <FlexibleWidthXYPlot
             animation
-            xAccessor={d => d.left}
-            yAccessor={d => d.top}
+            getX={d => d.left}
+            getY={d => d.top}
             onMouseLeave={this._mouseLeaveHandler}
             xDomain={[0, series[0].data.length - 1]}
             height={300}>

--- a/showcase/plot/complex-chart.js
+++ b/showcase/plot/complex-chart.js
@@ -46,8 +46,8 @@ function getRandomSeriesData(total) {
   for (let i = 0; i < Math.max(total, 3); i++) {
     y = Math.random() * firstY - firstY / 2 + lastY;
     result.push({
-      x: i,
-      y
+      left: i,
+      top: y
     });
     lastY = y;
   }
@@ -121,7 +121,7 @@ export default class Example extends React.Component {
   _formatCrosshairTitle(values) {
     return {
       title: 'X',
-      value: values[0].x
+      value: values[0].left
     };
   }
 
@@ -136,7 +136,7 @@ export default class Example extends React.Component {
     return values.map((v, i) => {
       return {
         title: series[i].title,
-        value: v.y
+        value: v.top
       };
     });
   }
@@ -167,6 +167,8 @@ export default class Example extends React.Component {
         <div className="chart">
           <FlexibleWidthXYPlot
             animation
+            xAccessor={d => d.left}
+            yAccessor={d => d.top}
             onMouseLeave={this._mouseLeaveHandler}
             xDomain={[0, series[0].data.length - 1]}
             height={300}>
@@ -182,7 +184,7 @@ export default class Example extends React.Component {
               tickSizeOuter={8}
             />
             <VerticalRectSeries
-              data={series[0].data.map(({x, y}) => ({x0: x - 0.5, x: x + 0.5, y}))}
+              data={series[0].data.map(({left, top}) => ({x0: left - 0.5, left: left + 0.5, top}))}
               stroke="white"
               onNearestX={this._nearestXHandler}
               {...(series[0].disabled ? {opacity: 0.2} : null)}/>

--- a/showcase/plot/contour-series-example.js
+++ b/showcase/plot/contour-series-example.js
@@ -44,8 +44,8 @@ export default class ContourSeriesExample extends Component {
           xDomain={[40, 100]}
           yDomain={[1.5, 8]}
           width={600}
-          xAccessor={d => d.waiting}
-          yAccessor={d => d.eruptions}
+          getX={d => d.waiting}
+          getY={d => d.eruptions}
           height={300}>
           <ContourSeries
             animation

--- a/showcase/plot/contour-series-example.js
+++ b/showcase/plot/contour-series-example.js
@@ -25,20 +25,16 @@ import ShowcaseButton from '../showcase-components/showcase-button';
 import {XYPlot, XAxis, YAxis, ContourSeries, MarkSeriesCanvas, Borders} from 'index';
 
 import DATA from './old-faithful.json';
-const MAPPED_DATA = DATA.map(row => ({
-  x: row.waiting,
-  y: row.eruptions
-}));
 
 function updateData() {
-  return MAPPED_DATA.map(row => ({
-    x: row.x + (Math.random() - 0.5) * 10,
-    y: row.y + (Math.random() - 0.5) * 2
+  return DATA.map(row => ({
+    waiting: row.waiting + (Math.random() - 0.5) * 10,
+    eruptions: row.eruptions + (Math.random() - 0.5) * 2
   }));
 }
 export default class ContourSeriesExample extends Component {
   state = {
-    data: MAPPED_DATA
+    data: DATA
   }
   render() {
     const {data} = this.state;
@@ -48,6 +44,8 @@ export default class ContourSeriesExample extends Component {
           xDomain={[40, 100]}
           yDomain={[1.5, 8]}
           width={600}
+          xAccessor={d => d.waiting}
+          yAccessor={d => d.eruptions}
           height={300}>
           <ContourSeries
             animation

--- a/showcase/radar-chart/basic-radar-chart.js
+++ b/showcase/radar-chart/basic-radar-chart.js
@@ -41,11 +41,11 @@ export default class BasicRadarChart extends Component {
         startingAngle={0}
         domains={[
           {name: 'mileage', domain: [0, 10]},
-          {name: 'price', domain: [2, 16], tickFormat: t => `$${basicFormat(t)}`, accessor: d => d.price},
-          {name: 'safety', domain: [5, 10], accessor: d => d.safety},
-          {name: 'performance', domain: [0, 10], accessor: d => d.performance},
-          {name: 'interior', domain: [0, 7], accessor: d => d.interior},
-          {name: 'warranty', domain: [10, 2], accessor: d => d.warranty}
+          {name: 'price', domain: [2, 16], tickFormat: t => `$${basicFormat(t)}`, getValue: d => d.price},
+          {name: 'safety', domain: [5, 10], getValue: d => d.safety},
+          {name: 'performance', domain: [0, 10], getValue: d => d.performance},
+          {name: 'interior', domain: [0, 7], getValue: d => d.interior},
+          {name: 'warranty', domain: [10, 2], getValue: d => d.warranty}
         ]}
         width={400}
         height={300} />

--- a/showcase/radar-chart/basic-radar-chart.js
+++ b/showcase/radar-chart/basic-radar-chart.js
@@ -41,11 +41,11 @@ export default class BasicRadarChart extends Component {
         startingAngle={0}
         domains={[
           {name: 'mileage', domain: [0, 10]},
-          {name: 'price', domain: [2, 16], tickFormat: t => `$${basicFormat(t)}`},
-          {name: 'safety', domain: [5, 10]},
-          {name: 'performance', domain: [0, 10]},
-          {name: 'interior', domain: [0, 7]},
-          {name: 'warranty', domain: [10, 2]}
+          {name: 'price', domain: [2, 16], tickFormat: t => `$${basicFormat(t)}`, accessor: d => d.price},
+          {name: 'safety', domain: [5, 10], accessor: d => d.safety},
+          {name: 'performance', domain: [0, 10], accessor: d => d.performance},
+          {name: 'interior', domain: [0, 7], accessor: d => d.interior},
+          {name: 'warranty', domain: [10, 2], accessor: d => d.warranty}
         ]}
         width={400}
         height={300} />

--- a/showcase/radial-chart/donut-chart.js
+++ b/showcase/radial-chart/donut-chart.js
@@ -36,12 +36,13 @@ export default class SimpleRadialChart extends Component {
         className={'donut-chart-example'}
         innerRadius={100}
         radius={140}
+        angleAccessor={d => d.theta}
         data={[
-          {angle: 2, className: 'custom-class'},
-          {angle: 6},
-          {angle: 2},
-          {angle: 3},
-          {angle: 1}
+          {theta: 2, className: 'custom-class'},
+          {theta: 6},
+          {theta: 2},
+          {theta: 3},
+          {theta: 1}
         ]}
         onValueMouseOver={v => this.setState({value: v})}
         onSeriesMouseOut={v => this.setState({value: false})}

--- a/showcase/radial-chart/donut-chart.js
+++ b/showcase/radial-chart/donut-chart.js
@@ -36,7 +36,7 @@ export default class SimpleRadialChart extends Component {
         className={'donut-chart-example'}
         innerRadius={100}
         radius={140}
-        angleAccessor={d => d.theta}
+        getAngle={d => d.theta}
         data={[
           {theta: 2, className: 'custom-class'},
           {theta: 6},

--- a/showcase/radial-chart/simple-radial-chart.js
+++ b/showcase/radial-chart/simple-radial-chart.js
@@ -30,12 +30,13 @@ export default class SimpleRadialChart extends React.Component {
         colorDomain={[0, 100]}
         colorRange={[0, 10]}
         margin={{top: 100}}
+        labelAccessor={d => d.name}
         data={[
-          {angle: 1, color: '#89DAC1', label: 'green', opacity: 0.2},
-          {angle: 2, color: '#F6D18A', label: 'yellow'},
-          {angle: 5, color: '#1E96BE', label: 'cyan'},
-          {angle: 3, color: '#DA70BF', label: 'magenta'},
-          {angle: 5, color: '#F6D18A', label: 'yellow again'}
+          {angle: 1, color: '#89DAC1', name: 'green', opacity: 0.2},
+          {angle: 2, color: '#F6D18A', name: 'yellow'},
+          {angle: 5, color: '#1E96BE', name: 'cyan'},
+          {angle: 3, color: '#DA70BF', name: 'magenta'},
+          {angle: 5, color: '#F6D18A', name: 'yellow again'}
         ]}
         showLabels
         width={400}

--- a/showcase/radial-chart/simple-radial-chart.js
+++ b/showcase/radial-chart/simple-radial-chart.js
@@ -30,7 +30,7 @@ export default class SimpleRadialChart extends React.Component {
         colorDomain={[0, 100]}
         colorRange={[0, 10]}
         margin={{top: 100}}
-        labelAccessor={d => d.name}
+        getLabel={d => d.name}
         data={[
           {angle: 1, color: '#89DAC1', name: 'green', opacity: 0.2},
           {angle: 2, color: '#F6D18A', name: 'yellow'},

--- a/showcase/showcase-sections/plots-showcase.js
+++ b/showcase/showcase-sections/plots-showcase.js
@@ -145,7 +145,9 @@ class PlotsShowcase extends Component {
         <h2>Series Types</h2>
         {PLOTS.map(mapSection)}
         <h2>Basic Components</h2>
-        {BASIC_COMPONENTS.map(mapSection)}
+        {
+          BASIC_COMPONENTS.map(mapSection)
+        }
       </article>
     );
   }

--- a/showcase/sunbursts/basic-sunburst.js
+++ b/showcase/sunbursts/basic-sunburst.js
@@ -56,7 +56,7 @@ function updateData(data, keyPath) {
     data.children.map(child => updateData(child, keyPath));
   }
   // add a fill to all the uncolored cells
-  if (!data.color) {
+  if (!data.hex) {
     data.style = {
       fill: EXTENDED_DISCRETE_COLOR_RANGE[5]
     };
@@ -115,6 +115,8 @@ export default class BasicSunburst extends React.Component {
             strokeWidth: '0.5'
           }}
           colorType="literal"
+          sizeAccessor={d => d.value}
+          colorAccessor={d => d.hex}
           data={data}
           height={300}
           width={350}>

--- a/showcase/sunbursts/basic-sunburst.js
+++ b/showcase/sunbursts/basic-sunburst.js
@@ -115,8 +115,8 @@ export default class BasicSunburst extends React.Component {
             strokeWidth: '0.5'
           }}
           colorType="literal"
-          sizeAccessor={d => d.value}
-          colorAccessor={d => d.hex}
+          getSize={d => d.value}
+          getColor={d => d.hex}
           data={data}
           height={300}
           width={350}>

--- a/showcase/sunbursts/clock-example.js
+++ b/showcase/sunbursts/clock-example.js
@@ -57,8 +57,8 @@ export default class ClockExample extends React.Component {
         xDomain={[-3, 3]}
         yDomain={[-3, 3]}
         width={300}
-        angleAccessor={d => d.time}
-        angle0Accessor={d => 0}
+        getAngle={d => d.time}
+        getAngle0={d => 0}
         height={300}>
         <ArcSeries
           animation={{

--- a/showcase/sunbursts/clock-example.js
+++ b/showcase/sunbursts/clock-example.js
@@ -57,6 +57,8 @@ export default class ClockExample extends React.Component {
         xDomain={[-3, 3]}
         yDomain={[-3, 3]}
         width={300}
+        angleAccessor={d => d.time}
+        angle0Accessor={d => 0}
         height={300}>
         <ArcSeries
           animation={{
@@ -65,9 +67,9 @@ export default class ClockExample extends React.Component {
           }}
           radiusDomain={[0, 3]}
           data={[
-            {angle0: 0, angle: seconds / 60 * 2 * PI, radius0: 1, radius: 1.5, color: 0},
-            {angle0: 0, angle: minutes / 60 * 2 * PI, radius0: 1.6, radius: 2.1, color: 1},
-            {angle0: 0, angle: hours / 24 * 2 * PI, radius0: 2.2, radius: 2.7, color: 2}
+            {time: seconds / 60 * 2 * PI, radius0: 1, radius: 1.5, color: 0},
+            {time: minutes / 60 * 2 * PI, radius0: 1.6, radius: 2.1, color: 1},
+            {time: hours / 24 * 2 * PI, radius0: 2.2, radius: 2.7, color: 2}
           ]}
           colorRange={EXTENDED_DISCRETE_COLOR_RANGE} />
       </XYPlot>

--- a/showcase/sunbursts/sunburst-with-tooltips.js
+++ b/showcase/sunbursts/sunburst-with-tooltips.js
@@ -32,25 +32,25 @@ import {
 const DATA = {
   children: [
     {children: [
-      {size: 1, children: [], color: COLORS[1], label: 'excellent'},
-      {size: 1, children: [], color: COLORS[2], label: 'chart'}
-    ], color: COLORS[3]},
+      {bigness: 1, children: [], clr: COLORS[1], name: 'excellent'},
+      {bigness: 1, children: [], clr: COLORS[2], name: 'chart'}
+    ], clr: COLORS[3]},
     {
-      size: 1,
+      bigness: 1,
       children: [],
-      color: COLORS[4],
-      label: 'cool',
+      clr: COLORS[4],
+      name: 'cool',
       labelStyle: {
         fontSize: 15,
         fontWeight: 'bold'
       }
     },
-    {size: 1, children: [], color: COLORS[5], label: 'dogs'},
-    {size: 1, children: [], color: COLORS[6], label: 'sunglasses'},
+    {bigness: 1, children: [], clr: COLORS[5], name: 'dogs'},
+    {bigness: 1, children: [], clr: COLORS[6], name: 'sunglasses'},
     {children: [
-      {size: 1, children: [], color: COLORS[7], label: 'great'},
-      {size: 1, children: [], color: COLORS[8], label: 'label'}
-    ], color: COLORS[9]}
+      {bigness: 1, children: [], clr: COLORS[7], name: 'great'},
+      {bigness: 1, children: [], clr: COLORS[8], name: 'label'}
+    ], clr: COLORS[9]}
   ]
 };
 
@@ -86,11 +86,14 @@ export default class SunburstWithTooltips extends React.Component {
         onValueMouseOut={v => this.setState({hoveredCell: false})}
         height={300}
         margin={{top: 50, bottom: 50, left: 50, right: 50}}
+        labelAccessor={d => d.name}
+        sizeAccessor={d => d.bigness}
+        colorAccessor={d => d.clr}
         width={350}>
         {hoveredCell ? <Hint value={buildValue(hoveredCell)}>
           <div style={tipStyle}>
-            <div style={{...boxStyle, background: hoveredCell.color}}/>
-            {hoveredCell.color}
+            <div style={{...boxStyle, background: hoveredCell.clr}}/>
+            {hoveredCell.clr}
           </div>
         </ Hint> : null}
       </Sunburst>

--- a/showcase/sunbursts/sunburst-with-tooltips.js
+++ b/showcase/sunbursts/sunburst-with-tooltips.js
@@ -86,9 +86,9 @@ export default class SunburstWithTooltips extends React.Component {
         onValueMouseOut={v => this.setState({hoveredCell: false})}
         height={300}
         margin={{top: 50, bottom: 50, left: 50, right: 50}}
-        labelAccessor={d => d.name}
-        sizeAccessor={d => d.bigness}
-        colorAccessor={d => d.clr}
+        getLabel={d => d.name}
+        getSize={d => d.bigness}
+        getColor={d => d.clr}
         width={350}>
         {hoveredCell ? <Hint value={buildValue(hoveredCell)}>
           <div style={tipStyle}>

--- a/showcase/treemap/d3-flare-example.json
+++ b/showcase/treemap/d3-flare-example.json
@@ -2,31 +2,31 @@
  "children": [
   {
    "name": "analytics",
-   "color": "#12939A",
+   "hex": "#12939A",
    "children": [
     {
      "name": "cluster",
      "children": [
-      {"name": "AgglomerativeCluster", "color": "#12939A", "size": 3938},
-      {"name": "CommunityStructure", "color": "#12939A", "size": 3812},
-      {"name": "HierarchicalCluster", "color": "#12939A", "size": 6714},
-      {"name": "MergeEdge", "color": "#12939A", "size": 743}
+      {"name": "AgglomerativeCluster", "hex": "#12939A", "value": 3938},
+      {"name": "CommunityStructure", "hex": "#12939A", "value": 3812},
+      {"name": "HierarchicalCluster", "hex": "#12939A", "value": 6714},
+      {"name": "MergeEdge", "hex": "#12939A", "value": 743}
      ]
     },
     {
      "name": "graph",
      "children": [
-      {"name": "BetweennessCentrality", "color": "#12939A", "size": 3534},
-      {"name": "LinkDistance", "color": "#12939A", "size": 5731},
-      {"name": "MaxFlowMinCut", "color": "#12939A", "size": 7840},
-      {"name": "ShortestPaths", "color": "#12939A", "size": 5914},
-      {"name": "SpanningTree", "color": "#12939A", "size": 3416}
+      {"name": "BetweennessCentrality", "hex": "#12939A", "value": 3534},
+      {"name": "LinkDistance", "hex": "#12939A", "value": 5731},
+      {"name": "MaxFlowMinCut", "hex": "#12939A", "value": 7840},
+      {"name": "ShortestPaths", "hex": "#12939A", "value": 5914},
+      {"name": "SpanningTree", "hex": "#12939A", "value": 3416}
      ]
     },
     {
      "name": "optimization",
      "children": [
-      {"name": "AspectRatioBanker", "color": "#12939A", "size": 7074}
+      {"name": "AspectRatioBanker", "hex": "#12939A", "value": 7074}
      ]
     }
    ]
@@ -34,31 +34,31 @@
   {
    "name": "animate",
    "children": [
-    {"name": "Easing", "color": "#12939A", "size": 17010},
-    {"name": "FunctionSequence", "color": "#12939A", "size": 5842},
+    {"name": "Easing", "hex": "#12939A", "value": 17010},
+    {"name": "FunctionSequence", "hex": "#12939A", "value": 5842},
     {
      "name": "interpolate",
      "children": [
-      {"name": "ArrayInterpolator", "color": "#12939A", "size": 1983},
-      {"name": "ColorInterpolator", "color": "#12939A", "size": 2047},
-      {"name": "DateInterpolator", "color": "#12939A", "size": 1375},
-      {"name": "Interpolator", "color": "#12939A", "size": 8746},
-      {"name": "MatrixInterpolator", "color": "#12939A", "size": 2202},
-      {"name": "NumberInterpolator", "color": "#12939A", "size": 1382},
-      {"name": "ObjectInterpolator", "color": "#12939A", "size": 1629},
-      {"name": "PointInterpolator", "color": "#12939A", "size": 1675},
-      {"name": "RectangleInterpolator", "color": "#12939A", "size": 2042}
+      {"name": "ArrayInterpolator", "hex": "#12939A", "value": 1983},
+      {"name": "hexInterpolator", "hex": "#12939A", "value": 2047},
+      {"name": "DateInterpolator", "hex": "#12939A", "value": 1375},
+      {"name": "Interpolator", "hex": "#12939A", "value": 8746},
+      {"name": "MatrixInterpolator", "hex": "#12939A", "value": 2202},
+      {"name": "NumberInterpolator", "hex": "#12939A", "value": 1382},
+      {"name": "ObjectInterpolator", "hex": "#12939A", "value": 1629},
+      {"name": "PointInterpolator", "hex": "#12939A", "value": 1675},
+      {"name": "RectangleInterpolator", "hex": "#12939A", "value": 2042}
      ]
     },
-    {"name": "ISchedulable", "color": "#12939A", "size": 1041},
-    {"name": "Parallel", "color": "#12939A", "size": 5176},
-    {"name": "Pause", "color": "#12939A", "size": 449},
-    {"name": "Scheduler", "color": "#12939A", "size": 5593},
-    {"name": "Sequence", "color": "#12939A", "size": 5534},
-    {"name": "Transition", "color": "#12939A", "size": 9201},
-    {"name": "Transitioner", "color": "#12939A", "size": 19975},
-    {"name": "TransitionEvent", "color": "#12939A", "size": 1116},
-    {"name": "Neonate", "color": "#12939A", "size": 6006}
+    {"name": "ISchedulable", "hex": "#12939A", "value": 1041},
+    {"name": "Parallel", "hex": "#12939A", "value": 5176},
+    {"name": "Pause", "hex": "#12939A", "value": 449},
+    {"name": "Scheduler", "hex": "#12939A", "value": 5593},
+    {"name": "Sequence", "hex": "#12939A", "value": 5534},
+    {"name": "Transition", "hex": "#12939A", "value": 9201},
+    {"name": "Transitioner", "hex": "#12939A", "value": 19975},
+    {"name": "TransitionEvent", "hex": "#12939A", "value": 1116},
+    {"name": "Neonate", "hex": "#12939A", "value": 6006}
    ]
   },
   {
@@ -67,177 +67,177 @@
     {
      "name": "converters",
      "children": [
-      {"name": "Converters", "color": "#12939A", "size": 721},
-      {"name": "DelimitedTextConverter", "color": "#12939A", "size": 4294},
-      {"name": "GraphMLConverter", "color": "#12939A", "size": 9800},
-      {"name": "IDataConverter", "color": "#12939A", "size": 1314},
-      {"name": "JSONConverter", "color": "#12939A", "size": 2220}
+      {"name": "Converters", "hex": "#12939A", "value": 721},
+      {"name": "DelimitedTextConverter", "hex": "#12939A", "value": 4294},
+      {"name": "GraphMLConverter", "hex": "#12939A", "value": 9800},
+      {"name": "IDataConverter", "hex": "#12939A", "value": 1314},
+      {"name": "JSONConverter", "hex": "#12939A", "value": 2220}
      ]
     },
-    {"name": "DataField", "color": "#12939A", "size": 1759},
-    {"name": "DataSchema", "color": "#12939A", "size": 2165},
-    {"name": "DataSet", "color": "#12939A", "size": 586},
-    {"name": "DataSource", "color": "#12939A", "size": 3331},
-    {"name": "DataTable", "color": "#12939A", "size": 772},
-    {"name": "DataUtil", "color": "#12939A", "size": 3322}
+    {"name": "DataField", "hex": "#12939A", "value": 1759},
+    {"name": "DataSchema", "hex": "#12939A", "value": 2165},
+    {"name": "DataSet", "hex": "#12939A", "value": 586},
+    {"name": "DataSource", "hex": "#12939A", "value": 3331},
+    {"name": "DataTable", "hex": "#12939A", "value": 772},
+    {"name": "DataUtil", "hex": "#12939A", "value": 3322}
    ]
   },
   {
    "name": "display",
    "children": [
-    {"name": "DirtySprite", "color": "#12939A", "size": 8833},
-    {"name": "LineSprite", "color": "#12939A", "size": 1732},
-    {"name": "RectSprite", "color": "#12939A", "size": 3623},
-    {"name": "TextSprite", "color": "#12939A", "size": 10066}
+    {"name": "DirtySprite", "hex": "#12939A", "value": 8833},
+    {"name": "LineSprite", "hex": "#12939A", "value": 1732},
+    {"name": "RectSprite", "hex": "#12939A", "value": 3623},
+    {"name": "TextSprite", "hex": "#12939A", "value": 10066}
    ]
   },
   {
    "name": "flex",
    "children": [
-    {"name": "FlareVis", "color": "#12939A", "size": 4116}
+    {"name": "FlareVis", "hex": "#12939A", "value": 4116}
    ]
   },
   {
    "name": "physics",
    "children": [
-    {"name": "DragForce", "color": "#12939A", "size": 1082},
-    {"name": "GravityForce", "color": "#12939A", "size": 1336},
-    {"name": "IForce", "color": "#12939A", "size": 319},
-    {"name": "NBodyForce", "color": "#12939A", "size": 10498},
-    {"name": "Particle", "color": "#12939A", "size": 2822},
-    {"name": "Simulation", "color": "#12939A", "size": 9983},
-    {"name": "Spring", "color": "#12939A", "size": 2213},
-    {"name": "SpringForce", "color": "#12939A", "size": 1681}
+    {"name": "DragForce", "hex": "#12939A", "value": 1082},
+    {"name": "GravityForce", "hex": "#12939A", "value": 1336},
+    {"name": "IForce", "hex": "#12939A", "value": 319},
+    {"name": "NBodyForce", "hex": "#12939A", "value": 10498},
+    {"name": "Particle", "hex": "#12939A", "value": 2822},
+    {"name": "Simulation", "hex": "#12939A", "value": 9983},
+    {"name": "Spring", "hex": "#12939A", "value": 2213},
+    {"name": "SpringForce", "hex": "#12939A", "value": 1681}
    ]
   },
   {
    "name": "query",
    "children": [
-    {"name": "AggregateExpression", "color": "#12939A", "size": 1616},
-    {"name": "And", "color": "#12939A", "size": 1027},
-    {"name": "Arithmetic", "color": "#12939A", "size": 3891},
-    {"name": "Average", "color": "#12939A", "size": 891},
-    {"name": "BinaryExpression", "color": "#12939A", "size": 2893},
-    {"name": "Comparison", "color": "#12939A", "size": 5103},
-    {"name": "CompositeExpression", "color": "#12939A", "size": 3677},
-    {"name": "Count", "color": "#12939A", "size": 781},
-    {"name": "DateUtil", "color": "#12939A", "size": 4141},
-    {"name": "Distinct", "color": "#12939A", "size": 933},
-    {"name": "Expression", "color": "#12939A", "size": 5130},
-    {"name": "ExpressionIterator", "color": "#12939A", "size": 3617},
-    {"name": "Fn", "color": "#12939A", "size": 3240},
-    {"name": "If", "color": "#12939A", "size": 2732},
-    {"name": "IsA", "color": "#12939A", "size": 2039},
-    {"name": "Literal", "color": "#12939A", "size": 1214},
-    {"name": "Match", "color": "#12939A", "size": 3748},
-    {"name": "Maximum", "color": "#12939A", "size": 843},
+    {"name": "AggregateExpression", "hex": "#12939A", "value": 1616},
+    {"name": "And", "hex": "#12939A", "value": 1027},
+    {"name": "Arithmetic", "hex": "#12939A", "value": 3891},
+    {"name": "Average", "hex": "#12939A", "value": 891},
+    {"name": "BinaryExpression", "hex": "#12939A", "value": 2893},
+    {"name": "Comparison", "hex": "#12939A", "value": 5103},
+    {"name": "CompositeExpression", "hex": "#12939A", "value": 3677},
+    {"name": "Count", "hex": "#12939A", "value": 781},
+    {"name": "DateUtil", "hex": "#12939A", "value": 4141},
+    {"name": "Distinct", "hex": "#12939A", "value": 933},
+    {"name": "Expression", "hex": "#12939A", "value": 5130},
+    {"name": "ExpressionIterator", "hex": "#12939A", "value": 3617},
+    {"name": "Fn", "hex": "#12939A", "value": 3240},
+    {"name": "If", "hex": "#12939A", "value": 2732},
+    {"name": "IsA", "hex": "#12939A", "value": 2039},
+    {"name": "Literal", "hex": "#12939A", "value": 1214},
+    {"name": "Match", "hex": "#12939A", "value": 3748},
+    {"name": "Maximum", "hex": "#12939A", "value": 843},
     {
      "name": "methods",
      "children": [
-      {"name": "add", "color": "#12939A", "size": 593},
-      {"name": "and", "color": "#12939A", "size": 330},
-      {"name": "average", "color": "#12939A", "size": 287},
-      {"name": "count", "color": "#12939A", "size": 277},
-      {"name": "distinct", "color": "#12939A", "size": 292},
-      {"name": "div", "color": "#12939A", "size": 595},
-      {"name": "eq", "color": "#12939A", "size": 594},
-      {"name": "fn", "color": "#12939A", "size": 460},
-      {"name": "gt", "color": "#12939A", "size": 603},
-      {"name": "gte", "color": "#12939A", "size": 625},
-      {"name": "iff", "color": "#12939A", "size": 748},
-      {"name": "isa", "color": "#12939A", "size": 461},
-      {"name": "lt", "color": "#12939A", "size": 597},
-      {"name": "lte", "color": "#12939A", "size": 619},
-      {"name": "max", "color": "#12939A", "size": 283},
-      {"name": "min", "color": "#12939A", "size": 283},
-      {"name": "mod", "color": "#12939A", "size": 591},
-      {"name": "mul", "color": "#12939A", "size": 603},
-      {"name": "neq", "color": "#12939A", "size": 599},
-      {"name": "not", "color": "#12939A", "size": 386},
-      {"name": "or", "color": "#12939A", "size": 323},
-      {"name": "orderby", "color": "#12939A", "size": 307},
-      {"name": "range", "color": "#12939A", "size": 772},
-      {"name": "select", "color": "#12939A", "size": 296},
-      {"name": "stddev", "color": "#12939A", "size": 363},
-      {"name": "sub", "color": "#12939A", "size": 600},
-      {"name": "sum", "color": "#12939A", "size": 280},
-      {"name": "update", "color": "#12939A", "size": 307},
-      {"name": "variance", "color": "#12939A", "size": 335},
-      {"name": "where", "color": "#12939A", "size": 299},
-      {"name": "xor", "color": "#12939A", "size": 354},
-      {"name": "_", "color": "#12939A", "size": 264}
+      {"name": "add", "hex": "#12939A", "value": 593},
+      {"name": "and", "hex": "#12939A", "value": 330},
+      {"name": "average", "hex": "#12939A", "value": 287},
+      {"name": "count", "hex": "#12939A", "value": 277},
+      {"name": "distinct", "hex": "#12939A", "value": 292},
+      {"name": "div", "hex": "#12939A", "value": 595},
+      {"name": "eq", "hex": "#12939A", "value": 594},
+      {"name": "fn", "hex": "#12939A", "value": 460},
+      {"name": "gt", "hex": "#12939A", "value": 603},
+      {"name": "gte", "hex": "#12939A", "value": 625},
+      {"name": "iff", "hex": "#12939A", "value": 748},
+      {"name": "isa", "hex": "#12939A", "value": 461},
+      {"name": "lt", "hex": "#12939A", "value": 597},
+      {"name": "lte", "hex": "#12939A", "value": 619},
+      {"name": "max", "hex": "#12939A", "value": 283},
+      {"name": "min", "hex": "#12939A", "value": 283},
+      {"name": "mod", "hex": "#12939A", "value": 591},
+      {"name": "mul", "hex": "#12939A", "value": 603},
+      {"name": "neq", "hex": "#12939A", "value": 599},
+      {"name": "not", "hex": "#12939A", "value": 386},
+      {"name": "or", "hex": "#12939A", "value": 323},
+      {"name": "orderby", "hex": "#12939A", "value": 307},
+      {"name": "range", "hex": "#12939A", "value": 772},
+      {"name": "select", "hex": "#12939A", "value": 296},
+      {"name": "stddev", "hex": "#12939A", "value": 363},
+      {"name": "sub", "hex": "#12939A", "value": 600},
+      {"name": "sum", "hex": "#12939A", "value": 280},
+      {"name": "update", "hex": "#12939A", "value": 307},
+      {"name": "variance", "hex": "#12939A", "value": 335},
+      {"name": "where", "hex": "#12939A", "value": 299},
+      {"name": "xor", "hex": "#12939A", "value": 354},
+      {"name": "_", "hex": "#12939A", "value": 264}
      ]
     },
-    {"name": "Minimum", "color": "#12939A", "size": 843},
-    {"name": "Not", "color": "#12939A", "size": 1554},
-    {"name": "Or", "color": "#12939A", "size": 970},
-    {"name": "Query", "color": "#12939A", "size": 13896},
-    {"name": "Range", "color": "#12939A", "size": 1594},
-    {"name": "StringUtil", "color": "#12939A", "size": 4130},
-    {"name": "Sum", "color": "#12939A", "size": 791},
-    {"name": "Variable", "color": "#12939A", "size": 1124},
-    {"name": "Variance", "color": "#12939A", "size": 1876},
-    {"name": "Xor", "color": "#12939A", "size": 1101}
+    {"name": "Minimum", "hex": "#12939A", "value": 843},
+    {"name": "Not", "hex": "#12939A", "value": 1554},
+    {"name": "Or", "hex": "#12939A", "value": 970},
+    {"name": "Query", "hex": "#12939A", "value": 13896},
+    {"name": "Range", "hex": "#12939A", "value": 1594},
+    {"name": "StringUtil", "hex": "#12939A", "value": 4130},
+    {"name": "Sum", "hex": "#12939A", "value": 791},
+    {"name": "Variable", "hex": "#12939A", "value": 1124},
+    {"name": "Variance", "hex": "#12939A", "value": 1876},
+    {"name": "Xor", "hex": "#12939A", "value": 1101}
    ]
   },
   {
    "name": "scale",
    "children": [
-    {"name": "IScaleMap", "color": "#FF9833", "size": 2105},
-    {"name": "LinearScale", "color": "#FF9833", "size": 1316},
-    {"name": "LogScale", "color": "#FF9833", "size": 3151},
-    {"name": "OrdinalScale", "color": "#FF9833", "size": 3770},
-    {"name": "QuantileScale", "color": "#1A3177", "size": 2435},
-    {"name": "QuantitativeScale", "color": "#FF9833", "size": 4839},
-    {"name": "RootScale", "color": "#FF9833", "size": 1756},
-    {"name": "Scale", "color": "#FF9833", "size": 4268},
-    {"name": "ScaleType", "color": "#FF9833", "size": 1821},
-    {"name": "TimeScale", "color": "#FF9833", "size": 5833}
+    {"name": "IScaleMap", "hex": "#FF9833", "value": 2105},
+    {"name": "LinearScale", "hex": "#FF9833", "value": 1316},
+    {"name": "LogScale", "hex": "#FF9833", "value": 3151},
+    {"name": "OrdinalScale", "hex": "#FF9833", "value": 3770},
+    {"name": "QuantileScale", "hex": "#1A3177", "value": 2435},
+    {"name": "QuantitativeScale", "hex": "#FF9833", "value": 4839},
+    {"name": "RootScale", "hex": "#FF9833", "value": 1756},
+    {"name": "Scale", "hex": "#FF9833", "value": 4268},
+    {"name": "ScaleType", "hex": "#FF9833", "value": 1821},
+    {"name": "TimeScale", "hex": "#FF9833", "value": 5833}
    ]
   },
   {
    "name": "util",
    "children": [
-    {"name": "Arrays", "color": "#12939A", "size": 8258},
-    {"name": "Colors", "color": "#12939A", "size": 10001},
-    {"name": "Dates", "color": "#12939A", "size": 8217},
-    {"name": "Displays", "color": "#12939A", "size": 12555},
-    {"name": "Filter", "color": "#12939A", "size": 2324},
-    {"name": "Geometry", "color": "#12939A", "size": 10993},
+    {"name": "Arrays", "hex": "#12939A", "value": 8258},
+    {"name": "hexs", "hex": "#12939A", "value": 10001},
+    {"name": "Dates", "hex": "#12939A", "value": 8217},
+    {"name": "Displays", "hex": "#12939A", "value": 12555},
+    {"name": "Filter", "hex": "#12939A", "value": 2324},
+    {"name": "Geometry", "hex": "#12939A", "value": 10993},
     {
      "name": "heap",
      "children": [
-      {"name": "FibonacciHeap", "color": "#12939A", "size": 9354},
-      {"name": "HeapNode", "color": "#12939A", "size": 1233}
+      {"name": "FibonacciHeap", "hex": "#12939A", "value": 9354},
+      {"name": "HeapNode", "hex": "#12939A", "value": 1233}
      ]
     },
-    {"name": "IEvaluable", "color": "#12939A", "size": 335},
-    {"name": "IPredicate", "color": "#12939A", "size": 383},
-    {"name": "IValueProxy", "color": "#12939A", "size": 874},
+    {"name": "IEvaluable", "hex": "#12939A", "value": 335},
+    {"name": "IPredicate", "hex": "#12939A", "value": 383},
+    {"name": "IValueProxy", "hex": "#12939A", "value": 874},
     {
      "name": "math",
      "children": [
-      {"name": "DenseMatrix", "color": "#12939A", "size": 3165},
-      {"name": "IMatrix", "color": "#12939A", "size": 2815},
-      {"name": "SparseMatrix", "color": "#12939A", "size": 3366}
+      {"name": "DenseMatrix", "hex": "#12939A", "value": 3165},
+      {"name": "IMatrix", "hex": "#12939A", "value": 2815},
+      {"name": "SparseMatrix", "hex": "#12939A", "value": 3366}
      ]
     },
-    {"name": "Maths", "color": "#12939A", "size": 17705},
-    {"name": "Orientation", "color": "#12939A", "size": 1486},
+    {"name": "Maths", "hex": "#12939A", "value": 17705},
+    {"name": "Orientation", "hex": "#12939A", "value": 1486},
     {
      "name": "palette",
      "children": [
-      {"name": "ColorPalette", "color": "#12939A", "size": 6367},
-      {"name": "Palette", "color": "#12939A", "size": 1229},
-      {"name": "ShapePalette", "color": "#12939A", "size": 2059},
-      {"name": "SizePalette", "color": "#12939A", "size": 2291}
+      {"name": "hexPalette", "hex": "#12939A", "value": 6367},
+      {"name": "Palette", "hex": "#12939A", "value": 1229},
+      {"name": "ShapePalette", "hex": "#12939A", "value": 2059},
+      {"name": "valuePalette", "hex": "#12939A", "value": 2291}
      ]
     },
-    {"name": "Property", "color": "#12939A", "size": 5559},
-    {"name": "Shapes", "color": "#12939A", "size": 19118},
-    {"name": "Sort", "color": "#12939A", "size": 6887},
-    {"name": "Stats", "color": "#12939A", "size": 6557},
-    {"name": "Strings", "color": "#12939A", "size": 22026}
+    {"name": "Property", "hex": "#12939A", "value": 5559},
+    {"name": "Shapes", "hex": "#12939A", "value": 19118},
+    {"name": "Sort", "hex": "#12939A", "value": 6887},
+    {"name": "Stats", "hex": "#12939A", "value": 6557},
+    {"name": "Strings", "hex": "#12939A", "value": 22026}
    ]
   },
   {
@@ -246,66 +246,66 @@
     {
      "name": "axis",
      "children": [
-      {"name": "Axes", "color": "#12939A", "size": 1302},
-      {"name": "Axis", "color": "#12939A", "size": 24593},
-      {"name": "AxisGridLine", "color": "#12939A", "size": 652},
-      {"name": "AxisLabel", "color": "#12939A", "size": 636},
-      {"name": "CartesianAxes", "color": "#12939A", "size": 6703}
+      {"name": "Axes", "hex": "#12939A", "value": 1302},
+      {"name": "Axis", "hex": "#12939A", "value": 24593},
+      {"name": "AxisGridLine", "hex": "#12939A", "value": 652},
+      {"name": "AxisLabel", "hex": "#12939A", "value": 636},
+      {"name": "CartesianAxes", "hex": "#12939A", "value": 6703}
      ]
     },
     {
      "name": "controls",
      "children": [
-      {"name": "AnchorControl", "color": "#12939A", "size": 2138},
-      {"name": "ClickControl", "color": "#12939A", "size": 3824},
-      {"name": "Control", "color": "#12939A", "size": 1353},
-      {"name": "ControlList", "color": "#12939A", "size": 4665},
-      {"name": "DragControl", "color": "#12939A", "size": 2649},
-      {"name": "ExpandControl", "color": "#12939A", "size": 2832},
-      {"name": "HoverControl", "color": "#12939A", "size": 4896},
-      {"name": "IControl", "color": "#12939A", "size": 763},
-      {"name": "PanZoomControl", "color": "#12939A", "size": 5222},
-      {"name": "SelectionControl", "color": "#12939A", "size": 7862},
-      {"name": "TooltipControl", "color": "#12939A", "size": 8435}
+      {"name": "AnchorControl", "hex": "#12939A", "value": 2138},
+      {"name": "ClickControl", "hex": "#12939A", "value": 3824},
+      {"name": "Control", "hex": "#12939A", "value": 1353},
+      {"name": "ControlList", "hex": "#12939A", "value": 4665},
+      {"name": "DragControl", "hex": "#12939A", "value": 2649},
+      {"name": "ExpandControl", "hex": "#12939A", "value": 2832},
+      {"name": "HoverControl", "hex": "#12939A", "value": 4896},
+      {"name": "IControl", "hex": "#12939A", "value": 763},
+      {"name": "PanZoomControl", "hex": "#12939A", "value": 5222},
+      {"name": "SelectionControl", "hex": "#12939A", "value": 7862},
+      {"name": "TooltipControl", "hex": "#12939A", "value": 8435}
      ]
     },
     {
      "name": "data",
      "children": [
-      {"name": "Data", "color": "#12939A", "size": 20544},
-      {"name": "DataList", "color": "#12939A", "size": 19788},
-      {"name": "DataSprite", "color": "#12939A", "size": 10349},
-      {"name": "EdgeSprite", "color": "#12939A", "size": 3301},
-      {"name": "NodeSprite", "color": "#12939A", "size": 19382},
+      {"name": "Data", "hex": "#12939A", "value": 20544},
+      {"name": "DataList", "hex": "#12939A", "value": 19788},
+      {"name": "DataSprite", "hex": "#12939A", "value": 10349},
+      {"name": "EdgeSprite", "hex": "#12939A", "value": 3301},
+      {"name": "NodeSprite", "hex": "#12939A", "value": 19382},
       {
        "name": "render",
        "children": [
-        {"name": "ArrowType", "color": "#12939A", "size": 698},
-        {"name": "EdgeRenderer", "color": "#12939A", "size": 5569},
-        {"name": "IRenderer", "color": "#12939A", "size": 353},
-        {"name": "ShapeRenderer", "color": "#12939A", "size": 2247}
+        {"name": "ArrowType", "hex": "#12939A", "value": 698},
+        {"name": "EdgeRenderer", "hex": "#12939A", "value": 5569},
+        {"name": "IRenderer", "hex": "#12939A", "value": 353},
+        {"name": "ShapeRenderer", "hex": "#12939A", "value": 2247}
        ]
       },
-      {"name": "ScaleBinding", "color": "#12939A", "size": 11275},
-      {"name": "Tree", "color": "#12939A", "size": 7147},
-      {"name": "TreeBuilder", "color": "#12939A", "size": 9930}
+      {"name": "ScaleBinding", "hex": "#12939A", "value": 11275},
+      {"name": "Tree", "hex": "#12939A", "value": 7147},
+      {"name": "TreeBuilder", "hex": "#12939A", "value": 9930}
      ]
     },
     {
      "name": "events",
      "children": [
-      {"name": "DataEvent", "color": "#12939A", "size": 2313},
-      {"name": "SelectionEvent", "color": "#12939A", "size": 1880},
-      {"name": "TooltipEvent", "color": "#12939A", "size": 1701},
-      {"name": "VisualizationEvent", "color": "#12939A", "size": 1117}
+      {"name": "DataEvent", "hex": "#12939A", "value": 2313},
+      {"name": "SelectionEvent", "hex": "#12939A", "value": 1880},
+      {"name": "TooltipEvent", "hex": "#12939A", "value": 1701},
+      {"name": "VisualizationEvent", "hex": "#12939A", "value": 1117}
      ]
     },
     {
      "name": "legend",
      "children": [
-      {"name": "Legend", "color": "#12939A", "size": 20859},
-      {"name": "LegendItem", "color": "#12939A", "size": 4614},
-      {"name": "LegendRange", "color": "#12939A", "size": 10530}
+      {"name": "Legend", "hex": "#12939A", "value": 20859},
+      {"name": "LegendItem", "hex": "#12939A", "value": 4614},
+      {"name": "LegendRange", "hex": "#12939A", "value": 10530}
      ]
     },
     {
@@ -314,66 +314,66 @@
       {
        "name": "distortion",
        "children": [
-        {"name": "BifocalDistortion", "color": "#12939A", "size": 4461},
-        {"name": "Distortion", "color": "#12939A", "size": 6314},
-        {"name": "FisheyeDistortion", "color": "#12939A", "size": 3444}
+        {"name": "BifocalDistortion", "hex": "#12939A", "value": 4461},
+        {"name": "Distortion", "hex": "#12939A", "value": 6314},
+        {"name": "FisheyeDistortion", "hex": "#12939A", "value": 3444}
        ]
       },
       {
        "name": "encoder",
        "children": [
-        {"name": "ColorEncoder", "color": "#12939A", "size": 3179},
-        {"name": "Encoder", "color": "#12939A", "size": 4060},
-        {"name": "PropertyEncoder", "color": "#12939A", "size": 4138},
-        {"name": "ShapeEncoder", "color": "#12939A", "size": 1690},
-        {"name": "SizeEncoder", "color": "#12939A", "size": 1830}
+        {"name": "hexEncoder", "hex": "#12939A", "value": 3179},
+        {"name": "Encoder", "hex": "#12939A", "value": 4060},
+        {"name": "PropertyEncoder", "hex": "#12939A", "value": 4138},
+        {"name": "ShapeEncoder", "hex": "#12939A", "value": 1690},
+        {"name": "valueEncoder", "hex": "#12939A", "value": 1830}
        ]
       },
       {
        "name": "filter",
        "children": [
-        {"name": "FisheyeTreeFilter", "color": "#12939A", "size": 5219},
-        {"name": "GraphDistanceFilter", "color": "#12939A", "size": 3165},
-        {"name": "VisibilityFilter", "color": "#12939A", "size": 3509}
+        {"name": "FisheyeTreeFilter", "hex": "#12939A", "value": 5219},
+        {"name": "GraphDistanceFilter", "hex": "#12939A", "value": 3165},
+        {"name": "VisibilityFilter", "hex": "#12939A", "value": 3509}
        ]
       },
-      {"name": "IOperator", "color": "#12939A", "size": 1286},
+      {"name": "IOperator", "hex": "#12939A", "value": 1286},
       {
        "name": "label",
        "children": [
-        {"name": "Labeler", "color": "#12939A", "size": 9956},
-        {"name": "RadialLabeler", "color": "#12939A", "size": 3899},
-        {"name": "StackedAreaLabeler", "color": "#12939A", "size": 3202}
+        {"name": "Labeler", "hex": "#12939A", "value": 9956},
+        {"name": "RadialLabeler", "hex": "#12939A", "value": 3899},
+        {"name": "StackedAreaLabeler", "hex": "#12939A", "value": 3202}
        ]
       },
       {
        "name": "layout",
        "children": [
-        {"name": "AxisLayout", "color": "#12939A", "size": 6725},
-        {"name": "BundledEdgeRouter", "color": "#12939A", "size": 3727},
-        {"name": "CircleLayout", "color": "#12939A", "size": 9317},
-        {"name": "CirclePackingLayout", "color": "#12939A", "size": 12003},
-        {"name": "DendrogramLayout", "color": "#12939A", "size": 4853},
-        {"name": "ForceDirectedLayout", "color": "#12939A", "size": 8411},
-        {"name": "IcicleTreeLayout", "color": "#12939A", "size": 4864},
-        {"name": "IndentedTreeLayout", "color": "#12939A", "size": 3174},
-        {"name": "Layout", "color": "#12939A", "size": 7881},
-        {"name": "NodeLinkTreeLayout", "color": "#12939A", "size": 12870},
-        {"name": "PieLayout", "color": "#12939A", "size": 2728},
-        {"name": "RadialTreeLayout", "color": "#12939A", "size": 12348},
-        {"name": "RandomLayout", "color": "#12939A", "size": 870},
-        {"name": "StackedAreaLayout", "color": "#12939A", "size": 9121},
-        {"name": "TreeMapLayout", "color": "#12939A", "size": 9191}
+        {"name": "AxisLayout", "hex": "#12939A", "value": 6725},
+        {"name": "BundledEdgeRouter", "hex": "#12939A", "value": 3727},
+        {"name": "CircleLayout", "hex": "#12939A", "value": 9317},
+        {"name": "CirclePackingLayout", "hex": "#12939A", "value": 12003},
+        {"name": "DendrogramLayout", "hex": "#12939A", "value": 4853},
+        {"name": "ForceDirectedLayout", "hex": "#12939A", "value": 8411},
+        {"name": "IcicleTreeLayout", "hex": "#12939A", "value": 4864},
+        {"name": "IndentedTreeLayout", "hex": "#12939A", "value": 3174},
+        {"name": "Layout", "hex": "#12939A", "value": 7881},
+        {"name": "NodeLinkTreeLayout", "hex": "#12939A", "value": 12870},
+        {"name": "PieLayout", "hex": "#12939A", "value": 2728},
+        {"name": "RadialTreeLayout", "hex": "#12939A", "value": 12348},
+        {"name": "RandomLayout", "hex": "#12939A", "value": 870},
+        {"name": "StackedAreaLayout", "hex": "#12939A", "value": 9121},
+        {"name": "TreeMapLayout", "hex": "#12939A", "value": 9191}
        ]
       },
-      {"name": "Operator", "color": "#12939A", "size": 2490},
-      {"name": "OperatorList", "color": "#12939A", "size": 5248},
-      {"name": "OperatorSequence", "color": "#12939A", "size": 4190},
-      {"name": "OperatorSwitch", "color": "#12939A", "size": 2581},
-      {"name": "SortOperator", "color": "#12939A", "size": 2023}
+      {"name": "Operator", "hex": "#12939A", "value": 2490},
+      {"name": "OperatorList", "hex": "#12939A", "value": 5248},
+      {"name": "OperatorSequence", "hex": "#12939A", "value": 4190},
+      {"name": "OperatorSwitch", "hex": "#12939A", "value": 2581},
+      {"name": "SortOperator", "hex": "#12939A", "value": 2023}
      ]
     },
-    {"name": "Visualization", "color": "#12939A", "size": 16540}
+    {"name": "Visualization", "hex": "#12939A", "value": 16540}
    ]
   }
  ]

--- a/showcase/treemap/dynamic-treemap.js
+++ b/showcase/treemap/dynamic-treemap.js
@@ -63,7 +63,7 @@ export default class DynamicTreemapExample extends React.Component {
       onLeafClick: () => this.setState({treemapData: _getRandomData()}),
       height: 300,
       mode: this.state.useCirclePacking ? 'circlePack' : 'squarify',
-      labelAccessor: x => x.name,
+      getLabel: x => x.name,
       width: 350
     };
     return (

--- a/showcase/treemap/dynamic-treemap.js
+++ b/showcase/treemap/dynamic-treemap.js
@@ -28,7 +28,7 @@ function _getRandomData(total) {
   const leaves = [];
   for (let i = 0; i < totalLeaves; i++) {
     leaves.push({
-      title: total ? total : String(Math.random()).slice(0, 3),
+      name: total ? total : String(Math.random()).slice(0, 3),
       size: Math.random() * 1000,
       color: Math.random(),
       style: {
@@ -63,6 +63,7 @@ export default class DynamicTreemapExample extends React.Component {
       onLeafClick: () => this.setState({treemapData: _getRandomData()}),
       height: 300,
       mode: this.state.useCirclePacking ? 'circlePack' : 'squarify',
+      labelAccessor: x => x.name,
       width: 350
     };
     return (

--- a/showcase/treemap/simple-treemap.js
+++ b/showcase/treemap/simple-treemap.js
@@ -86,8 +86,8 @@ export default class SimpleTreemapExample extends React.Component {
           height: 300,
           width: 350,
           margin: 10,
-          sizeAccessor: d => d.value,
-          colorAccessor: d => d.hex,
+          getSize: d => d.value,
+          getColor: d => d.hex,
           style: STYLES[useSVG ? 'SVG' : 'DOM']
         }}/>
       </div>

--- a/showcase/treemap/simple-treemap.js
+++ b/showcase/treemap/simple-treemap.js
@@ -86,6 +86,8 @@ export default class SimpleTreemapExample extends React.Component {
           height: 300,
           width: 350,
           margin: 10,
+          sizeAccessor: d => d.value,
+          colorAccessor: d => d.hex,
           style: STYLES[useSVG ? 'SVG' : 'DOM']
         }}/>
       </div>

--- a/src/parallel-coordinates/index.js
+++ b/src/parallel-coordinates/index.js
@@ -117,10 +117,10 @@ function getLines(props) {
 
   return data.map((row, rowIndex) => {
     const mappedData = domains.map((domain, index) => {
-      const {accessor, name} = domain;
+      const {getValue, name} = domain;
       return {
         x: name,
-        y: scales[name](accessor ? accessor(row) : row[name])
+        y: scales[name](getValue ? getValue(row) : row[name])
       };
     });
     const lineProps = {

--- a/src/parallel-coordinates/index.js
+++ b/src/parallel-coordinates/index.js
@@ -110,16 +110,17 @@ function getLines(props) {
     style,
     showMarks
   } = props;
-  const scales = domains.reduce((acc, domain) => {
-    acc[domain.name] = scaleLinear().domain(domain.domain).range([0, 1]);
+  const scales = domains.reduce((acc, {domain, name}) => {
+    acc[name] = scaleLinear().domain(domain).range([0, 1]);
     return acc;
   }, {});
 
   return data.map((row, rowIndex) => {
     const mappedData = domains.map((domain, index) => {
+      const {accessor, name} = domain;
       return {
-        x: domain.name,
-        y: scales[domain.name](row[domain.name])
+        x: name,
+        y: scales[name](accessor ? accessor(row) : row[name])
       };
     });
     const lineProps = {

--- a/src/plot/series/canvas-wrapper.js
+++ b/src/plot/series/canvas-wrapper.js
@@ -114,6 +114,9 @@ class CanvasWrapper extends Component {
   componentDidMount() {
     const ctx = this.refs.canvas.getContext('2d');
     const {pixelRatio} = this.props;
+    if (!ctx) {
+      return;
+    }
     ctx.scale(pixelRatio, pixelRatio);
 
     this.drawChildren(this.props, null, ctx);

--- a/src/plot/series/label-series.js
+++ b/src/plot/series/label-series.js
@@ -34,7 +34,7 @@ class LabelSeries extends AbstractSeries {
       className,
       data,
       _data,
-      labelAccessor,
+      getLabel,
       marginLeft,
       marginTop,
       rotation,
@@ -63,7 +63,7 @@ class LabelSeries extends AbstractSeries {
          transform={`translate(${marginLeft},${marginTop})`}>
         {data.reduce((res, d, i) => {
           const {style, xOffset, yOffset} = d;
-          if (!labelAccessor(d)) {
+          if (!getLabel(d)) {
             return res;
           }
           const xVal = xFunctor(d);
@@ -87,7 +87,7 @@ class LabelSeries extends AbstractSeries {
             transform: `rotate(${d.rotation || rotation},${x},${y})`,
             ...style
           };
-          const textContent = labelAccessor(_data ? _data[i] : d);
+          const textContent = getLabel(_data ? _data[i] : d);
           return res.concat([<text {...attrs} >{textContent}</text>]);
         }, [])}
       </g>
@@ -118,7 +118,7 @@ LabelSeries.propTypes = {
 LabelSeries.defaultProps = {
   animation: false,
   rotation: 0,
-  labelAccessor: d => d.label
+  getLabel: d => d.label
 };
 LabelSeries.displayName = 'LabelSeries';
 export default LabelSeries;

--- a/src/plot/series/label-series.js
+++ b/src/plot/series/label-series.js
@@ -34,6 +34,7 @@ class LabelSeries extends AbstractSeries {
       className,
       data,
       _data,
+      labelAccessor,
       marginLeft,
       marginTop,
       rotation,
@@ -61,8 +62,8 @@ class LabelSeries extends AbstractSeries {
          ref="container"
          transform={`translate(${marginLeft},${marginTop})`}>
         {data.reduce((res, d, i) => {
-          const {label, style, xOffset, yOffset} = d;
-          if (!label) {
+          const {style, xOffset, yOffset} = d;
+          if (!labelAccessor(d)) {
             return res;
           }
           const xVal = xFunctor(d);
@@ -86,7 +87,8 @@ class LabelSeries extends AbstractSeries {
             transform: `rotate(${d.rotation || rotation},${x},${y})`,
             ...style
           };
-          return res.concat([<text {...attrs} >{_data ? _data[i].label : label}</text>]);
+          const textContent = labelAccessor(_data ? _data[i] : d);
+          return res.concat([<text {...attrs} >{textContent}</text>]);
         }, [])}
       </g>
     );
@@ -115,7 +117,8 @@ LabelSeries.propTypes = {
 };
 LabelSeries.defaultProps = {
   animation: false,
-  rotation: 0
+  rotation: 0,
+  labelAccessor: d => d.label
 };
 LabelSeries.displayName = 'LabelSeries';
 export default LabelSeries;

--- a/src/plot/series/mark-series.js
+++ b/src/plot/series/mark-series.js
@@ -33,24 +33,24 @@ const predefinedClassName = 'rv-xy-plot__series rv-xy-plot__series--mark';
 const DEFAULT_STROKE_WIDTH = 1;
 
 class MarkSeries extends AbstractSeries {
-  _renderCircle(d, i, strokeWidth, style) {
-    const sizeFunctor = this._getAttributeFunctor('size');
-    const opacityFunctor = this._getAttributeFunctor('opacity');
-    const fillFunctor =
-      this._getAttributeFunctor('fill') || this._getAttributeFunctor('color');
-    const strokeFunctor =
-      this._getAttributeFunctor('stroke') || this._getAttributeFunctor('color');
-    const xFunctor = this._getAttributeFunctor('x');
-    const yFunctor = this._getAttributeFunctor('y');
+  _renderCircle(d, i, strokeWidth, style, scalingFunctions) {
+    const {
+      fill,
+      opacity,
+      size,
+      stroke,
+      x,
+      y
+    } = scalingFunctions;
 
     const attrs = {
-      r: sizeFunctor ? sizeFunctor(d) : DEFAULT_SIZE,
-      cx: xFunctor(d),
-      cy: yFunctor(d),
+      r: size ? size(d) : DEFAULT_SIZE,
+      cx: x(d),
+      cy: y(d),
       style: {
-        opacity: opacityFunctor ? opacityFunctor(d) : DEFAULT_OPACITY,
-        stroke: strokeFunctor && strokeFunctor(d),
-        fill: fillFunctor && fillFunctor(d),
+        opacity: opacity ? opacity(d) : DEFAULT_OPACITY,
+        stroke: stroke && stroke(d),
+        fill: fill && fill(d),
         strokeWidth: strokeWidth || DEFAULT_STROKE_WIDTH,
         ...style
       },
@@ -92,6 +92,15 @@ class MarkSeries extends AbstractSeries {
       );
     }
 
+    const scalingFunctions = {
+      fill: this._getAttributeFunctor('fill') || this._getAttributeFunctor('color'),
+      opacity: this._getAttributeFunctor('opacity'),
+      size: this._getAttributeFunctor('size'),
+      stroke: this._getAttributeFunctor('stroke') || this._getAttributeFunctor('color'),
+      x: this._getAttributeFunctor('x'),
+      y: this._getAttributeFunctor('y')
+    };
+
     return (
       <g
         className={`${predefinedClassName} ${className}`}
@@ -99,7 +108,7 @@ class MarkSeries extends AbstractSeries {
         transform={`translate(${marginLeft},${marginTop})`}
       >
         {data.map((d, i) => {
-          return getNull(d) && this._renderCircle(d, i, strokeWidth, style);
+          return getNull(d) && this._renderCircle(d, i, strokeWidth, style, scalingFunctions);
         })}
       </g>
     );

--- a/src/plot/xy-plot.js
+++ b/src/plot/xy-plot.js
@@ -374,7 +374,6 @@ class XYPlot extends React.Component {
         const {seriesIndex} = seriesProps[index];
         dataProps = {data: data[seriesIndex]};
       }
-
       return React.cloneElement(child, {
         ...dimensions,
         animation,

--- a/src/radar-chart/index.js
+++ b/src/radar-chart/index.js
@@ -88,13 +88,13 @@ function getAxes(props) {
  */
 function getLabels(props) {
   const {domains, startingAngle, style} = props;
-  return domains.map((domain, index) => {
+  return domains.map(({name}, index) => {
     const angle = index / domains.length * Math.PI * 2 + startingAngle;
     const radius = 1.2;
     return {
       x: radius * Math.cos(angle),
       y: radius * Math.sin(angle),
-      label: domain.name,
+      label: name,
       style
     };
   });
@@ -119,18 +119,18 @@ function getPolygons(props) {
     style,
     startingAngle
   } = props;
-  const scales = domains.reduce((acc, domain) => {
-    acc[domain.name] = scaleLinear().domain(domain.domain).range([0, 1]);
+  const scales = domains.reduce((acc, {domain, name}) => {
+    acc[name] = scaleLinear().domain(domain).range([0, 1]);
     return acc;
   }, {});
 
   return data.map((row, rowIndex) => {
-    const mappedData = domains.map((domain, index) => {
-      const dataPoint = row[domain.name];
+    const mappedData = domains.map(({name, accessor}, index) => {
+      const dataPoint = accessor ? accessor(row) : row[name];
       // error handling if point doesn't exist
       const angle = index / domains.length * Math.PI * 2 + startingAngle;
       // dont let the radius become negative
-      const radius = Math.max(scales[domain.name](dataPoint), 0);
+      const radius = Math.max(scales[name](dataPoint), 0);
       return {x: radius * Math.cos(angle), y: radius * Math.sin(angle)};
     });
 

--- a/src/radar-chart/index.js
+++ b/src/radar-chart/index.js
@@ -125,8 +125,8 @@ function getPolygons(props) {
   }, {});
 
   return data.map((row, rowIndex) => {
-    const mappedData = domains.map(({name, accessor}, index) => {
-      const dataPoint = accessor ? accessor(row) : row[name];
+    const mappedData = domains.map(({name, getValue}, index) => {
+      const dataPoint = getValue ? getValue(row) : row[name];
       // error handling if point doesn't exist
       const angle = index / domains.length * Math.PI * 2 + startingAngle;
       // dont let the radius become negative

--- a/src/radial-chart/index.js
+++ b/src/radial-chart/index.js
@@ -40,8 +40,8 @@ const DEFAULT_RADIUS_MARGIN = 15;
    props.data {Object} - tree structured data (each node has a name anc an array of children)
  * @returns {Array} Array of nodes.
  */
-function getWedgesToRender({data, angleAccessor}) {
-  const pie = pieBuilder().sort(null).value(angleAccessor);
+function getWedgesToRender({data, getAngle}) {
+  const pie = pieBuilder().sort(null).value(getAngle);
   const pieData = pie(data).reverse();
   return pieData.map((row, index) => {
     return {
@@ -57,8 +57,8 @@ function getWedgesToRender({data, angleAccessor}) {
 
 function generateLabels(mappedData, accessors) {
   const {
-    labelAccessor,
-    subLabelAccessor
+    getLabel,
+    getSubLabel
   } = accessors;
   return mappedData.reduce((res, row) => {
     const {angle, angle0, radius} = row;
@@ -68,20 +68,20 @@ function generateLabels(mappedData, accessors) {
     // and move clockwise rather than counter clockwise. why why why!
     const updatedAngle = -1 * centeredAngle + Math.PI / 2;
     const newLabels = [];
-    if (labelAccessor(row)) {
+    if (getLabel(row)) {
       newLabels.push({
         angle: updatedAngle,
         radius: radius * 1.1,
-        label: labelAccessor(row),
+        label: getLabel(row),
         style: {fontSize: '12px'}
       });
     }
 
-    if (subLabelAccessor(row)) {
+    if (getSubLabel(row)) {
       newLabels.push({
         angle: updatedAngle,
         radius: radius * 1.1,
-        label: subLabelAccessor(row),
+        label: getSubLabel(row),
         yOffset: 12,
         style: {fontSize: '10px'}
       });
@@ -119,11 +119,11 @@ class RadialChart extends Component {
       onMouseLeave,
       onMouseEnter,
       labelsAboveChildren,
-      angleAccessor,
-      labelAccessor,
-      subLabelAccessor
+      getAngle,
+      getLabel,
+      getSubLabel
     } = this.props;
-    const mappedData = getWedgesToRender({data, height, hideRootNode, width, angleAccessor});
+    const mappedData = getWedgesToRender({data, height, hideRootNode, width, getAngle});
     const radialDomain = getRadialDomain(mappedData);
     const arcProps = {
       colorType,
@@ -143,8 +143,8 @@ class RadialChart extends Component {
     const defaultMargin = getRadialLayoutMargin(width, height, maxRadius);
 
     const labels = generateLabels(mappedData, {
-      labelAccessor,
-      subLabelAccessor
+      getLabel,
+      getSubLabel
     });
     return (
       <XYPlot
@@ -159,7 +159,7 @@ class RadialChart extends Component {
         onMouseEnter={onMouseEnter}
         xDomain={[-radialDomain, radialDomain]}
         yDomain={[-radialDomain, radialDomain]}>
-        <ArcSeries {...arcProps} angleAccessor={d => d.angle}/>
+        <ArcSeries {...arcProps} getAngle={d => d.angle}/>
         {showLabels && !labelsAboveChildren && <LabelSeries data={labels}/>}
         {children}
         {showLabels && labelsAboveChildren && <LabelSeries data={labels}/>}
@@ -180,6 +180,11 @@ RadialChart.propTypes = {
     radius: PropTypes.number,
     style: PropTypes.object
   })).isRequired,
+  getAngle: PropTypes.func,
+  getAngle0: PropTypes.func,
+  getRadius: PropTypes.func,
+  getRadius0: PropTypes.func,
+  getLabel: PropTypes.func,
   height: PropTypes.number.isRequired,
   labelsAboveChildren: PropTypes.bool,
   margin: MarginPropType,
@@ -188,23 +193,18 @@ RadialChart.propTypes = {
   onValueMouseOut: PropTypes.func,
   width: PropTypes.number.isRequired,
   showLabels: PropTypes.bool,
-  angleAccessor: PropTypes.func,
-  angle0Accessor: PropTypes.func,
-  radiusAccessor: PropTypes.func,
-  radius0Accessor: PropTypes.func,
-  labelAccessor: PropTypes.func,
   subLabel: PropTypes.func
 };
 RadialChart.defaultProps = {
   className: '',
   colorType: 'category',
   colorRange: DISCRETE_COLOR_RANGE,
-  angleAccessor: d => d.angle,
-  angle0Accessor: d => d.angle0,
-  radiusAccessor: d => d.radius,
-  radius0Accessor: d => d.radius0,
-  labelAccessor: d => d.label,
-  subLabelAccessor: d => d.subLabel
+  getAngle: d => d.angle,
+  getAngle0: d => d.angle0,
+  getRadius: d => d.radius,
+  getRadius0: d => d.radius0,
+  getLabel: d => d.label,
+  getSubLabel: d => d.subLabel
 };
 
 export default RadialChart;

--- a/src/sunburst/index.js
+++ b/src/sunburst/index.js
@@ -57,12 +57,12 @@ const LISTENERS_TO_OVERWRITE = [
    props.height {number} - the height of the graphic to be rendered
    props.hideRootNode {boolean} - whether or not to hide the root node
    props.width {number} - the width of the graphic to be rendered
-   props.sizeAccessor {function} - accessor for the size
+   props.getSize {function} - accessor for the size
  * @returns {Array} Array of nodes.
  */
-function getNodesToRender({data, height, hideRootNode, width, sizeAccessor}) {
+function getNodesToRender({data, height, hideRootNode, width, getSize}) {
   const partitionFunction = partition();
-  const structuredInput = hierarchy(data).sum(sizeAccessor);
+  const structuredInput = hierarchy(data).sum(getSize);
   const radius = (Math.min(width, height) / 2) - 10;
   const x = scaleLinear().range([0, 2 * Math.PI]);
   const y = scaleSqrt().range([0, radius]);
@@ -94,17 +94,17 @@ function getNodesToRender({data, height, hideRootNode, width, sizeAccessor}) {
  */
 function buildLabels(mappedData, accessors) {
   const {
-    angleAccessor,
-    angle0Accessor,
-    labelAccessor,
-    radius0Accessor
+    getAngle,
+    getAngle0,
+    getLabel,
+    getRadius0
   } = accessors;
 
   return mappedData
-  .filter(labelAccessor)
+  .filter(getLabel)
   .map(row => {
-    const truedAngle = -1 * angleAccessor(row) + Math.PI / 2;
-    const truedAngle0 = -1 * angle0Accessor(row) + Math.PI / 2;
+    const truedAngle = -1 * getAngle(row) + Math.PI / 2;
+    const truedAngle0 = -1 * getAngle0(row) + Math.PI / 2;
     const angle = (truedAngle0 + truedAngle) / 2;
     const rotateLabels = !row.dontRotateLabel;
     const rotAngle = -angle / (2 * Math.PI) * 360;
@@ -114,8 +114,8 @@ function buildLabels(mappedData, accessors) {
       children: null,
       angle: null,
       radius: null,
-      x: radius0Accessor(row) * Math.cos(angle),
-      y: radius0Accessor(row) * Math.sin(angle),
+      x: getRadius0(row) * Math.cos(angle),
+      y: getRadius0(row) * Math.sin(angle),
       style: {
         textAnchor: rotAngle > 90 ? 'end' : 'start',
         ...row.labelStyle
@@ -132,28 +132,28 @@ const NOOP = () => {};
 class Sunburst extends React.Component {
   render() {
     const {
-      angleAccessor,
-      angle0Accessor,
+      getAngle,
+      getAngle0,
       animation,
       className,
       children,
       data,
       height,
       hideRootNode,
-      labelAccessor,
+      getLabel,
       width,
-      sizeAccessor,
+      getSize,
       colorType
     } = this.props;
-    const mappedData = getNodesToRender({data, height, hideRootNode, width, sizeAccessor});
+    const mappedData = getNodesToRender({data, height, hideRootNode, width, getSize});
     const radialDomain = getRadialDomain(mappedData);
     const margin = getRadialLayoutMargin(width, height, radialDomain);
 
     const labelData = buildLabels(mappedData, {
-      angleAccessor,
-      angle0Accessor,
-      labelAccessor,
-      radius0Accessor: d => d.radius0
+      getAngle,
+      getAngle0,
+      getLabel,
+      getRadius0: d => d.radius0
     });
 
     const hofBuilder = f => (e, i) => f ? f(mappedData[e.index], i) : NOOP;
@@ -183,7 +183,7 @@ class Sunburst extends React.Component {
             return acc;
           }, {}))
         }}/>
-        {labelData.length > 0 && (<LabelSeries data={labelData} labelAccessor={labelAccessor}/>)}
+        {labelData.length > 0 && (<LabelSeries data={labelData} getLabel={getLabel}/>)}
         {children}
       </XYPlot>
     );
@@ -193,29 +193,29 @@ class Sunburst extends React.Component {
 Sunburst.displayName = 'Sunburst';
 Sunburst.propTypes = {
   animation: AnimationPropType,
-  angleAccessor: PropTypes.func,
-  angle0Accessor: PropTypes.func,
+  getAngle: PropTypes.func,
+  getAngle0: PropTypes.func,
   className: PropTypes.string,
   colorType: PropTypes.string,
   data: PropTypes.object.isRequired,
   height: PropTypes.number.isRequired,
   hideRootNode: PropTypes.bool,
-  labelAccessor: PropTypes.func,
+  getLabel: PropTypes.func,
   onValueClick: PropTypes.func,
   onValueMouseOver: PropTypes.func,
   onValueMouseOut: PropTypes.func,
-  sizeAccessor: PropTypes.func,
+  getSize: PropTypes.func,
   width: PropTypes.number.isRequired
 };
 Sunburst.defaultProps = {
-  angleAccessor: d => d.angle,
-  angle0Accessor: d => d.angle0,
+  getAngle: d => d.angle,
+  getAngle0: d => d.angle0,
   className: '',
   colorType: 'literal',
-  colorAccessor: d => d.color,
+  getColor: d => d.color,
   hideRootNode: false,
-  labelAccessor: d => d.label,
-  sizeAccessor: d => d.size
+  getLabel: d => d.label,
+  getSize: d => d.size
 };
 
 export default Sunburst;

--- a/src/treemap/index.js
+++ b/src/treemap/index.js
@@ -142,8 +142,8 @@ class Treemap extends React.Component {
           .size([innerWidth, innerHeight])
           .padding(padding);
       const structuredInput = hierarchy(data)
-        .sum(d => d.size)
-        .sort(sortFunction);
+        .sum(sizeAccessor)
+        .sort((a, b) => sortFunction(a, b, sizeAccessor));
       return packingFunction(structuredInput).descendants();
     }
 
@@ -153,8 +153,8 @@ class Treemap extends React.Component {
       .size([innerWidth, innerHeight])
       .padding(padding);
     const structuredInput = hierarchy(data)
-      .sum(d => d.size)
-      .sort(sortFunction);
+      .sum(sizeAccessor)
+      .sort((a, b) => sortFunction(a, b, sizeAccessor));
     return treemapingFunction(structuredInput).descendants();
 
   }
@@ -207,7 +207,7 @@ Treemap.defaultProps = {
   opacityType: OPACITY_TYPE,
   _opacityValue: DEFAULT_OPACITY,
   padding: 1,
-  sortFunction: (a, b) => a.size - b.size,
+  sortFunction: (a, b, accessor) => accessor(a) - accessor(b),
   sizeAccessor: d => d.size,
   colorAccessor: d => d.color,
   labelAccessor: d => d.title

--- a/src/treemap/index.js
+++ b/src/treemap/index.js
@@ -113,7 +113,7 @@ class Treemap extends React.Component {
    */
   _getNodesToRender() {
     const {innerWidth, innerHeight} = this.state;
-    const {data, mode, padding, sortFunction} = this.props;
+    const {data, mode, padding, sortFunction, sizeAccessor} = this.props;
     if (!data) {
       return [];
     }
@@ -186,7 +186,9 @@ Treemap.propTypes = {
   useCirclePacking: PropTypes.bool,
   padding: PropTypes.number.isRequired,
   sortFunction: PropTypes.func,
-  width: PropTypes.number.isRequired
+  width: PropTypes.number.isRequired,
+  sizeAccessor: PropTypes.func,
+  colorAccessor: PropTypes.func
 };
 
 Treemap.defaultProps = {
@@ -205,6 +207,9 @@ Treemap.defaultProps = {
   opacityType: OPACITY_TYPE,
   _opacityValue: DEFAULT_OPACITY,
   padding: 1,
-  sortFunction: (a, b) => a.size - b.size
+  sortFunction: (a, b) => a.size - b.size,
+  sizeAccessor: d => d.size,
+  colorAccessor: d => d.color,
+  labelAccessor: d => d.title
 };
 export default Treemap;

--- a/src/treemap/index.js
+++ b/src/treemap/index.js
@@ -113,7 +113,7 @@ class Treemap extends React.Component {
    */
   _getNodesToRender() {
     const {innerWidth, innerHeight} = this.state;
-    const {data, mode, padding, sortFunction, sizeAccessor} = this.props;
+    const {data, mode, padding, sortFunction, getSize} = this.props;
     if (!data) {
       return [];
     }
@@ -123,8 +123,8 @@ class Treemap extends React.Component {
           .size(mode === 'partition-pivot' ? [innerHeight, innerWidth] : [innerWidth, innerHeight])
           .padding(padding);
       const structuredInput = hierarchy(data)
-        .sum(d => d.size)
-        .sort(sortFunction);
+        .sum(getSize)
+        .sort((a, b) => sortFunction(a, b, getSize));
       const mappedNodes = partitionFunction(structuredInput).descendants();
       if (mode === 'partition-pivot') {
         return mappedNodes.map(node => ({
@@ -142,8 +142,8 @@ class Treemap extends React.Component {
           .size([innerWidth, innerHeight])
           .padding(padding);
       const structuredInput = hierarchy(data)
-        .sum(sizeAccessor)
-        .sort((a, b) => sortFunction(a, b, sizeAccessor));
+        .sum(getSize)
+        .sort((a, b) => sortFunction(a, b, getSize));
       return packingFunction(structuredInput).descendants();
     }
 
@@ -153,8 +153,8 @@ class Treemap extends React.Component {
       .size([innerWidth, innerHeight])
       .padding(padding);
     const structuredInput = hierarchy(data)
-      .sum(sizeAccessor)
-      .sort((a, b) => sortFunction(a, b, sizeAccessor));
+      .sum(getSize)
+      .sort((a, b) => sortFunction(a, b, getSize));
     return treemapingFunction(structuredInput).descendants();
 
   }
@@ -187,8 +187,8 @@ Treemap.propTypes = {
   padding: PropTypes.number.isRequired,
   sortFunction: PropTypes.func,
   width: PropTypes.number.isRequired,
-  sizeAccessor: PropTypes.func,
-  colorAccessor: PropTypes.func
+  getSize: PropTypes.func,
+  getColor: PropTypes.func
 };
 
 Treemap.defaultProps = {
@@ -207,9 +207,14 @@ Treemap.defaultProps = {
   opacityType: OPACITY_TYPE,
   _opacityValue: DEFAULT_OPACITY,
   padding: 1,
-  sortFunction: (a, b, accessor) => accessor(a) - accessor(b),
-  sizeAccessor: d => d.size,
-  colorAccessor: d => d.color,
-  labelAccessor: d => d.title
+  sortFunction: (a, b, accessor) => {
+    if (!accessor) {
+      return 0;
+    }
+    return accessor(a) - accessor(b);
+  },
+  getSize: d => d.size,
+  getColor: d => d.color,
+  getLabel: d => d.title
 };
 export default Treemap;

--- a/src/treemap/treemap-dom.js
+++ b/src/treemap/treemap-dom.js
@@ -23,7 +23,7 @@ import TreemapLeaf from './treemap-leaf';
 
 class TreemapDOM extends React.Component {
   render() {
-    const {animation, className, height, hideRootNode, mode, nodes, width, scales, style} = this.props;
+    const {animation, className, height, hideRootNode, labelAccessor, mode, nodes, width, scales, style} = this.props;
     const useCirclePacking = mode === 'circlePack';
     return (
       <div
@@ -38,6 +38,7 @@ class TreemapDOM extends React.Component {
           const nodeProps = {
             animation,
             node,
+            labelAccessor,
             ...this.props,
             x0: useCirclePacking ? node.x : node.x0,
             x1: useCirclePacking ? node.x : node.x1,

--- a/src/treemap/treemap-dom.js
+++ b/src/treemap/treemap-dom.js
@@ -23,7 +23,7 @@ import TreemapLeaf from './treemap-leaf';
 
 class TreemapDOM extends React.Component {
   render() {
-    const {animation, className, height, hideRootNode, labelAccessor, mode, nodes, width, scales, style} = this.props;
+    const {animation, className, height, hideRootNode, getLabel, mode, nodes, width, scales, style} = this.props;
     const useCirclePacking = mode === 'circlePack';
     return (
       <div
@@ -38,7 +38,7 @@ class TreemapDOM extends React.Component {
           const nodeProps = {
             animation,
             node,
-            labelAccessor,
+            getLabel,
             ...this.props,
             x0: useCirclePacking ? node.x : node.x0,
             x1: useCirclePacking ? node.x : node.x1,

--- a/src/treemap/treemap-leaf.js
+++ b/src/treemap/treemap-leaf.js
@@ -35,6 +35,7 @@ class TreemapLeaf extends React.Component {
   render() {
     const {
       animation,
+      labelAccessor,
       mode,
       node,
       onLeafClick,
@@ -60,7 +61,8 @@ class TreemapLeaf extends React.Component {
     const background = scales.color(node);
     const opacity = scales.opacity(node);
     const color = getFontColorFromBackground(background);
-    const {data: {title}} = node;
+    const {data} = node;
+    const title = labelAccessor(data);
     const leafStyle = {
       top: useCirclePacking ? (y0 - r) : y0,
       left: useCirclePacking ? (x0 - r) : x0,

--- a/src/treemap/treemap-leaf.js
+++ b/src/treemap/treemap-leaf.js
@@ -35,7 +35,7 @@ class TreemapLeaf extends React.Component {
   render() {
     const {
       animation,
-      labelAccessor,
+      getLabel,
       mode,
       node,
       onLeafClick,
@@ -62,7 +62,7 @@ class TreemapLeaf extends React.Component {
     const opacity = scales.opacity(node);
     const color = getFontColorFromBackground(background);
     const {data} = node;
-    const title = labelAccessor(data);
+    const title = getLabel(data);
     const leafStyle = {
       top: useCirclePacking ? (y0 - r) : y0,
       left: useCirclePacking ? (x0 - r) : x0,

--- a/src/treemap/treemap-svg.js
+++ b/src/treemap/treemap-svg.js
@@ -74,6 +74,7 @@ class TreemapSVG extends React.Component {
           onSeriesClick={onLeafClick}
           data={rows}
           colorType="literal"
+          colorAccessor={d => d.color}
           sizeType="literal"
           sizeAccessor={d => d.size}
           style={style}/>

--- a/src/treemap/treemap-svg.js
+++ b/src/treemap/treemap-svg.js
@@ -75,6 +75,7 @@ class TreemapSVG extends React.Component {
           data={rows}
           colorType="literal"
           sizeType="literal"
+          sizeAccessor={d => d.size}
           style={style}/>
       ),
       minY,

--- a/src/treemap/treemap-svg.js
+++ b/src/treemap/treemap-svg.js
@@ -74,9 +74,9 @@ class TreemapSVG extends React.Component {
           onSeriesClick={onLeafClick}
           data={rows}
           colorType="literal"
-          colorAccessor={d => d.color}
+          getColor={d => d.color}
           sizeType="literal"
-          sizeAccessor={d => d.size}
+          getSize={d => d.size}
           style={style}/>
       ),
       minY,

--- a/src/utils/data-utils.js
+++ b/src/utils/data-utils.js
@@ -19,22 +19,13 @@
 // THE SOFTWARE.
 
 /**
- * Get the value accessor function that gets a property from an object.
- * @param {string} propertyName Property name.
- * @returns {Function} Value accessor.
- */
-export function getObjectValueAccessor(propertyName) {
-  return obj => obj[propertyName];
-}
-
-/**
  * Get unique property values from an array.
  * @param {Array} arr Array of data.
  * @param {string} propertyName Prop name.
  * @returns {Array} Array of unique values.
  */
-export function getUniquePropertyValues(arr, propertyName) {
-  const setOfValues = new Set(arr.map(getObjectValueAccessor(propertyName)));
+export function getUniquePropertyValues(arr, accessor) {
+  const setOfValues = new Set(arr.map(accessor));
   return Array.from(setOfValues);
 }
 

--- a/src/utils/scales-utils.js
+++ b/src/utils/scales-utils.js
@@ -177,19 +177,19 @@ export function getScaleFnFromScaleObject(scaleObject) {
 /**
  * Get the domain from the array of data.
  * @param {Array} allData All data.
- * @param {string} attr Property name.
+ * @param {function} accessor - accessor for main value.
+ * @param {function} accessor0 - accessor for the naught value.
  * @param {string} type Scale type.
  * @returns {Array} Domain.
  * @private
  */
-export function getDomainByAttr(allData, attr, type) {
+export function getDomainByAccessor(allData, accessor, accessor0, type) {
   let domain;
-  const attr0 = `${attr}0`;
 
   // Collect both attr and available attr0 values from the array of data.
   const values = allData.reduce((data, d) => {
-    const value = d[attr];
-    const value0 = d[attr0];
+    const value = accessor(d);
+    const value0 = accessor0(d);
     if (_isDefined(value)) {
       data.push(value);
     }
@@ -218,10 +218,12 @@ export function getDomainByAttr(allData, attr, type) {
  * @param {string} attr Attribute.
  * @param {*} value Value.
  * @param {string} type - the type of scale being used
+ * @param {function} accessor - the accessor function
+ * @param {function} accessor0 - the accessor function for the potential naught value
  * @returns {Object} Custom scale object.
  * @private
  */
-function _createScaleObjectForValue(attr, value, type) {
+function _createScaleObjectForValue(attr, value, type, accessor, accessor0) {
   if (type === LITERAL_SCALE_TYPE) {
     return {
       type: LITERAL_SCALE_TYPE,
@@ -230,7 +232,8 @@ function _createScaleObjectForValue(attr, value, type) {
       distance: 0,
       attr,
       baseValue: undefined,
-      isValue: true
+      isValue: true,
+      accessor
     };
   }
   if (typeof value === 'undefined') {
@@ -243,22 +246,27 @@ function _createScaleObjectForValue(attr, value, type) {
     distance: 0,
     attr,
     baseValue: undefined,
-    isValue: true
+    isValue: true,
+    accessor
   };
 }
 
 /**
  * Create a regular scale object for a further use from the existing parameters.
- * @param {Array} domain Domain.
- * @param {Array} range Range.
- * @param {string} type Type.
- * @param {number} distance Distance.
- * @param {string} attr Attribute.
- * @param {number} baseValue Base value.
+ * @param {Array} domain - Domain.
+ * @param {Array} range - Range.
+ * @param {string} type - Type.
+ * @param {number} distance - Distance.
+ * @param {string} attr - Attribute.
+ * @param {number} baseValue - Base value.
+ * @param {function} accessor - Attribute accesor
+ * @param {function} accessor0 - Attribute accesor for potential naught value
  * @returns {Object} Scale object.
  * @private
  */
-function _createScaleObjectForFunction(domain, range, type, distance, attr, baseValue) {
+function _createScaleObjectForFunction({
+  domain, range, type, distance, attr, baseValue, accessor, accessor0
+}) {
   return {
     domain,
     range,
@@ -266,7 +274,9 @@ function _createScaleObjectForFunction(domain, range, type, distance, attr, base
     distance,
     attr,
     baseValue,
-    isValue: false
+    isValue: false,
+    accessor,
+    accessor0
   };
 }
 
@@ -286,15 +296,16 @@ function _collectScaleObjectFromProps(props, attr) {
     [`${attr}Distance`]: distance = 0,
     [`${attr}BaseValue`]: baseValue,
     [`${attr}Type`]: type = LINEAR_SCALE_TYPE,
-    [`${attr}NoFallBack`]: noFallBack
+    [`${attr}NoFallBack`]: noFallBack,
+    [`${attr}Accessor`]: accessor = d => d[attr],
+    [`${attr}0Accessor`]: accessor0 = d => d[`${attr}0`]
   } = props;
 
   let {[`${attr}Domain`]: domain} = props;
-
   // Return value-based scale if the value is assigned.
   if (!noFallBack && typeof value !== 'undefined') {
     return _createScaleObjectForValue(
-      attr, value, props[`${attr}Type`]);
+      attr, value, props[`${attr}Type`], accessor, accessor0);
   }
 
   // Pick up the domain from the properties and create a new one if it's not
@@ -306,17 +317,20 @@ function _collectScaleObjectFromProps(props, attr) {
   // Make sure that the minimum necessary properties exist.
   if (!range || !domain || !domain.length) {
     // Try to use the fallback value if it is available.
-    return _createScaleObjectForValue(attr, fallbackValue, props[`${attr}Type`]);
+    return _createScaleObjectForValue(
+      attr, fallbackValue, props[`${attr}Type`], accessor, accessor0);
   }
 
-  return _createScaleObjectForFunction(
+  return _createScaleObjectForFunction({
     domain,
     range,
     type,
     distance,
     attr,
-    baseValue
-  );
+    baseValue,
+    accessor,
+    accessor0
+  });
 }
 
 /**
@@ -380,9 +394,9 @@ function _computeScaleDistance(values, domain, bestDistIndex, scaleFn) {
  * @param {string} type Type.
  * @private
  */
-function _normalizeValues(data, values, attr, type) {
+function _normalizeValues(data, values, accessor0, type) {
   if (type === TIME_SCALE_TYPE && values.length === 1) {
-    const attr0 = data[0][`${attr}0`];
+    const attr0 = accessor0(data[0]);
 
     return [attr0, ...values];
   }
@@ -398,13 +412,12 @@ function _normalizeValues(data, values, attr, type) {
  * @private
  */
 export function _getScaleDistanceAndAdjustedDomain(data, scaleObject) {
-  const {attr, domain, type} = scaleObject;
+  const {domain, type, accessor, accessor0} = scaleObject;
 
-  const uniqueValues = getUniquePropertyValues(data, attr);
+  const uniqueValues = getUniquePropertyValues(data, accessor);
 
   // Fix time scale if a data has only one value.
-  const values = _normalizeValues(data, uniqueValues, attr, type);
-
+  const values = _normalizeValues(data, uniqueValues, accessor0, type);
   const index = _getSmallestDistanceIndex(values, scaleObject);
 
   const adjustedDomain = [].concat(domain);
@@ -526,7 +539,6 @@ export function _adjustCategoricalScale(scaleObject) {
 export function getScaleObjectFromProps(props, attr) {
   // Create the initial scale object.
   const scaleObject = _collectScaleObjectFromProps(props, attr);
-
   if (!scaleObject) {
     return null;
   }
@@ -560,13 +572,13 @@ export function getAttributeScale(props, attr) {
 
 /**
  * Get the value of `attr` from the object.
- * @param {Object} d Object.
- * @param {string} attr Attribute.
+ * @param {Object} d - data Object.
+ * @param {Function} accessor - accessor function.
  * @returns {*} Value of the point.
  * @private
  */
-function _getAttrValue(d, attr) {
-  return d.data ? d.data[attr] : d[attr];
+function _getAttrValue(d, accessor) {
+  return accessor(d.data ? d.data : d);
 }
 
 function _isDefined(value) {
@@ -594,14 +606,14 @@ function _padDomain(domain, padding) {
 /**
  * Get prop functor (either a value or a function) for a given attribute.
  * @param {Object} props Series props.
- * @param {string} attr Property name.
+ * @param {Function} accessor - Property accessor.
  * @returns {*} Function or value.
  */
 export function getAttributeFunctor(props, attr) {
   const scaleObject = getScaleObjectFromProps(props, attr);
   if (scaleObject) {
     const scaleFn = getScaleFnFromScaleObject(scaleObject);
-    return d => scaleFn(_getAttrValue(d, attr));
+    return d => scaleFn(_getAttrValue(d, scaleObject.accessor));
   }
   return null;
 }
@@ -622,7 +634,7 @@ export function getAttr0Functor(props, attr) {
     const {baseValue = domain[0]} = scaleObject;
     const scaleFn = getScaleFnFromScaleObject(scaleObject);
     return d => {
-      const value = _getAttrValue(d, attr0);
+      const value = _getAttrValue(d, el => el[attr0]);
       return scaleFn(_isDefined(value) ? value : baseValue);
     };
   }
@@ -658,6 +670,8 @@ export function getScalePropTypesByAttribute(attr) {
   return {
     [`_${attr}Value`]: PropTypes.any,
     [`${attr}Domain`]: PropTypes.array,
+    [`${attr}Accessor`]: PropTypes.func,
+    [`${attr}0Accessor`]: PropTypes.func,
     [`${attr}Range`]: PropTypes.array,
     [`${attr}Type`]: PropTypes.oneOf(
       Object.keys(SCALE_FUNCTIONS)
@@ -700,10 +714,17 @@ export function getMissingScaleProps(props, data, attributes) {
   const result = {};
   // Make sure that the domain is set pad it if specified
   attributes.forEach(attr => {
+    if (!props[`${attr}Accessor`]) {
+      result[`${attr}Accessor`] = d => d[attr];
+    }
+    if (!props[`${attr}0Accessor`]) {
+      result[`${attr}0Accessor`] = d => d[`${attr}0`];
+    }
     if (!props[`${attr}Domain`]) {
-      result[`${attr}Domain`] = getDomainByAttr(
+      result[`${attr}Domain`] = getDomainByAccessor(
         data,
-        attr,
+        props[`${attr}Accessor`] || result[`${attr}Accessor`],
+        props[`${attr}0Accessor`] || result[`${attr}0Accessor`],
         props[`${attr}Type`]
       );
       if (props[`${attr}Padding`]) {
@@ -811,7 +832,7 @@ export default {
   getAttributeFunctor,
   getAttr0Functor,
   getAttributeValue,
-  getDomainByAttr,
+  getDomainByAccessor,
   getFontColorFromBackground,
   getMissingScaleProps,
   getOptionalScaleProps,

--- a/tests/components/line-series-tests.js
+++ b/tests/components/line-series-tests.js
@@ -8,6 +8,8 @@ import LineChart from '../../showcase/plot/line-chart';
 import LineMarkSeries from '../../showcase/plot/linemark-chart';
 import LineChartManyColors from '../../showcase/color/line-chart-many-colors';
 import NullData from '../../showcase/misc/null-data-example';
+import TimeChart from '../../showcase/misc/time-chart';
+import SyncedCharts from '../../showcase/misc/synced-charts';
 
 testRenderWithProps(LineSeries, GENERIC_XYPLOT_SERIES_PROPS);
 
@@ -81,6 +83,27 @@ test('LineSeries: Showcase Example - LineChartManyColors', t => {
     LINE_WITH_MANY_COLORS_COLORS[i],
     `${i}th line series gets the right color`)
   );
+  t.end();
+});
+
+test('LineSeries: Showcase Example - TimeChart', t => {
+  const $ = mount(<TimeChart />);
+  t.equal($.find('.rv-xy-plot__series--line').length, 2, 'should find the right number of lines');
+  t.equal($.text(), 'Sep 1012 PMMon 1112 PMTue 1212 PMX Axis2468101214Y Axis', 'should find the right number of lines');
+  t.end();
+});
+
+test('LineSeries: Showcase Example - SyncedCharts', t => {
+  const $ = mount(<SyncedCharts />);
+  const tests = () => {
+    t.equal($.find('.rv-xy-plot').length, 2, 'should find the right number of lines');
+    t.equal($.find('.rv-xy-plot__series--line').length, 4, 'should find the right number of lines');
+    t.equal($.text(), '1.01.52.02.53.024681012141.01.52.02.53.0246810', 'should find the right number of lines');
+  };
+  tests();
+  $.find('.rv-xy-plot__series--line').at(0).simulate('mouseEnter');
+  tests();
+  $.find('.rv-xy-plot').at(0).simulate('mouseLeave');
   t.end();
 });
 

--- a/tests/components/line-series-tests.js
+++ b/tests/components/line-series-tests.js
@@ -89,7 +89,7 @@ test('LineSeries: Showcase Example - LineChartManyColors', t => {
 test('LineSeries: Showcase Example - TimeChart', t => {
   const $ = mount(<TimeChart />);
   t.equal($.find('.rv-xy-plot__series--line').length, 2, 'should find the right number of lines');
-  t.equal($.text(), 'Sep 1012 PMMon 1112 PMTue 1212 PMX Axis2468101214Y Axis', 'should find the right number of lines');
+  t.equal($.text(), 'Sep 1012 PMMon 1112 PMTue 1212 PMWed 13X Axis2468101214Y Axis', 'should find the right number of lines');
   t.end();
 });
 

--- a/tests/components/radial-tests.js
+++ b/tests/components/radial-tests.js
@@ -55,7 +55,7 @@ test('RadialChart: Showcase Example - DonutChart', t => {
   t.equal($.find('.rv-xy-plot__series--label-text').length, 0, 'should find no label wrappers, as labels is turned off');
   t.equal($.text(), '', 'should find no text');
   $.find('.rv-radial-chart__series--pie__slice').at(1).simulate('mouseOver');
-  t.equal($.text(), 'angle: -4.263590029871862angle0: -2.9171931783333793radius0: 0radius: 1color: 1x: -0.4338837391175583y: 0.900968867902419', 'should find appropriate hover text');
+  t.equal($.text(), 'theta: 3angle0: -2.9171931783333793angle: -4.263590029871862radius0: 0radius: 1color: 1x: -0.4338837391175583y: 0.900968867902419', 'should find appropriate hover text');
   t.end();
 });
 

--- a/tests/utils/data-utils-tests.js
+++ b/tests/utils/data-utils-tests.js
@@ -19,24 +19,16 @@
 // THE SOFTWARE.
 
 import test from 'tape';
-import equal from 'deep-equal';
 
 import {
-  getObjectValueAccessor,
   getUniquePropertyValues,
   addValueToArray
 } from 'utils/data-utils';
 
 const arr = [{a: 1}, {b: 3, a: 2}, {a: 2}];
 
-test('data-utils #getObjectValueAccessor', t => {
-  const result = getObjectValueAccessor('a');
-  t.ok(result({a: 1, b: 2}) === 1, 'Should return value of the property');
-  t.end();
-});
-
 test('data-utils #getUniquePropertyValues', t => {
-  const result = getUniquePropertyValues(arr, 'a');
+  const result = getUniquePropertyValues(arr, d => d.a);
   t.ok(result.length === 2, 'Should return the array of the proper size');
   t.ok(
     result.indexOf(1) !== -1 && result.indexOf(2) !== -1,
@@ -45,14 +37,11 @@ test('data-utils #getUniquePropertyValues', t => {
 });
 
 test('data-utils #addValueToArray', t => {
-  t.ok(
-    equal(addValueToArray([-10, 10], 1), [-10, 10]),
+  t.deepEqual(addValueToArray([-10, 10], 1), [-10, 10],
     'Shouldn\'t add the value if the value is in the array');
-  t.ok(
-    equal(addValueToArray([-10, 0], 1), [-10, 1]),
+  t.deepEqual(addValueToArray([-10, 0], 1), [-10, 1],
     'Should add the value if the value is larger');
-  t.ok(
-    equal(addValueToArray([0, 10], -1), [-1, 10]),
+  t.deepEqual(addValueToArray([0, 10], -1), [-1, 10],
     'Should add the value if the value is smaller');
   t.end();
 });

--- a/tests/utils/scales-utils-tests.js
+++ b/tests/utils/scales-utils-tests.js
@@ -90,8 +90,8 @@ test('scales-utils #getScalePropTypesByAttribute', t => {
   const expectedResult = [
     '_sizeValue',
     'sizeDomain',
-    'sizeAccessor',
-    'size0Accessor',
+    'getSize',
+    'getSize0',
     'sizeRange',
     'sizeType',
     'sizeDistance',
@@ -266,7 +266,7 @@ test('scales-utils #getMissingScaleProps', t => {
       xPadding: fakePadding,
       xDomain: fakeDomain
     }, fakeDataInteger, ['x'])),
-    ['xAccessor', 'x0Accessor'],
+    ['getX', 'getX0'],
     'should not pad if xDomain is already supplied, but accessors should be present'
   );
   t.deepEqual(

--- a/tests/utils/scales-utils-tests.js
+++ b/tests/utils/scales-utils-tests.js
@@ -87,7 +87,16 @@ test('scales-utils #getScaleObjectFromProps ', t => {
 
 test('scales-utils #getScalePropTypesByAttribute', t => {
   const result = Object.keys(getScalePropTypesByAttribute('size'));
-  const expectedResult = ['_sizeValue', 'sizeDomain', 'sizeRange', 'sizeType', 'sizeDistance', 'sizeBaseValue'];
+  const expectedResult = [
+    '_sizeValue',
+    'sizeDomain',
+    'sizeAccessor',
+    'size0Accessor',
+    'sizeRange',
+    'sizeType',
+    'sizeDistance',
+    'sizeBaseValue'
+  ];
   t.deepEqual(result, expectedResult, 'should find the correct scale prop attributes');
   t.end();
 });
@@ -229,7 +238,7 @@ test('scales-utils #getMissingScaleProps', t => {
   const paddedDayTen = (dayTen + ((dayTen - dayOne) * 0.1));
   const fakePadding = 10;
 
-  t.ok(Object.keys(getMissingScaleProps({}, [], [])).length === 0,
+  t.equal(Object.keys(getMissingScaleProps({}, [], [])).length, 0,
     'Should return empty result on empty arguments');
   const result = getMissingScaleProps({}, _allData[0], ['x']);
   t.ok(Boolean(result.xDomain) && result.xDomain.length === 2 &&
@@ -243,13 +252,22 @@ test('scales-utils #getMissingScaleProps', t => {
     fakeDataIntegerDomain,
     'should pad number xDomain'
   );
+  // need to use json stringify to peel off the functions
   t.deepEqual(
-    getMissingScaleProps({
+    JSON.stringify(getMissingScaleProps({
       xPadding: fakePadding,
       xDomain: fakeDomain
-    }, fakeDataInteger, ['x']),
-    {},
+    }, fakeDataInteger, ['x'])),
+    '{}',
     'should not pad if xDomain is already supplied'
+  );
+  t.deepEqual(
+    Object.keys(getMissingScaleProps({
+      xPadding: fakePadding,
+      xDomain: fakeDomain
+    }, fakeDataInteger, ['x'])),
+    ['xAccessor', 'x0Accessor'],
+    'should not pad if xDomain is already supplied, but accessors should be present'
   );
   t.deepEqual(
     getMissingScaleProps({
@@ -326,7 +344,7 @@ test('scales-utils #getScaleFnFromScaleObject', t => {
 });
 
 function generateFakeData() {
-  return new Array(100).fill(0).map((zero, i) => ({x: i}));
+  return new Array(100).fill(0).map((zero, i) => ({xxxx: i}));
 }
 
 test('scales-utils #_getScaleDistanceAndAdjustedDomain', t => {
@@ -335,11 +353,13 @@ test('scales-utils #_getScaleDistanceAndAdjustedDomain', t => {
     attr: 'x',
     domain: [0, 100],
     range: [0, 1],
-    type: 'linear'
+    type: 'linear',
+    // the extra x's are here to test the accessor behaviour
+    accessor: d => d.xxxx
   };
   const resultObject = _getScaleDistanceAndAdjustedDomain(FAKE_DATA, scaleObject);
   const expectedResults = {distance: 0.009900990099009799, domain0: -0.5, domainN: 100.5};
-  t.deepEqual(resultObject, expectedResults, 'should fine reasonable results');
+  t.deepEqual(resultObject, expectedResults, 'should find reasonable results');
 
   const FAKE_TIME_DATA_WITH_ONE_VALUE_AND_X0 = [{
     x: 1422774000000,
@@ -357,7 +377,9 @@ test('scales-utils #_getScaleDistanceAndAdjustedDomain', t => {
     attr: 'x',
     domain: [1417546800000, 1430420400000],
     range: [0, 550],
-    type: 'time'
+    type: 'time',
+    accessor: d => d.x,
+    accessor0: d => d.x0
   };
   const timeResultWithOneValueAndX0 = _getScaleDistanceAndAdjustedDomain(
     FAKE_TIME_DATA_WITH_ONE_VALUE_AND_X0,
@@ -371,14 +393,16 @@ test('scales-utils #_getScaleDistanceAndAdjustedDomain', t => {
   t.deepEqual(
     timeResultWithOneValueAndX0,
     expectedTimeResultsWithOneValueAndX0,
-    'should fine reasonable results'
+    'should fine reasonable results for time _getScaleDistanceAndAdjustedDomain'
   );
 
   const timeScaleObjectY = {
     attr: 'y',
     domain: [1417546800000, 1430420400000],
     range: [0, 550],
-    type: 'time'
+    type: 'time',
+    accessor: d => d.y,
+    accessor0: d => d.y0
   };
   const timeResultWithOneValueAndY0 = _getScaleDistanceAndAdjustedDomain(
     FAKE_TIME_DATA_WITH_ONE_VALUE_AND_Y0,
@@ -392,26 +416,30 @@ test('scales-utils #_getScaleDistanceAndAdjustedDomain', t => {
   t.deepEqual(
     timeResultWithOneValueAndY0,
     expectedTimeResultsWithOneValueAndY0,
-    'should fine reasonable results'
+    'should find reasonable results for y time _getScaleDistanceAndAdjustedDomain'
   );
 
-  const timeResult = _getScaleDistanceAndAdjustedDomain(FAKE_DATA, timeScaleObjectX);
+  const timeResult = _getScaleDistanceAndAdjustedDomain(FAKE_DATA, {
+    ...timeScaleObjectX,
+    accessor: d => d.xxxx
+  });
   const expectedTimeResults = {
     distance: 4.272442311048508e-8,
     domain0: 1417546799999.5,
     domainN: 1430420400000.5
   };
-  t.deepEqual(timeResult, expectedTimeResults, 'should fine reasonable results');
+  t.deepEqual(timeResult, expectedTimeResults, 'should fine reasonable results for a time scale');
 
   const logScaleObject = {
     attr: 'x',
     domain: [-0.5, 1],
     range: [1, 10],
-    type: 'log'
+    type: 'log',
+    accessor: d => d.xxxx
   };
   const logResult = _getScaleDistanceAndAdjustedDomain(FAKE_DATA, logScaleObject);
   const expectedLogResults = {distance: Infinity, domain0: 0.1, domainN: 1.5};
-  t.deepEqual(logResult, expectedLogResults, 'should fine reasonable results');
+  t.deepEqual(logResult, expectedLogResults, 'should fine reasonable results for a log scale');
 
   t.end();
 });


### PR DESCRIPTION
This sprawling PR adds support for accessors throughout the library, thus addressing #360. It modifies the way that scales are built, by replacing a default notion of attr with a comprable notation of accessor, while adding default accessors that emulate the original behaviour. (Hopefully) This change is non-breaking, in that all old charts should still work, with the new accessor functionality enabled. 

Note: one of the original goals of adding accessors was to enable immutable manipulations, and while were close, there is probably one or two more PRS worth of clean up around the library that needs to be done first. (i'm looking at you, several for loops still left in the library)

There still needs some documentation, but should be ready to review.

