### PR TITLE
Update `tickFormat` example in `axis.md docs with exposed index

### DIFF
--- a/docs/axes.md
+++ b/docs/axes.md
@@ -56,7 +56,7 @@ Type: `function(*)`
 Format function for the tick label. Similar to the `tickFormat()` method of d3-axis. Typically the value that is return is a string or a number, however this function also supports rendering svg react elements. To wit, I could have formatting function like
 
 ```javascript
-function myFormatter(t) {
+function myFormatter(t, i) {
   return (<tspan>
     <tspan x="0" dy="1em">MY VALUE</tspan>
     <tspan x="0" dy="1em">{t}</tspan>


### PR DESCRIPTION
Update `tickFormat` example to show exposed index from https://github.com/uber/react-vis/pull/615 and https://github.com/uber/react-vis/issues/616