### PR TITLE
Add event handlers to Sankey links

### DIFF
--- a/docs/sankey.md
+++ b/docs/sankey.md
@@ -146,6 +146,45 @@ This handler is triggered either when the users mouse leaves a node. Callback wh
 ```
 
 
+#### onLinkClick (optional)
+Type: `function`
+Default noop
+This handler is triggered when the user clicks on a link. Callback accepts the data point associated with this link as well as the click event.
+```jsx
+<Sankey
+  onLinkClick={(linkdata, event)=>{
+    // does something on click
+    // you can access the value of the event
+  }}
+/>
+```
+
+#### onLinkMouseOver (optional)
+Type: `function`
+Default noop
+This handler is triggered when the user's mouse hovers over a link. Callback accepts the data point associated with this link as well as the click event.
+```jsx
+<Sankey
+  onLinkMouseOver={(linkdata, event)=>{
+    // does something on mouseover
+    // you can access the value of the event
+  }}
+/>
+```
+
+#### onLinkMouseOut (optional)
+Type: `function`
+Default noop
+This handler is triggered when the user's exits a link. Callback accepts the data point associated with this link as well as the click event.
+```jsx
+<Sankey
+  onLinkMouseOut={(linkdata, event)=>{
+    // does something on mouseout
+    // you can access the value of the event
+  }}
+/>
+```
+
 ### style (optional)
 Type: `object`
 An object that contains CSS properties with which the axis component can be entirely re-styled.

--- a/showcase/index.js
+++ b/showcase/index.js
@@ -136,6 +136,7 @@ import SunburstWithTooltips from './sunbursts/sunburst-with-tooltips';
 import BasicSankeyExample from './sankey/basic';
 import VoronoiSankeyExample from './sankey/voronoi';
 import EnergySankeyExample from './sankey/energy-sankey';
+import LinkEventSankeyExample from './sankey/link-event';
 
 import SimpleTreemap from './treemap/simple-treemap';
 import TreemapExample from './treemap/dynamic-treemap';
@@ -244,6 +245,7 @@ export const showCase = {
   BasicSankeyExample,
   VoronoiSankeyExample,
   EnergySankeyExample,
+  LinkEventSankeyExample,
 
   VerticalDiscreteColorLegendExample,
   HorizontalDiscreteColorLegendExample,

--- a/showcase/sankey/link-event.js
+++ b/showcase/sankey/link-event.js
@@ -1,0 +1,49 @@
+import React from 'react';
+
+import Sankey from 'sankey';
+
+const BLURRED_LINK_OPACITY = 0.3;
+const FOCUSED_LINK_OPACITY = 0.6;
+
+const nodes = [{name: 'a'}, {name: 'b'}, {name: 'c'}];
+const links = [
+  {source: 0, target: 1, value: 10},
+  {source: 0, target: 2, value: 20},
+  {source: 1, target: 2, value: 20}
+];
+
+export default class LinkEventSankeyExample extends React.Component {
+
+  state = {
+    activeLink: null
+  }
+
+  render() {
+    const {activeLink} = this.state;
+
+    // Note: d3.sankey currently mutates the `nodes` and `links` arrays, which doesn't play nice
+    // with React's single-direction data flow. We create a copy of each before we pass to the sankey
+    // component, just to be sure.
+    return (
+      <div>
+        <div>
+          {`${activeLink ? (
+            `${nodes[activeLink.source.index].name} -> ${nodes[activeLink.target.index].name}`
+          ) : (
+            'None'
+          )} selected`}</div>
+        <Sankey
+          nodes={nodes.map(d => ({...d}))}
+          links={links.map((d, i) => ({
+            ...d,
+            opacity: activeLink && i === activeLink.index ? FOCUSED_LINK_OPACITY : BLURRED_LINK_OPACITY
+          }))}
+          width={200}
+          height={200}
+          onLinkMouseOver={node => this.setState({activeLink: node})}
+          onLinkMouseOut={() => this.setState({activeLink: null})}
+        />
+      </div>
+    );
+  }
+}

--- a/showcase/showcase-sections/sankeys-showcase.js
+++ b/showcase/showcase-sections/sankeys-showcase.js
@@ -5,7 +5,8 @@ import {showCase} from '../index';
 const {
   BasicSankeyExample,
   VoronoiSankeyExample,
-  EnergySankeyExample
+  EnergySankeyExample,
+  LinkEventSankeyExample
 } = showCase;
 
 const SANKEYS = [{
@@ -16,6 +17,9 @@ const SANKEYS = [{
 }, {
   name: 'With Voronoi Selection',
   component: VoronoiSankeyExample
+}, {
+  name: 'With link selection',
+  component: LinkEventSankeyExample
 }, {
   name: 'Energy Example',
   component: EnergySankeyExample

--- a/src/sankey/index.js
+++ b/src/sankey/index.js
@@ -53,6 +53,9 @@ class Sankey extends Component {
       onValueClick,
       onValueMouseOver,
       onValueMouseOut,
+      onLinkClick,
+      onLinkMouseOver,
+      onLinkMouseOut,
       style,
       width
     } = this.props;
@@ -89,7 +92,9 @@ class Sankey extends Component {
             data={path(link)}
             opacity={link.opacity || linkOpacity}
             color={link.color}
-
+            onLinkClick={onLinkClick}
+            onLinkMouseOver={onLinkMouseOver}
+            onLinkMouseOut={onLinkMouseOut}
             strokeWidth={Math.max(link.width, 1)}
             node={link}
             nWidth={nWidth}
@@ -159,6 +164,9 @@ Sankey.defaultProps = {
   onValueMouseOver: NOOP,
   onValueClick: NOOP,
   onValueMouseOut: NOOP,
+  onLinkClick: NOOP,
+  onLinkMouseOver: NOOP,
+  onLinkMouseOut: NOOP,
   style: {
     links: {},
     rects: {},
@@ -189,6 +197,9 @@ Sankey.propTypes = {
   onValueMouseOver: PropTypes.func,
   onValueClick: PropTypes.func,
   onValueMouseOut: PropTypes.func,
+  onLinkClick: PropTypes.func,
+  onLinkMouseOver: PropTypes.func,
+  onLinkMouseOut: PropTypes.func,
   style: PropTypes.shape({
     links: PropTypes.object,
     rects: PropTypes.object,

--- a/src/sankey/sankey-link.js
+++ b/src/sankey/sankey-link.js
@@ -28,7 +28,18 @@ const DEFAULT_LINK_OPACITY = 0.7;
 
 class SankeyLink extends PureComponent {
   render() {
-    const {animation, data, opacity, color, strokeWidth, style} = this.props;
+    const {
+      animation,
+      data,
+      node,
+      opacity,
+      color,
+      strokeWidth,
+      style,
+      onLinkClick,
+      onLinkMouseOver,
+      onLinkMouseOut
+    } = this.props;
     if (animation) {
       return (
         <Animation {...this.props} animatedProps={ANIMATED_SERIES_PROPS}>
@@ -43,6 +54,9 @@ class SankeyLink extends PureComponent {
         className="rv-sankey__link"
         opacity={Number.isFinite(opacity) ? opacity : DEFAULT_LINK_OPACITY}
         stroke={color || DEFAULT_LINK_COLOR}
+        onClick={e => onLinkClick(node, e)}
+        onMouseOver={e => onLinkMouseOver(node, e)}
+        onMouseOut={e => onLinkMouseOut(node, e)}
         strokeWidth={strokeWidth}
         fill="none" />
     );

--- a/tests/components/sankey-tests.js
+++ b/tests/components/sankey-tests.js
@@ -6,6 +6,7 @@ import Sankey from 'sankey';
 import BasicSankey from '../../showcase/sankey/basic';
 import VoronoiSankey from '../../showcase/sankey/voronoi';
 import EnergySankey from '../../showcase/sankey/energy-sankey';
+import LinkEventSankey from '../../showcase/sankey/link-event';
 
 const SANKEY_PROPS = {
   nodes: [],
@@ -56,6 +57,21 @@ test('Sankey: Showcase Example - VoronoiSankey', t => {
   $.find('.rv-voronoi__cell').at(0).simulate('mouseOver');
   t.equal($.text(), 'a selectedabc', 'should find that the first bar is hovered bar is hovered');
   $.find('.rv-voronoi__cell').at(0).simulate('mouseLeave');
+
+  t.end();
+});
+
+test('Sankey: Showcase Example - LinkEventSankey', t => {
+  const $ = mount(<LinkEventSankey />);
+
+  t.equal($.find('.rv-sankey__link').length, 3, 'should find the right number of links');
+  t.equal($.find('.rv-sankey__node rect').length, 3, 'should find the right number of nodes');
+
+  t.equal($.text(), 'None selectedabc', 'should find that no link is hovered');
+  $.find('.rv-sankey__link').at(0).simulate('mouseOver');
+  t.equal($.text(), 'a -> b selectedabc', 'should find that the first link is hovered');
+  $.find('.rv-sankey__link').at(0).simulate('mouseOut');
+  t.equal($.text(), 'None selectedabc', 'should find that no bar is hovered');
 
   t.end();
 });


### PR DESCRIPTION
This commit adds onClick, onMouseOver, and onMouseOut event handlers to
the link SVG paths on Sankey charts. I've also added a quick example to
the showcase.

Will be useful for #631 