### PR TITLE
Allow user to alter the input field class name on the Searchable Legend

### DIFF
--- a/docs/legends.md
+++ b/docs/legends.md
@@ -75,6 +75,11 @@ Outer height of the component. Default is not set, the component stretches with 
 
 Its API includes the API of `DiscreteColorLegend`, but adds several search-related items:
 
+#### inputClassName (optional)
+Type: `string`
+Default: `'rv-search-wrapper__form__input'`
+Override this to use a custom class name on the input field.  Or set to null for no class name.
+
 #### searchText (optional)
 Type: `string`
 Default: `''`

--- a/showcase/legends/searchable-discrete-color.js
+++ b/showcase/legends/searchable-discrete-color.js
@@ -22,6 +22,8 @@ import React from 'react';
 
 import SearchableDiscreteColorLegend from 'legends/searchable-discrete-color-legend';
 
+import ShowcaseButton from '../showcase-components/showcase-button';
+
 export default class Example extends React.Component {
 
   constructor(props) {
@@ -36,7 +38,8 @@ export default class Example extends React.Component {
         {title: 'Limes', color: '#cf3'},
         {title: 'Potatoes', color: '#766'}
       ],
-      searchText: ''
+      searchText: '',
+      useDefaultInputClass: true
     };
     this._clickHandler = this._clickHandler.bind(this);
     this._searchChangeHandler = this._searchChangeHandler.bind(this);
@@ -45,7 +48,9 @@ export default class Example extends React.Component {
   _clickHandler(item) {
     const {items} = this.state;
     item.disabled = !item.disabled;
-    this.setState({items});
+    this.setState({
+      items
+    });
   }
 
   _searchChangeHandler(searchText) {
@@ -53,16 +58,25 @@ export default class Example extends React.Component {
   }
 
   render() {
-    const {items, searchText} = this.state;
+    const {items, searchText, useDefaultInputClass} = this.state;
+    const content = useDefaultInputClass ? 'REMOVE DEFAULT INPUT CLASS' : 'USE DEFAULT INPUT CLASS';
     return (
-      <SearchableDiscreteColorLegend
-        height={200}
-        width={300}
-        onSearchChange={this._searchChangeHandler}
-        searchText={searchText}
-        onItemClick={this._clickHandler}
-        items={items}
-      />
+      <div>
+        <ShowcaseButton
+          onClick={() => this.setState({
+            useDefaultInputClass: !useDefaultInputClass
+          })}
+          buttonContent={content}/>
+        <SearchableDiscreteColorLegend
+          height={200}
+          width={300}
+          onSearchChange={this._searchChangeHandler}
+          searchText={searchText}
+          onItemClick={this._clickHandler}
+          items={items}
+          {... !useDefaultInputClass && {inputClassName: null} }
+        />
+      </div>
     );
   }
 }

--- a/src/legends/searchable-discrete-color-legend.js
+++ b/src/legends/searchable-discrete-color-legend.js
@@ -26,6 +26,7 @@ import DiscreteColorLegend from 'legends/discrete-color-legend';
 
 const propTypes = {
   ...DiscreteColorLegend.propTypes,
+  inputClassName: PropTypes.string,
   searchText: PropTypes.string,
   onSearchChange: PropTypes.func,
   searchPlaceholder: PropTypes.string,
@@ -34,6 +35,7 @@ const propTypes = {
 
 const defaultProps = {
   className: '',
+  inputClassName: 'rv-search-wrapper__form__input',
   searchText: '',
   searchFn: (items, s) => items.filter(
     item => String(item.title || item).toLowerCase().indexOf(s) !== -1
@@ -45,6 +47,7 @@ function SearchableDiscreteColorLegend(props) {
     className,
     colors,
     height,
+    inputClassName,
     items,
     onItemClick,
     onSearchChange,
@@ -64,7 +67,7 @@ function SearchableDiscreteColorLegend(props) {
         <input
           type="search"
           placeholder={searchPlaceholder}
-          className="rv-search-wrapper__form__input"
+          className={inputClassName}
           value={searchText}
           onChange={onChange}/>
       </form>

--- a/tests/components/legends-tests.js
+++ b/tests/components/legends-tests.js
@@ -46,18 +46,21 @@ test('Discrete Legends', t => {
     'custom discrete legend uses custom palette');
 
   const $ = mount(<SearchableDiscreteLegend/>);
-  t.equal($.text(), 'ApplesBananasBlueberriesCarrotsEggplantsLimesPotatoes',
+  t.equal($.find('.rv-search-wrapper__contents').text(), 'ApplesBananasBlueberriesCarrotsEggplantsLimesPotatoes',
   'should find the correct text content for the searchable legend');
   t.equal($.find('.rv-discrete-color-legend-item__color').length, 7,
   'should find the right number of element for the searchable legends');
   $.find('.rv-search-wrapper__form__input').simulate('change', {target: {value: 'egg'}});
-  t.equal($.text(), 'Eggplants', 'should find the correct text content after search');
+  t.equal($.find('.rv-search-wrapper__contents').text(), 'Eggplants', 'should find the correct text content after search');
   const itemsFound = $.find('.rv-discrete-color-legend-item__color').length;
   t.equal(itemsFound, 1, 'should find the right number of elements for the searchable legend after searched');
 
   t.equal($.find('.disabled').length, 0, 'before clicking, should find no items disabled');
   $.find('.clickable').simulate('click');
   t.equal($.find('.disabled').length, 1, 'before clicking, should find no items disabled');
+
+  $.find('button').simulate('click');
+  t.equal($.find('.rv-search-wrapper__form__input').length, 0, 'should remove default class from input');
 
   t.end();
 });


### PR DESCRIPTION
We have a default input style in our app.  By putting an unconfigurable class name on the input I can't easily use both the default css from react-vis and the default input style from our app.