### PR TITLE
Move react-test-renderer to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,8 +48,7 @@
     "deep-equal": "^1.0.1",
     "global": "^4.3.1",
     "prop-types": "^15.5.8",
-    "react-motion": "^0.4.8",
-    "react-test-renderer": "^15.5.4"
+    "react-motion": "^0.4.8"
   },
   "devDependencies": {
     "babel-cli": "6.18.0",
@@ -75,6 +74,7 @@
     "react": "^15.5.4",
     "react-addons-test-utils": ">=15.4.2",
     "react-dom": "^15.5.4",
+    "react-test-renderer": "^15.5.4",
     "stylelint": "^7.7.1",
     "stylelint-config-standard": "^15.0.1",
     "tape": "^4.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3948,8 +3948,8 @@ react-motion@^0.4.8:
     raf "^3.1.0"
 
 react-test-renderer@^15.5.4:
-  version "15.5.4"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-15.5.4.tgz#d4ebb23f613d685ea8f5390109c2d20fbf7c83bc"
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-15.6.2.tgz#d0333434fc2c438092696ca770da5ed48037efa8"
   dependencies:
     fbjs "^0.8.9"
     object-assign "^4.1.0"


### PR DESCRIPTION
Moves react-test-renderer from `dependencies` to `devDependencies` since I doubt it's actually needed to use the library