### PR TITLE
Added treemap hideRootNode property

### DIFF
--- a/docs/treemap.md
+++ b/docs/treemap.md
@@ -120,6 +120,10 @@ Each point consists of following properties:
 Type: `boolean|Object`
 Please refer to [Animation](animation.md) doc for more information.
 
+#### hideRootNode (optional)
+Type: `boolean`
+Simple boolean on whether or not to show the root node of the tree.
+
 #### onLeafClick (optional)
 Type: `function`
 - Should accept arguments (leafNode, domEvent)

--- a/src/treemap/index.js
+++ b/src/treemap/index.js
@@ -175,6 +175,7 @@ Treemap.propTypes = {
   className: PropTypes.string,
   data: PropTypes.object.isRequired,
   height: PropTypes.number.isRequired,
+  hideRootNode: PropTypes.bool,
   margin: MarginPropType,
   mode: PropTypes.oneOf(
     Object.keys(TREEMAP_TILE_MODES).concat(TREEMAP_LAYOUT_MODES)
@@ -195,6 +196,7 @@ Treemap.defaultProps = {
   data: {
     children: []
   },
+  hideRootNode: false,
   margin: DEFAULT_MARGINS,
   mode: 'squarify',
   onLeafClick: NOOP,

--- a/src/treemap/treemap-dom.js
+++ b/src/treemap/treemap-dom.js
@@ -23,7 +23,7 @@ import TreemapLeaf from './treemap-leaf';
 
 class TreemapDOM extends React.Component {
   render() {
-    const {animation, className, height, mode, nodes, width, scales, style} = this.props;
+    const {animation, className, height, hideRootNode, mode, nodes, width, scales, style} = this.props;
     const useCirclePacking = mode === 'circlePack';
     return (
       <div
@@ -31,7 +31,7 @@ class TreemapDOM extends React.Component {
         style={{height, width}}>
         {nodes.map((node, index) => {
           // throw out the rootest node
-          if (!useCirclePacking && !index) {
+          if (hideRootNode && !index) {
             return null;
           }
 

--- a/src/treemap/treemap-svg.js
+++ b/src/treemap/treemap-svg.js
@@ -31,6 +31,7 @@ class TreemapSVG extends React.Component {
   getCircularNodes() {
     const {
       animation,
+      hideRootNode,
       nodes,
       onLeafMouseOver,
       onLeafMouseOut,
@@ -40,6 +41,9 @@ class TreemapSVG extends React.Component {
     } = this.props;
 
     const {rows, minY, maxY, minX, maxX} = nodes.reduce((acc, node, index) => {
+      if (!index && hideRootNode) {
+        return acc;
+      }
       const {x, y, r} = node;
       return {
         maxY: Math.max(y + r, acc.maxY),
@@ -83,6 +87,7 @@ class TreemapSVG extends React.Component {
   getNonCircularNodes() {
     const {
       animation,
+      hideRootNode,
       nodes,
       onLeafMouseOver,
       onLeafMouseOut,
@@ -92,7 +97,7 @@ class TreemapSVG extends React.Component {
     } = this.props;
     const {color} = scales;
     return nodes.reduce((acc, node, index) => {
-      if (!index) {
+      if (!index && hideRootNode) {
         return acc;
       }
       const {x0, x1, y1, y0} = node;

--- a/tests/components/treemap-tests.js
+++ b/tests/components/treemap-tests.js
@@ -99,7 +99,56 @@ test('Treemap: Custom Sorting', t => {
 
 test('Treemap: Empty treemap', t => {
   const $ = mount(<Treemap {...{...TREEMAP_PROPS, data: {}}}/>);
-  //1 is the empty root node
+  // 1 is the empty root node
+  t.equal($.find('.rv-treemap__leaf').length, 1, 'should find the right number of children');
+  t.equal($.find('.rv-treemap').text(), '', 'should find the correct text shown');
+  t.equal($.find('.little-nested-tree-example').length, 1, 'should find the custom class name used');
+
+  t.end();
+});
+
+test('Treemap: Hide Root Node', t => {
+  const $ = mount(<Treemap {...TREEMAP_PROPS}/>);
+  // the tree from TREEMAP_PROPS doesn't have a title so its text is the same with ot without the root
+  const expectedText = 'EasingNeonateinterpolateISchedulableParallelPauseFunctionSequenceSequenceTransitionTransitionerTransitionEventSchedulerArrayInterpolatorColorInterpolatorDateInterpolatorInterpolatorMatrixInterpolatorNumberInterpolatorObjectInterpolatorPointInterpolatorRectangleInterpolator';
+  const numberOfElements = 21;
+  const numberOfElementsWithRoot = numberOfElements + 1;
+  const expectedNewText = 'ArrayInterpolatorColorInterpolatorDateInterpolatorInterpolatorMatrixInterpolatorNumberInterpolatorObjectInterpolatorPointInterpolatorRectangleInterpolator';
+  const expectedNewTextWithRoot = `interpolate${expectedNewText}`;
+  const numberOfNewElements = 9;
+  const numberOfNewElementsWithRoot = numberOfNewElements + 1;
+  [
+    'circlePack',
+    'partition',
+    'partition-pivot',
+    'squarify',
+    'resquarify',
+    'slice',
+    'dice',
+    'slicedice',
+    'binary'
+  ].forEach(mode => {
+    $.setProps({mode, ...TREEMAP_PROPS, hideRootNode: false});
+    t.equal($.find('.rv-treemap').text(), expectedText, `should find the correct text shown for ${mode} with hideRootNode false`);
+    t.equal($.find('.rv-treemap__leaf').length, numberOfElementsWithRoot, `should find the correct number of children for ${mode} with  hideRootNode false`);
+    $.setProps({hideRootNode: true});
+    t.equal($.find('.rv-treemap').text(), expectedText, `should find the correct text shown for ${mode} with hideRootNode true`);
+    t.equal($.find('.rv-treemap__leaf').length, numberOfElements, `should find the right number of children for ${mode} with hideRootNode true`);
+
+    $.setProps({data: INTERPOLATE_DATA, hideRootNode: false});
+    t.equal($.find('.rv-treemap').text(), expectedNewTextWithRoot, `should find the correct new text shown for ${mode} with hideRootNode false`);
+    t.equal($.find('.rv-treemap__leaf').length, numberOfNewElementsWithRoot, `should find the new right number of children for ${mode} with  hideRootNode false`);
+    $.setProps({hideRootNode: true});
+    t.equal($.find('.rv-treemap').text(), expectedNewText, `should find the correct new text shown for ${mode} with hideRootNode true`);
+    t.equal($.find('.rv-treemap__leaf').length, numberOfNewElements, `should find the new right number of children for ${mode} with  hideRootNode true`);
+  });
+
+  t.end();
+});
+
+test('Treemap: Empty treemap', t => {
+  const $ = mount(<Treemap {...{...TREEMAP_PROPS, data: {}}}/>);
+  // 1 is the empty root node
   t.equal($.find('.rv-treemap__leaf').length, 1, 'should find the right number of children');
   t.equal($.find('.rv-treemap').text(), '', 'should find the correct text shown');
   t.equal($.find('.little-nested-tree-example').length, 1, 'should find the custom class name used');

--- a/tests/components/treemap-tests.js
+++ b/tests/components/treemap-tests.js
@@ -51,14 +51,14 @@ testRenderWithProps(Treemap, TREEMAP_PROPS);
 
 test('Treemap: Basic rendering', t => {
   const $ = mount(<Treemap {...TREEMAP_PROPS}/>);
-  t.equal($.find('.rv-treemap__leaf').length, 21, 'should find the right number of children');
+  t.equal($.find('.rv-treemap__leaf').length, 22, 'should find the right number of children');
   const expectedText = 'EasingNeonateinterpolateISchedulableParallelPauseFunctionSequenceSequenceTransitionTransitionerTransitionEventSchedulerArrayInterpolatorColorInterpolatorDateInterpolatorInterpolatorMatrixInterpolatorNumberInterpolatorObjectInterpolatorPointInterpolatorRectangleInterpolator';
   t.equal($.find('.rv-treemap').text(), expectedText, 'should find the correct text shown');
   t.equal($.find('.little-nested-tree-example').length, 1, 'should find the custom class name used');
 
   $.setProps({data: INTERPOLATE_DATA});
-  t.equal($.find('.rv-treemap__leaf').length, 9, 'should find the right number of children');
-  const newText = 'ArrayInterpolatorColorInterpolatorDateInterpolatorInterpolatorMatrixInterpolatorNumberInterpolatorObjectInterpolatorPointInterpolatorRectangleInterpolator';
+  t.equal($.find('.rv-treemap__leaf').length, 10, 'should find the right number of children');
+  const newText = 'interpolateArrayInterpolatorColorInterpolatorDateInterpolatorInterpolatorMatrixInterpolatorNumberInterpolatorObjectInterpolatorPointInterpolatorRectangleInterpolator';
   t.equal($.find('.rv-treemap').text(), newText, 'should find the correct text shown');
   t.equal($.find('.little-nested-tree-example').length, 1, 'should find the custom class name used');
   t.end();
@@ -68,10 +68,8 @@ test('Treemap: Custom Sorting', t => {
   const $ = mount(<Treemap {...TREEMAP_PROPS}/>);
   const expectedText = 'interpolateTransitionerEasingTransitionNeonateFunctionSequenceSchedulerSequenceParallelTransitionEventISchedulablePauseInterpolatorMatrixInterpolatorColorInterpolatorRectangleInterpolatorArrayInterpolatorPointInterpolatorObjectInterpolatorNumberInterpolatorDateInterpolator';
   const expectedReverseText = 'PauseISchedulableTransitionEventParallelSequenceSchedulerFunctionSequenceNeonateTransitionEasingTransitionerinterpolateDateInterpolatorNumberInterpolatorObjectInterpolatorPointInterpolatorArrayInterpolatorRectangleInterpolatorColorInterpolatorMatrixInterpolatorInterpolator';
-  const expectedNewText = 'InterpolatorMatrixInterpolatorColorInterpolatorRectangleInterpolatorArrayInterpolatorPointInterpolatorObjectInterpolatorNumberInterpolatorDateInterpolator';
-  const expectedReverseNewText = 'DateInterpolatorNumberInterpolatorObjectInterpolatorPointInterpolatorArrayInterpolatorRectangleInterpolatorColorInterpolatorMatrixInterpolatorInterpolator';
-  const expectedNewTextWithRoot = `interpolate${expectedNewText}`;
-  const expectedReverseNewTextWithRoot = `interpolate${expectedReverseNewText}`;
+  const expectedNewText = 'interpolateInterpolatorMatrixInterpolatorColorInterpolatorRectangleInterpolatorArrayInterpolatorPointInterpolatorObjectInterpolatorNumberInterpolatorDateInterpolator';
+  const expectedReverseNewText = 'interpolateDateInterpolatorNumberInterpolatorObjectInterpolatorPointInterpolatorArrayInterpolatorRectangleInterpolatorColorInterpolatorMatrixInterpolatorInterpolator';
 
   [
     'circlePack',
@@ -91,9 +89,9 @@ test('Treemap: Custom Sorting', t => {
 
     // circle pack includes the root node, while the other modes do not. The root of INTERPOLATE_DATA has a title, but the root of the default data does not
     $.setProps({data: INTERPOLATE_DATA, sortFunction: (a, b) => (b.value - a.value)});
-    t.equal($.find('.rv-treemap').text(), mode === 'circlePack' ? expectedNewTextWithRoot : expectedNewText, `should find the correct new text shown for ${mode} with sort`);
+    t.equal($.find('.rv-treemap').text(), expectedNewText, `should find the correct new text shown for ${mode} with sort`);
     $.setProps({sortFunction: (a, b) => (a.value - b.value)});
-    t.equal($.find('.rv-treemap').text(), mode === 'circlePack' ? expectedReverseNewTextWithRoot : expectedReverseNewText, `should find the correct new text shown for ${mode} with reverse sort`);
+    t.equal($.find('.rv-treemap').text(), expectedReverseNewText, `should find the correct new text shown for ${mode} with reverse sort`);
   });
 
   t.end();
@@ -101,7 +99,8 @@ test('Treemap: Custom Sorting', t => {
 
 test('Treemap: Empty treemap', t => {
   const $ = mount(<Treemap {...{...TREEMAP_PROPS, data: {}}}/>);
-  t.equal($.find('.rv-treemap__leaf').length, 0, 'should find the right number of children');
+  //1 is the empty root node
+  t.equal($.find('.rv-treemap__leaf').length, 1, 'should find the right number of children');
   t.equal($.find('.rv-treemap').text(), '', 'should find the correct text shown');
   t.equal($.find('.little-nested-tree-example').length, 1, 'should find the custom class name used');
 
@@ -123,7 +122,7 @@ test('Treemap: SimpleTreemap', t => {
   ].forEach(mode => {
     const selector = mode === 'circlePack' ? '.rv-treemap__leaf circle' : '.rv-treemap__leaf';
     // circle pack includes the root node, while the other modes do not
-    const numberOfElements = mode === 'circlePack' ? 252 : 251;
+    const numberOfElements = 252;
     t.equal($.find(selector).length, numberOfElements, `${mode}: should find the right number of SVG children`);
     t.equal($.text(), `USE DOMPREV MODE ${mode} NEXT MODE`, `${mode}: should find the correct text shown`);
     // switch to svg
@@ -141,7 +140,7 @@ test('Treemap: SimpleTreemap', t => {
 
 test('Treemap: DynamicTreemap', t => {
   const $ = mount(<DynamicTreemap />);
-  t.equal($.find('.rv-treemap__leaf').length, 20, 'should find the right number of children');
+  t.equal($.find('.rv-treemap__leaf').length, 21, 'should find the right number of children');
   t.equal($.find('.rv-treemap').text(), '2020202020202020202020202020202020202020', 'should find the correct text shown');
 
   t.end();


### PR DESCRIPTION
Added a  property to treemap hideRootNode with a default of false as discussed in #639 with @mcnuttandrew 

This did cause some changes in the number of nodes for existing treemaps.  I updated the tests and added a new test for this property.

This did result in visual changes for some treemaps.  

Partitions now show the root node(the desired result)
New
![image](https://user-images.githubusercontent.com/1678756/31560417-2e5103a8-b022-11e7-9764-504ac1cfe4e3.png)

vs Old

![image](https://user-images.githubusercontent.com/1678756/31560383-149d1d52-b022-11e7-9176-a7a80158e297.png)

For squarify there is a slight change in the space between the node padding(where the root node becomes visible)
New
![image](https://user-images.githubusercontent.com/1678756/31560510-8e9f7488-b022-11e7-8ca3-ed395f1c870f.png)

vs old

![image](https://user-images.githubusercontent.com/1678756/31560523-9d5dab5c-b022-11e7-8b68-a6e54ea581be.png)



