### PR TITLE
Updating peer dependencies to allow React 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "uglify-js": "^2.8.22"
   },
   "peerDependencies": {
-    "react": "0.14.x - 15.x"
+    "react": "0.14.x - 16.x"
   },
   "keywords": [
     "d3",
@@ -142,3 +142,4 @@
     "npm": ">=3.0"
   }
 }
+


### PR DESCRIPTION
Hi!

Quick one liner so there aren't errors when upgrading to React 16 - from a quick poke around everything seems to be working

I haven't updated any of test harness yet, there's some work to do with Enzyme to get things going there.