### PR TITLE
Fix axis title style bug

### DIFF
--- a/showcase/axes/custom-axis.js
+++ b/showcase/axes/custom-axis.js
@@ -31,6 +31,17 @@ import {
 
 export default class Example extends React.Component {
   render() {
+    const axisStyle = {
+      ticks: {
+        fontSize: '14px',
+        color: '#333'
+      },
+      title: {
+        fontSize: '16px',
+        color: '#333'
+      }
+    };
+
     return (
       <XYPlot
         width={300}
@@ -42,7 +53,8 @@ export default class Example extends React.Component {
           title="X"
           labelFormat={v => `Value is ${v}`}
           labelValues={[2]}
-          tickValues={[1, 1.5, 2, 3]}/>
+          tickValues={[1, 1.5, 2, 3]}
+          style={axisStyle}/>
         <YAxis hideTicks/>
         <LineSeries
           data={[

--- a/src/plot/axis/axis-title.js
+++ b/src/plot/axis/axis-title.js
@@ -81,7 +81,7 @@ function AxisTitle({orientation, width, height, style, title}) {
   return (
     <g transform={outerGroupTransform} className="rv-xy-plot__axis__title">
       <g style={{textAnchor, ...style}} transform={innerGroupTransform}>
-        <text>{title}</text>
+        <text style={style}>{title}</text>
       </g>
     </g>
   );

--- a/tests/components/axes-tests.js
+++ b/tests/components/axes-tests.js
@@ -22,6 +22,9 @@ test('Axis: Showcase Example - Custom axis', t => {
   t.equal($.text(), '1.01.52.03.0X', 'should find appropriate text');
   t.equal($.find('.rv-xy-plot__series--line').length, 1, 'should find the right number of lines');
   t.equal($.find('line').length, 15, 'should find the right number of grid lines');
+
+  const titleStyle = $.find('.rv-xy-plot__axis__title text').prop('style');
+  t.equal(titleStyle.fontSize, '16px', 'Styling: should honor title fontSize');
   t.end();
 });
 


### PR DESCRIPTION
issue: #651 

I am now applying the style to the text inside of the axis title.

I changed the showcase so that the custom axis chart shows that the user can change the font. 

I added a test to test if the style is being applied to the correct title.

<img width="326" alt="screen shot 2017-11-02 at 5 17 57 pm" src="https://user-images.githubusercontent.com/9452950/32350812-ce100db0-bff1-11e7-922c-ab3541da0d3e.png">

