### PR TITLE
Check if stylesheet has been imported

### DIFF
--- a/src/main.scss
+++ b/src/main.scss
@@ -1,3 +1,8 @@
+// special tag for using to check if the style file has been imported
+.react-vis-magic-css-import-rule {
+  display: inherit;
+}
+
 @import 'styles/treemap';
 @import 'styles/plot';
 @import 'styles/legends';

--- a/src/plot/xy-plot.js
+++ b/src/plot/xy-plot.js
@@ -25,6 +25,7 @@ import equal from 'deep-equal';
 import {extractScalePropsFromProps, getMissingScaleProps, getXYPlotValues} from 'utils/scales-utils';
 import {getStackedData, getSeriesChildren, getSeriesPropsFromChildren} from 'utils/series-utils';
 import {getInnerDimensions, MarginPropType} from 'utils/chart-utils';
+import {checkIfStyleSheetIsImported} from 'utils/react-utils';
 import {AnimationPropType} from 'animation';
 import {
   CONTINUOUS_COLOR_RANGE,
@@ -135,6 +136,10 @@ class XYPlot extends React.Component {
       scaleMixins: this._getScaleMixins(data, props),
       data
     };
+  }
+
+  componentDidMount() {
+    checkIfStyleSheetIsImported();
   }
 
   componentWillReceiveProps(nextProps) {

--- a/src/utils/react-utils.js
+++ b/src/utils/react-utils.js
@@ -72,3 +72,29 @@ export function warning(message, onlyShowMessageOnce = false) {
 export function warnOnce(message) {
   warning(message, true);
 }
+
+// special tag for using to check if the style file has been imported
+// represented the md5 hash of the phrase "react-vis is cool"
+const CLASS_HASH = '.react-vis-magic-css-import-rule';
+export function checkIfStyleSheetIsImported() {
+  /* eslint-disable no-undef, no-process-env */
+  if (process && HIDDEN_PROCESSES[process.env.NODE_ENV]) {
+    return;
+  }
+  /* eslint-enable no-undef, no-process-env */
+
+  const foundImportTag = [...new Array(document.styleSheets.length)].some((e, i) => {
+    const styleSheet = document.styleSheets[i];
+    const CSSRulesList = styleSheet.rules || styleSheet.cssRules;
+    return [...new Array(CSSRulesList ? CSSRulesList.length : 0)].some((el, j) => {
+      const selector = CSSRulesList[j];
+      return selector.selectorText === CLASS_HASH;
+    });
+  });
+
+  if (!foundImportTag) {
+    /* eslint-disable max-len */
+    warnOnce('REACT-VIS: The style sheet for react-vis has not been imported, checkout https://uber.github.io/react-vis/documentation/general-principles/style for more details.');
+    /* eslint-enable max-len */
+  }
+}

--- a/src/utils/react-utils.js
+++ b/src/utils/react-utils.js
@@ -75,7 +75,7 @@ export function warnOnce(message) {
 
 // special tag for using to check if the style file has been imported
 // represented the md5 hash of the phrase "react-vis is cool"
-const CLASS_HASH = '.react-vis-magic-css-import-rule';
+const MAGIC_CSS_RULE = '.react-vis-magic-css-import-rule';
 export function checkIfStyleSheetIsImported() {
   /* eslint-disable no-undef, no-process-env */
   if (process && HIDDEN_PROCESSES[process.env.NODE_ENV]) {
@@ -88,7 +88,7 @@ export function checkIfStyleSheetIsImported() {
     const CSSRulesList = styleSheet.rules || styleSheet.cssRules;
     return [...new Array(CSSRulesList ? CSSRulesList.length : 0)].some((el, j) => {
       const selector = CSSRulesList[j];
-      return selector.selectorText === CLASS_HASH;
+      return selector.selectorText === MAGIC_CSS_RULE;
     });
   });
 


### PR DESCRIPTION
One of the most common issues users run into is forgetting to import the stylesheet (#602). This PR adds a small script that looks through the styles sheets that are being used in the browser and evaluates whether or not a "magic css rule" is found. (This magic css rule doesn't do anything except add a tag to the minified css name space) If we are unable to find this rule, it implies the style sheet has not been imported, so we give a warning.