### PR TITLE
Fix treemap sorting 

### DIFF
--- a/docs/treemap.md
+++ b/docs/treemap.md
@@ -144,6 +144,12 @@ Type: `string`
 
 This modifies the tiling strategy for the treemap, for more information see the [d3 hierarchy docs](https://github.com/d3/d3-hierarchy).
 
+#### sortFuncion (optional)
+Type: `function`
+- Should accept arguments (a, b)
+
+Pass in a function that will be used to sort the nodes, for more information see the [d3 hierarchy docs on sorting](https://github.com/d3/d3-hierarchy#node_sort).
+
 ##### colorDomain, colorRange, colorType
 
 Scale properties for the `color` scale. If `color` property is not passed in the data object, each new section of the chart gets the next color (e. g. the `'category'` scale is applied).

--- a/src/treemap/index.js
+++ b/src/treemap/index.js
@@ -141,8 +141,8 @@ class Treemap extends React.Component {
           .size([innerWidth, innerHeight])
           .padding(padding);
       const structuredInput = hierarchy(data)
-        .sort((a, b) => a.size - b.size)
-        .sum(d => d.size);
+        .sum(d => d.size)
+        .sort((a, b) => a.value - b.value);
       return packingFunction(structuredInput).descendants();
     }
 
@@ -152,8 +152,8 @@ class Treemap extends React.Component {
       .size([innerWidth, innerHeight])
       .padding(padding);
     const structuredInput = hierarchy(data)
-      .sort((a, b) => a.size - b.size)
-      .sum(d => d.size);
+      .sum(d => d.size)
+      .sort((a, b) => b.value - a.value);
 
     return treemapingFunction(structuredInput).descendants();
 

--- a/src/treemap/index.js
+++ b/src/treemap/index.js
@@ -113,7 +113,7 @@ class Treemap extends React.Component {
    */
   _getNodesToRender() {
     const {innerWidth, innerHeight} = this.state;
-    const {data, mode, padding} = this.props;
+    const {data, mode, padding, sortFunction} = this.props;
     if (!data) {
       return [];
     }
@@ -142,7 +142,7 @@ class Treemap extends React.Component {
           .padding(padding);
       const structuredInput = hierarchy(data)
         .sum(d => d.size)
-        .sort((a, b) => b.value - a.value);
+        .sort(sortFunction);
       return packingFunction(structuredInput).descendants();
     }
 
@@ -153,8 +153,7 @@ class Treemap extends React.Component {
       .padding(padding);
     const structuredInput = hierarchy(data)
       .sum(d => d.size)
-      .sort((a, b) => b.height - a.height || b.value - a.value);
-
+      .sort(sortFunction);
     return treemapingFunction(structuredInput).descendants();
 
   }
@@ -184,6 +183,7 @@ Treemap.propTypes = {
   onLeafMouseOut: PropTypes.func,
   useCirclePacking: PropTypes.bool,
   padding: PropTypes.number.isRequired,
+  sortFunction: PropTypes.func,
   width: PropTypes.number.isRequired
 };
 
@@ -206,6 +206,7 @@ Treemap.defaultProps = {
   onLeafMouseOut: NOOP,
   opacityType: OPACITY_TYPE,
   _opacityValue: DEFAULT_OPACITY,
-  padding: 1
+  padding: 1,
+  sortFunction: (a, b) => a.size - b.size
 };
 export default Treemap;

--- a/src/treemap/index.js
+++ b/src/treemap/index.js
@@ -153,7 +153,7 @@ class Treemap extends React.Component {
       .padding(padding);
     const structuredInput = hierarchy(data)
       .sum(d => d.size)
-      .sort((a, b) => b.value - a.value);
+      .sort((a, b) => b.height - a.height || b.value - a.value);
 
     return treemapingFunction(structuredInput).descendants();
 

--- a/src/treemap/index.js
+++ b/src/treemap/index.js
@@ -142,7 +142,7 @@ class Treemap extends React.Component {
           .padding(padding);
       const structuredInput = hierarchy(data)
         .sum(d => d.size)
-        .sort((a, b) => a.value - b.value);
+        .sort((a, b) => b.value - a.value);
       return packingFunction(structuredInput).descendants();
     }
 

--- a/tests/components/treemap-tests.js
+++ b/tests/components/treemap-tests.js
@@ -64,6 +64,19 @@ test('Treemap: Basic rendering', t => {
   t.end();
 });
 
+test('Treemap: Custom Sorting', t => {
+  const $ = mount(<Treemap {...TREEMAP_PROPS}/>);
+  $.setProps({sortFunction: (a, b) => (b.height - a.height) || (b.value - a.value)});
+  const expectedText = 'interpolateTransitionerEasingTransitionNeonateFunctionSequenceSchedulerSequenceParallelTransitionEventISchedulablePauseInterpolatorMatrixInterpolatorColorInterpolatorRectangleInterpolatorArrayInterpolatorPointInterpolatorObjectInterpolatorNumberInterpolatorDateInterpolator';
+  t.equal($.find('.rv-treemap').text(), expectedText, 'should find the correct text shown');
+
+  $.setProps({data: INTERPOLATE_DATA});
+  const newText = 'InterpolatorMatrixInterpolatorColorInterpolatorRectangleInterpolatorArrayInterpolatorPointInterpolatorObjectInterpolatorNumberInterpolatorDateInterpolator';
+  t.equal($.find('.rv-treemap').text(), newText, 'should find the correct text shown');
+
+  t.end();
+});
+
 test('Treemap: Empty treemap', t => {
   const $ = mount(<Treemap {...{...TREEMAP_PROPS, data: {}}}/>);
   t.equal($.find('.rv-treemap__leaf').length, 0, 'should find the right number of children');

--- a/tests/components/treemap-tests.js
+++ b/tests/components/treemap-tests.js
@@ -46,30 +46,19 @@ const TREEMAP_PROPS = {
   }
 };
 
-function size(node) {
-  return !node.children ? node.size : node.children.reduce((sum, child) => sum + size(child), node.size || 0);
-}
-
-function toString(children) {
-  const childStrings = children.sort((a, b) => size(b) - size(a)).map(child => {
-    return {title: child.title, childrenText: child.children && toString(child.children)};
-  });
-  return `${childStrings.map(child => child.title).join('')}${childStrings.map(child => child.childrenText || '').join('')}`;
-}
-
 // make sure that the components render at all
 testRenderWithProps(Treemap, TREEMAP_PROPS);
 
 test('Treemap: Basic rendering', t => {
   const $ = mount(<Treemap {...TREEMAP_PROPS}/>);
   t.equal($.find('.rv-treemap__leaf').length, 21, 'should find the right number of children');
-  const expectedText = toString(TREEMAP_PROPS.data.children, 0);
+  const expectedText = 'EasingNeonateinterpolateISchedulableParallelPauseFunctionSequenceSequenceTransitionTransitionerTransitionEventSchedulerArrayInterpolatorColorInterpolatorDateInterpolatorInterpolatorMatrixInterpolatorNumberInterpolatorObjectInterpolatorPointInterpolatorRectangleInterpolator';
   t.equal($.find('.rv-treemap').text(), expectedText, 'should find the correct text shown');
   t.equal($.find('.little-nested-tree-example').length, 1, 'should find the custom class name used');
 
   $.setProps({data: INTERPOLATE_DATA});
   t.equal($.find('.rv-treemap__leaf').length, 9, 'should find the right number of children');
-  const newText = toString(INTERPOLATE_DATA.children, 0);
+  const newText = 'ArrayInterpolatorColorInterpolatorDateInterpolatorInterpolatorMatrixInterpolatorNumberInterpolatorObjectInterpolatorPointInterpolatorRectangleInterpolator';
   t.equal($.find('.rv-treemap').text(), newText, 'should find the correct text shown');
   t.equal($.find('.little-nested-tree-example').length, 1, 'should find the custom class name used');
   t.end();

--- a/tests/components/treemap-tests.js
+++ b/tests/components/treemap-tests.js
@@ -46,19 +46,30 @@ const TREEMAP_PROPS = {
   }
 };
 
+function size(node) {
+  return !node.children ? node.size : node.children.reduce((sum, child) => sum + size(child), node.size || 0);
+}
+
+function toString(children) {
+  const childStrings = children.sort((a, b) => size(b) - size(a)).map(child => {
+    return {title: child.title, childrenText: child.children && toString(child.children)};
+  });
+  return `${childStrings.map(child => child.title).join('')}${childStrings.map(child => child.childrenText || '').join('')}`;
+}
+
 // make sure that the components render at all
 testRenderWithProps(Treemap, TREEMAP_PROPS);
 
 test('Treemap: Basic rendering', t => {
   const $ = mount(<Treemap {...TREEMAP_PROPS}/>);
   t.equal($.find('.rv-treemap__leaf').length, 21, 'should find the right number of children');
-  const expectedText = 'EasingNeonateinterpolateISchedulableParallelPauseFunctionSequenceSequenceTransitionTransitionerTransitionEventSchedulerArrayInterpolatorColorInterpolatorDateInterpolatorInterpolatorMatrixInterpolatorNumberInterpolatorObjectInterpolatorPointInterpolatorRectangleInterpolator';
+  const expectedText = toString(TREEMAP_PROPS.data.children, 0);
   t.equal($.find('.rv-treemap').text(), expectedText, 'should find the correct text shown');
   t.equal($.find('.little-nested-tree-example').length, 1, 'should find the custom class name used');
 
   $.setProps({data: INTERPOLATE_DATA});
   t.equal($.find('.rv-treemap__leaf').length, 9, 'should find the right number of children');
-  const newText = 'ArrayInterpolatorColorInterpolatorDateInterpolatorInterpolatorMatrixInterpolatorNumberInterpolatorObjectInterpolatorPointInterpolatorRectangleInterpolator';
+  const newText = toString(INTERPOLATE_DATA.children, 0);
   t.equal($.find('.rv-treemap').text(), newText, 'should find the correct text shown');
   t.equal($.find('.little-nested-tree-example').length, 1, 'should find the custom class name used');
   t.end();


### PR DESCRIPTION
The node size property does not exist  when sorting is performed in the current code.  From the [d3-hierarchy docs](https://github.com/d3/d3-hierarchy#node_sum) sum should be called first to set the value property.  Then sort can be called to sort the node on value.

I also used the reccomended sort functions from that doc. We may want to move sortFunction to a prop allowing a user to override these.


Adjusting the sorts, created treemaps that are more organized, flowing from largest to smallest

Now
![image](https://user-images.githubusercontent.com/1678756/30435141-0441bf6e-9937-11e7-810b-71e222f355cd.png)


vs
Before

![image](https://user-images.githubusercontent.com/1678756/30435127-fa695a60-9936-11e7-95fb-eab8a37f220e.png)


