### PR TITLE
Use window.devicePixelRatio to sharpen canvas images

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Any changes you make to the example code will run the compiler to build the file
 
 To lint your code, run the tests, and create code coverage reports:
 
-    npm test
+    npm run full-test
 
 ## Requirements
 

--- a/src/plot/series/canvas-wrapper.js
+++ b/src/plot/series/canvas-wrapper.js
@@ -105,6 +105,12 @@ function buildLayers(newChildren, oldChildren) {
 }
 class CanvasWrapper extends Component {
 
+  static get defaultProps() {
+    return {
+      pixelRatio: window && window.devicePixelRatio || 1,
+    };
+  }
+
   componentDidMount() {
     const ctx = this.refs.canvas.getContext('2d');
     const {pixelRatio} = this.props;

--- a/src/plot/series/canvas-wrapper.js
+++ b/src/plot/series/canvas-wrapper.js
@@ -107,7 +107,7 @@ class CanvasWrapper extends Component {
 
   static get defaultProps() {
     return {
-      pixelRatio: window && window.devicePixelRatio || 1,
+      pixelRatio: window && window.devicePixelRatio || 1
     };
   }
 

--- a/src/plot/series/canvas-wrapper.js
+++ b/src/plot/series/canvas-wrapper.js
@@ -107,7 +107,7 @@ class CanvasWrapper extends Component {
 
   componentDidMount() {
     const ctx = this.refs.canvas.getContext('2d');
-    const { pixelRatio } = this.props;
+    const {pixelRatio} = this.props;
     ctx.scale(pixelRatio, pixelRatio);
 
     this.drawChildren(this.props, null, ctx);
@@ -154,12 +154,12 @@ class CanvasWrapper extends Component {
 
   render() {
     const {
+      innerHeight,
+      innerWidth,
       marginBottom,
       marginLeft,
       marginRight,
       marginTop,
-      innerHeight,
-      innerWidth,
       pixelRatio
     } = this.props;
 

--- a/src/plot/series/canvas-wrapper.js
+++ b/src/plot/series/canvas-wrapper.js
@@ -104,8 +104,13 @@ function buildLayers(newChildren, oldChildren) {
   });
 }
 class CanvasWrapper extends Component {
+
   componentDidMount() {
-    this.drawChildren(this.props, null, this.refs.canvas.getContext('2d'));
+    const ctx = this.refs.canvas.getContext('2d');
+    const { pixelRatio } = this.props;
+    ctx.scale(pixelRatio, pixelRatio);
+
+    this.drawChildren(this.props, null, ctx);
   }
 
   componentDidUpdate(nextProps) {
@@ -154,15 +159,23 @@ class CanvasWrapper extends Component {
       marginRight,
       marginTop,
       innerHeight,
-      innerWidth
+      innerWidth,
+      pixelRatio
     } = this.props;
+
+    const height = innerHeight + marginTop + marginBottom;
+    const width = innerWidth + marginLeft + marginRight;
 
     return (
       <div style={{left: 0, top: 0}} className="rv-xy-canvas">
         <canvas
           className="rv-xy-canvas-element"
-          height={innerHeight + marginTop + marginBottom}
-          width={innerWidth + marginLeft + marginRight}
+          height={height * pixelRatio}
+          width={width * pixelRatio}
+          style={{
+            height: `${height}px`,
+            width: `${width}px`
+          }}
           ref="canvas" />
       </div>
     );
@@ -176,7 +189,8 @@ CanvasWrapper.propTypes = {
   marginRight: PropTypes.number.isRequired,
   marginTop: PropTypes.number.isRequired,
   innerHeight: PropTypes.number.isRequired,
-  innerWidth: PropTypes.number.isRequired
+  innerWidth: PropTypes.number.isRequired,
+  pixelRatio: PropTypes.number.isRequired
 };
 
 export default CanvasWrapper;

--- a/src/plot/xy-plot.js
+++ b/src/plot/xy-plot.js
@@ -413,7 +413,8 @@ class XYPlot extends React.Component {
       marginBottom,
       marginRight,
       innerHeight,
-      innerWidth
+      innerWidth,
+      pixelRatio: window.devicePixelRatio
     }}>
       {componentsToRender}
     </CanvasWrapper>);

--- a/src/plot/xy-plot.js
+++ b/src/plot/xy-plot.js
@@ -56,6 +56,8 @@ const DEFAULT_MARGINS = {
   bottom: 40
 };
 
+const DEFAULT_PIXEL_RATIO = window && window.devicePixelRatio || 1;
+
 /**
  * Remove parents from tree formatted data. deep-equal doesnt play nice with data
  * that has circular structures, so we make every node single directional by pruning the parents.
@@ -408,13 +410,13 @@ class XYPlot extends React.Component {
       innerWidth
     } = componentsToRender[0].props;
     return (<CanvasWrapper {...{
+      innerHeight,
+      innerWidth,
       marginLeft,
       marginTop,
       marginBottom,
       marginRight,
-      innerHeight,
-      innerWidth,
-      pixelRatio: window.devicePixelRatio
+      pixelRatio: DEFAULT_PIXEL_RATIO
     }}>
       {componentsToRender}
     </CanvasWrapper>);

--- a/src/plot/xy-plot.js
+++ b/src/plot/xy-plot.js
@@ -56,8 +56,6 @@ const DEFAULT_MARGINS = {
   bottom: 40
 };
 
-const DEFAULT_PIXEL_RATIO = window && window.devicePixelRatio || 1;
-
 /**
  * Remove parents from tree formatted data. deep-equal doesnt play nice with data
  * that has circular structures, so we make every node single directional by pruning the parents.
@@ -415,8 +413,7 @@ class XYPlot extends React.Component {
       marginLeft,
       marginTop,
       marginBottom,
-      marginRight,
-      pixelRatio: DEFAULT_PIXEL_RATIO
+      marginRight
     }}>
       {componentsToRender}
     </CanvasWrapper>);


### PR DESCRIPTION
Using `devicePixelRatio` allows us to improve the visual quality of canvas renderings by accounting for the ratio between physical and virtual pixels. Most notably, canvas charts will look much better on Apple's Retina Displays.

**Before**
<img width="343" alt="screen shot 2017-09-11 at 3 00 58 pm" src="https://user-images.githubusercontent.com/458421/30295219-730e18b8-9705-11e7-9305-067192d22b76.png">

**After**
<img width="331" alt="screen shot 2017-09-11 at 3 00 51 pm" src="https://user-images.githubusercontent.com/458421/30295220-73126a6c-9705-11e7-8d06-605a5019dfaf.png">
