### PR TITLE
Improve performance of MarkSeries using shouldComponentUpdate

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "deep-equal": "^1.0.1",
     "global": "^4.3.1",
     "prop-types": "^15.5.8",
-    "react-motion": "^0.4.8"
+    "react-motion": "^0.4.8",
+    "shallowequal": "^1.0.2"
   },
   "devDependencies": {
     "babel-cli": "6.18.0",

--- a/showcase/index.js
+++ b/showcase/index.js
@@ -34,6 +34,7 @@ import Histogram from './plot/histogram';
 import AreaChart from './plot/area-chart';
 import AreaChartElevated from './plot/area-chart-elevated';
 import ScatterplotChart from './plot/scatterplot';
+import ScatterplotManyPointsChart from './plot/scatterplot-large';
 import WhiskerChart from './plot/whisker-chart.js';
 import CustomSVGExample from './plot/custom-svg-example';
 import CustomSVGRootLevel from './plot/custom-svg-root-level';
@@ -164,8 +165,9 @@ export const showCase = {
   CustomSVGExample,
   CustomSVGRootLevel,
   CustomSVGAllTheMarks,
-  ScatterplotChart,
   ScatterplotCanvas,
+  ScatterplotChart,
+  ScatterplotManyPointsChart,
   WhiskerChart,
   HeatmapChart,
   ContourSeriesExample,

--- a/showcase/plot/scatterplot-large.js
+++ b/showcase/plot/scatterplot-large.js
@@ -1,0 +1,84 @@
+// Copyright (c) 2016 - 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import React from 'react';
+
+import {
+  Hint,
+  HorizontalGridLines,
+  makeWidthFlexible,
+  MarkSeries,
+  VerticalGridLines,
+  XYPlot,
+  YAxis
+} from 'index';
+
+const FlexibleXYPlot = makeWidthFlexible(XYPlot);
+
+export default class Example extends React.Component {
+  componentWillMount() {
+    this.setState({
+      data: randomDatapoints(randomInt(700)),
+      nextPointCount: randomInt(700)
+    });
+  }
+
+  render() {
+    const {data, nextPointCount, value} = this.state || {};
+    return (
+      <div style={{width: '100%'}}>
+        Displaying {data.length} points per chart <button onClick={() => this.setState({
+          data: randomDatapoints(nextPointCount),
+          nextPointCount: randomInt(700)
+        })}>
+          Generate {nextPointCount} New Points
+        </button>
+        {new Array(4).fill('_').map((d, i) =>
+          <FlexibleXYPlot height={100} key={i}>
+            <VerticalGridLines />
+            <HorizontalGridLines />
+            <YAxis />
+            {value && <Hint value={value}/>}
+            <MarkSeries
+              className="mark-series-example"
+              data={data}
+              onNearestXY={v => this.setState({value: v})}
+              onSeriesMouseOut={v => this.setState({value: false})}
+              opacity="0.6"
+              sizeRange={[2, 5]}
+              strokeWidth={2} />
+          </FlexibleXYPlot>
+        )}
+      </div>
+    );
+  }
+}
+
+function randomInt(maxValue = 1) {
+  return Math.max(1, Math.round(Math.random() * maxValue));
+}
+
+function randomDatapoints(numberDataPoints) {
+  return new Array(numberDataPoints).fill('_').map((d, i) => ({
+    x: i,
+    y: Math.random() * 8,
+    size: randomInt(30)
+  }));
+}

--- a/showcase/showcase-sections/plots-showcase.js
+++ b/showcase/showcase-sections/plots-showcase.js
@@ -28,6 +28,7 @@ const {
   StackedHistogram,
   ScatterplotChart,
   ScatterplotCanvas,
+  ScatterplotManyPointsChart,
   WhiskerChart,
   WidthHeightMarginChart
 } = showCase;
@@ -57,6 +58,11 @@ const PLOTS = [{
 }, {
   component: ScatterplotChart,
   name: 'Mark Series',
+  sourceLink: 'https://github.com/uber/react-vis/blob/master/src/plot/series/mark-series.js',
+  docsLink: 'http://uber.github.io/react-vis/documentation/series-reference/mark-series'
+}, {
+  component: ScatterplotManyPointsChart,
+  name: 'Mark Series With Many Points',
   sourceLink: 'https://github.com/uber/react-vis/blob/master/src/plot/series/mark-series.js',
   docsLink: 'http://uber.github.io/react-vis/documentation/series-reference/mark-series'
 }, {

--- a/src/plot/series/mark-series.js
+++ b/src/plot/series/mark-series.js
@@ -35,6 +35,7 @@ const DEFAULT_STROKE_WIDTH = 1;
 class MarkSeries extends AbstractSeries {
   shouldComponentUpdate(nextProps, nextState) {
     const isMissingDataProp = !this.props.data || !nextProps.data;
+    const isMissingNullAccessorProp = !this.props.nullAccessor || !nextProps.nullAccessor;
     return [
       [this.props.animation, nextProps.animation],
       [this.props.className, nextProps.className],
@@ -64,7 +65,9 @@ class MarkSeries extends AbstractSeries {
         (this.props.data.length !== nextProps.data.length ||
          nextProps.data.some((d, i) =>
           !shallowequal(this.props.data[i], d) ||
-          (this.props.nullAccessor(d) !== nextProps.nullAccessor(d))))
+          (isMissingNullAccessorProp ?
+            !shallowequal(this.props.data, nextProps.data) :
+            this.props.nullAccessor(d) !== nextProps.nullAccessor(d))))
     );
   }
 

--- a/src/plot/series/mark-series.js
+++ b/src/plot/series/mark-series.js
@@ -19,6 +19,7 @@
 // THE SOFTWARE.
 
 import React from 'react';
+import shallowequal from 'shallowequal';
 
 import PropTypes from 'prop-types';
 
@@ -32,6 +33,35 @@ const predefinedClassName = 'rv-xy-plot__series rv-xy-plot__series--mark';
 const DEFAULT_STROKE_WIDTH = 1;
 
 class MarkSeries extends AbstractSeries {
+  shouldComponentUpdate(nextProps, nextState) {
+    return [
+      [this.props.animation, nextProps.animation],
+      [this.props.className, nextProps.className],
+      [this.props.colorDomain, nextProps.colorDomain],
+      [this.props.colorRange, nextProps.colorRange],
+      [this.props.data, nextProps.data],
+      [this.props.fillDomain, nextProps.fillDomain],
+      [this.props.fillRange, nextProps.fillRange],
+      [this.props.innerHeight, nextProps.innerHeight],
+      [this.props.innerWidth, nextProps.innerWidth],
+      [this.props.marginLeft, nextProps.marginLeft],
+      [this.props.marginTop, nextProps.marginTop],
+      [this.props.nullAccessor, nextProps.nullAccessor],
+      [this.props.opacityDomain, nextProps.opacityDomain],
+      [this.props.opacityRange, nextProps.opacityRange],
+      [this.props.sizeDomain, nextProps.sizeDomain],
+      [this.props.sizeRange, nextProps.sizeRange],
+      [this.props.strokeDomain, nextProps.strokeDomain],
+      [this.props.strokeRange, nextProps.strokeRange],
+      [this.props.strokeWidth, nextProps.strokeWidth],
+      [this.props.style, nextProps.style],
+      [this.props.xDomain, nextProps.xDomain],
+      [this.props.xRange, nextProps.xRange],
+      [this.props.yDomain, nextProps.yDomain],
+      [this.props.yRange, nextProps.yRange]
+    ].some(([a, b]) => !shallowequal(a, b));
+  }
+
   _renderCircle(d, i, strokeWidth, style) {
     const sizeFunctor = this._getAttributeFunctor('size');
     const opacityFunctor = this._getAttributeFunctor('opacity');

--- a/src/plot/series/mark-series.js
+++ b/src/plot/series/mark-series.js
@@ -34,19 +34,18 @@ const DEFAULT_STROKE_WIDTH = 1;
 
 class MarkSeries extends AbstractSeries {
   shouldComponentUpdate(nextProps, nextState) {
+    const isMissingDataProp = !this.props.data || !nextProps.data;
     return [
       [this.props.animation, nextProps.animation],
       [this.props.className, nextProps.className],
       [this.props.colorDomain, nextProps.colorDomain],
       [this.props.colorRange, nextProps.colorRange],
-      [this.props.data, nextProps.data],
       [this.props.fillDomain, nextProps.fillDomain],
       [this.props.fillRange, nextProps.fillRange],
       [this.props.innerHeight, nextProps.innerHeight],
       [this.props.innerWidth, nextProps.innerWidth],
       [this.props.marginLeft, nextProps.marginLeft],
       [this.props.marginTop, nextProps.marginTop],
-      [this.props.nullAccessor, nextProps.nullAccessor],
       [this.props.opacityDomain, nextProps.opacityDomain],
       [this.props.opacityRange, nextProps.opacityRange],
       [this.props.sizeDomain, nextProps.sizeDomain],
@@ -59,7 +58,14 @@ class MarkSeries extends AbstractSeries {
       [this.props.xRange, nextProps.xRange],
       [this.props.yDomain, nextProps.yDomain],
       [this.props.yRange, nextProps.yRange]
-    ].some(([a, b]) => !shallowequal(a, b));
+    ].some(([a, b]) => !shallowequal(a, b)) || (
+      isMissingDataProp ?
+        !shallowequal(this.props.data, nextProps.data) :
+        (this.props.data.length !== nextProps.data.length ||
+         nextProps.data.some((d, i) =>
+          !shallowequal(this.props.data[i], d) ||
+          (this.props.nullAccessor(d) !== nextProps.nullAccessor(d))))
+    );
   }
 
   _renderCircle(d, i, strokeWidth, style) {

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -1439,7 +1439,7 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
 
 create-react-class@^15.5.2:
   version "15.6.2"
-  resolved "https://unpm.uberinternal.com/create-react-class/-/create-react-class-15.6.2.tgz#cf1ed15f12aad7f14ef5f2dfe05e6c42f91ef02a"
+  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.2.tgz#cf1ed15f12aad7f14ef5f2dfe05e6c42f91ef02a"
   dependencies:
     fbjs "^0.8.9"
     loose-envify "^1.3.1"
@@ -1596,7 +1596,7 @@ currently-unhandled@^0.4.1:
 
 d3-array@1, d3-array@^1.1.1, d3-array@^1.2.0:
   version "1.2.1"
-  resolved "https://unpm.uberinternal.com/d3-array/-/d3-array-1.2.1.tgz#d1ca33de2f6ac31efadb8e050a021d7e2396d5dc"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.1.tgz#d1ca33de2f6ac31efadb8e050a021d7e2396d5dc"
 
 d3-collection@1, d3-collection@^1.0.3:
   version "1.0.4"
@@ -1608,7 +1608,7 @@ d3-color@1, d3-color@^1.0.3:
 
 d3-contour@^1.1.0:
   version "1.1.1"
-  resolved "https://unpm.uberinternal.com/d3-contour/-/d3-contour-1.1.1.tgz#2fc79994c13437dfa8fdaf22ced8cd1468f81a24"
+  resolved "https://registry.yarnpkg.com/d3-contour/-/d3-contour-1.1.1.tgz#2fc79994c13437dfa8fdaf22ced8cd1468f81a24"
   dependencies:
     d3-array "^1.1.1"
 
@@ -1627,27 +1627,27 @@ d3-force@^1.0.6:
 
 d3-format@1, d3-format@^1.2.0:
   version "1.2.0"
-  resolved "https://unpm.uberinternal.com/d3-format/-/d3-format-1.2.0.tgz#6b480baa886885d4651dc248a8f4ac9da16db07a"
+  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.2.0.tgz#6b480baa886885d4651dc248a8f4ac9da16db07a"
 
 d3-geo@^1.6.4:
   version "1.7.1"
-  resolved "https://unpm.uberinternal.com/d3-geo/-/d3-geo-1.7.1.tgz#44bbc7a218b1fd859f3d8fd7c443ca836569ce99"
+  resolved "https://registry.yarnpkg.com/d3-geo/-/d3-geo-1.7.1.tgz#44bbc7a218b1fd859f3d8fd7c443ca836569ce99"
   dependencies:
     d3-array "1"
 
 d3-hierarchy@^1.1.4:
   version "1.1.5"
-  resolved "https://unpm.uberinternal.com/d3-hierarchy/-/d3-hierarchy-1.1.5.tgz#a1c845c42f84a206bcf1c01c01098ea4ddaa7a26"
+  resolved "https://registry.yarnpkg.com/d3-hierarchy/-/d3-hierarchy-1.1.5.tgz#a1c845c42f84a206bcf1c01c01098ea4ddaa7a26"
 
 d3-interpolate@1, d3-interpolate@^1.1.4:
   version "1.1.5"
-  resolved "https://unpm.uberinternal.com/d3-interpolate/-/d3-interpolate-1.1.5.tgz#69e099ff39214716e563c9aec3ea9d1ea4b8a79f"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-1.1.5.tgz#69e099ff39214716e563c9aec3ea9d1ea4b8a79f"
   dependencies:
     d3-color "1"
 
 d3-path@1:
   version "1.0.5"
-  resolved "https://unpm.uberinternal.com/d3-path/-/d3-path-1.0.5.tgz#241eb1849bd9e9e8021c0d0a799f8a0e8e441764"
+  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-1.0.5.tgz#241eb1849bd9e9e8021c0d0a799f8a0e8e441764"
 
 d3-quadtree@1:
   version "1.0.3"
@@ -1659,7 +1659,7 @@ d3-random@^1.1.0:
 
 d3-sankey@^0.7.1:
   version "0.7.1"
-  resolved "https://unpm.uberinternal.com/d3-sankey/-/d3-sankey-0.7.1.tgz#d229832268fc69a7fec84803e96c2256a614c521"
+  resolved "https://registry.yarnpkg.com/d3-sankey/-/d3-sankey-0.7.1.tgz#d229832268fc69a7fec84803e96c2256a614c521"
   dependencies:
     d3-array "1"
     d3-collection "1"
@@ -1667,7 +1667,7 @@ d3-sankey@^0.7.1:
 
 d3-scale@^1.0.5:
   version "1.0.6"
-  resolved "https://unpm.uberinternal.com/d3-scale/-/d3-scale-1.0.6.tgz#bce19da80d3a0cf422c9543ae3322086220b34ed"
+  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-1.0.6.tgz#bce19da80d3a0cf422c9543ae3322086220b34ed"
   dependencies:
     d3-array "^1.2.0"
     d3-collection "1"
@@ -1679,19 +1679,19 @@ d3-scale@^1.0.5:
 
 d3-shape@^1.1.0, d3-shape@^1.2.0:
   version "1.2.0"
-  resolved "https://unpm.uberinternal.com/d3-shape/-/d3-shape-1.2.0.tgz#45d01538f064bafd05ea3d6d2cb748fd8c41f777"
+  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-1.2.0.tgz#45d01538f064bafd05ea3d6d2cb748fd8c41f777"
   dependencies:
     d3-path "1"
 
 d3-time-format@2:
   version "2.0.5"
-  resolved "https://unpm.uberinternal.com/d3-time-format/-/d3-time-format-2.0.5.tgz#9d7780204f7c9119c9170b1a56db4de9a8af972e"
+  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-2.0.5.tgz#9d7780204f7c9119c9170b1a56db4de9a8af972e"
   dependencies:
     d3-time "1"
 
 d3-time@1:
   version "1.0.7"
-  resolved "https://unpm.uberinternal.com/d3-time/-/d3-time-1.0.7.tgz#94caf6edbb7879bb809d0d1f7572bc48482f7270"
+  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-1.0.7.tgz#94caf6edbb7879bb809d0d1f7572bc48482f7270"
 
 d3-timer@1:
   version "1.0.7"
@@ -1699,7 +1699,7 @@ d3-timer@1:
 
 d3-voronoi@^1.1.2:
   version "1.1.2"
-  resolved "https://unpm.uberinternal.com/d3-voronoi/-/d3-voronoi-1.1.2.tgz#1687667e8f13a2d158c80c1480c5a29cb0d8973c"
+  resolved "https://registry.yarnpkg.com/d3-voronoi/-/d3-voronoi-1.1.2.tgz#1687667e8f13a2d158c80c1480c5a29cb0d8973c"
 
 d@1:
   version "1.0.0"
@@ -2330,7 +2330,7 @@ faye-websocket@~0.11.0:
 
 fbjs@^0.8.16:
   version "0.8.16"
-  resolved "https://unpm.uberinternal.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
   dependencies:
     core-js "^1.0.0"
     isomorphic-fetch "^2.1.1"
@@ -4093,7 +4093,7 @@ performance-now@^0.2.0:
 
 performance-now@^2.1.0:
   version "2.1.0"
-  resolved "https://unpm.uberinternal.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
+  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
 
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
@@ -4455,7 +4455,7 @@ prop-types@^15.5.10, prop-types@^15.5.4:
 
 prop-types@^15.5.8:
   version "15.6.0"
-  resolved "https://unpm.uberinternal.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.3.1"
@@ -4531,7 +4531,7 @@ querystringify@~1.0.0:
 
 raf@^3.1.0:
   version "3.3.2"
-  resolved "https://unpm.uberinternal.com/raf/-/raf-3.3.2.tgz#0c13be0b5b49b46f76d6669248d527cf2b02fe27"
+  resolved "https://registry.yarnpkg.com/raf/-/raf-3.3.2.tgz#0c13be0b5b49b46f76d6669248d527cf2b02fe27"
   dependencies:
     performance-now "^2.1.0"
 
@@ -4603,7 +4603,7 @@ react-icons@^2.2.5:
 
 react-motion@^0.4.8:
   version "0.4.8"
-  resolved "https://unpm.uberinternal.com/react-motion/-/react-motion-0.4.8.tgz#23bb2dd27c2d8e00d229e45572d105efcf40a35e"
+  resolved "https://registry.yarnpkg.com/react-motion/-/react-motion-0.4.8.tgz#23bb2dd27c2d8e00d229e45572d105efcf40a35e"
   dependencies:
     create-react-class "^15.5.2"
     performance-now "^0.2.0"
@@ -4660,14 +4660,14 @@ react-router@^4.1.1, react-router@^4.1.2, react-router@^4.2.0:
 
 react-test-renderer@^15.5.4:
   version "15.6.2"
-  resolved "https://unpm.uberinternal.com/react-test-renderer/-/react-test-renderer-15.6.2.tgz#d0333434fc2c438092696ca770da5ed48037efa8"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-15.6.2.tgz#d0333434fc2c438092696ca770da5ed48037efa8"
   dependencies:
     fbjs "^0.8.9"
     object-assign "^4.1.0"
 
 react-vis@^1.7.7:
   version "1.7.7"
-  resolved "https://unpm.uberinternal.com/react-vis/-/react-vis-1.7.7.tgz#728c1d88b54c982279ad0bd2b4cd21ce78581f52"
+  resolved "https://registry.yarnpkg.com/react-vis/-/react-vis-1.7.7.tgz#728c1d88b54c982279ad0bd2b4cd21ce78581f52"
   dependencies:
     d3-array "^1.2.0"
     d3-collection "^1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4272,6 +4272,10 @@ sha.js@^2.4.0, sha.js@^2.4.8, sha.js@~2.4.4:
   dependencies:
     inherits "^2.0.1"
 
+shallowequal@^1.0.2:
+  version "1.0.2"
+  resolved "https://unpm.uberinternal.com/shallowequal/-/shallowequal-1.0.2.tgz#1561dbdefb8c01408100319085764da3fcf83f8f"
+
 shasum@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/shasum/-/shasum-1.0.2.tgz#e7012310d8f417f4deb5712150e5678b87ae565f"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4274,7 +4274,7 @@ sha.js@^2.4.0, sha.js@^2.4.8, sha.js@~2.4.4:
 
 shallowequal@^1.0.2:
   version "1.0.2"
-  resolved "https://unpm.uberinternal.com/shallowequal/-/shallowequal-1.0.2.tgz#1561dbdefb8c01408100319085764da3fcf83f8f"
+  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.0.2.tgz#1561dbdefb8c01408100319085764da3fcf83f8f"
 
 shasum@^1.0.0:
   version "1.0.2"


### PR DESCRIPTION
## Prompt
Improve rerendering performance of `MarkSeries` component by using `shouldComponentUpdate`

## Problem
The `MarkSeries` component receives several props of type function (`onNearestX`, `onNearestXY`, etc.). If these functions are called, the `MarkSeries` component will automatically rerender all datapoints by mapping `this._renderCircle` on them, regardless if the change is necessary.

## Proposal
Only rerender when props affecting the view are changed. 

## Before and After
### Before
![kapture 2017-11-13 at 11 29 13-min](https://user-images.githubusercontent.com/6504944/32745040-637df00c-c866-11e7-9311-8f0a8383a9c0.gif)

### After
![kapture 2017-11-13 at 10 48 02-min](https://user-images.githubusercontent.com/6504944/32743765-399e6a90-c862-11e7-93d3-737a13012ebd.gif)


