### PR TITLE
Swap height and width in partition pivot treemaps

### DIFF
--- a/src/treemap/index.js
+++ b/src/treemap/index.js
@@ -120,7 +120,7 @@ class Treemap extends React.Component {
 
     if ((mode === 'partition' || mode === 'partition-pivot')) {
       const partitionFunction = partition()
-          .size([innerWidth, innerHeight])
+          .size(mode === 'partition-pivot' ? [innerHeight, innerWidth] : [innerWidth, innerHeight])
           .padding(padding);
       const structuredInput = hierarchy(data)
         .sum(d => d.size);


### PR DESCRIPTION
The height and width need to be swapped when using a partition pivot.  Otherwise the treemap will flow out of the container.
Old behavior
![image](https://user-images.githubusercontent.com/1678756/31452377-c50c53f8-ae7c-11e7-8c55-aa73eae75022.png)

Fixed behavior
![image](https://user-images.githubusercontent.com/1678756/31452474-03bbd736-ae7d-11e7-8048-669523b04b10.png)

