### PR TITLE
fix for refs being null with JEST

### DIFF
--- a/src/make-vis-flexible.js
+++ b/src/make-vis-flexible.js
@@ -123,7 +123,7 @@ function makeFlexible(Component, isWidthFlexible, isHeightFlexible) {
      * @private
      */
     _onResize() {
-      const containerElement = getDOMNode(this.refs[CONTAINER_REF]);
+      const containerElement = getDOMNode(this.refs[CONTAINER_REF]) || {};
       const {offsetHeight, offsetWidth} = containerElement;
 
       const newHeight = this.state.height === offsetHeight ? {} :


### PR DESCRIPTION
I'm using snapshot testing with JEST and because refs are not being recognized by JEST => containerElement is undefined, and I can't use the components in snapshot testing because on line 127, it will try to access offsetHeight & offsetWidth on an undefined element. So this was my fix for this problem.

If i do it like this, snapshot works!