### PR TITLE
Refactor getOptionalScaleProps, add tests, IE11 support

### DIFF
--- a/src/plot/xy-plot.js
+++ b/src/plot/xy-plot.js
@@ -22,7 +22,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import equal from 'deep-equal';
 
-import {extractScalePropsFromProps, getMissingScaleProps, getXYPlotValues} from 'utils/scales-utils';
+import {
+  extractScalePropsFromProps,
+  getMissingScaleProps,
+  getOptionalScaleProps,
+  getXYPlotValues
+} from 'utils/scales-utils';
 import {getStackedData, getSeriesChildren, getSeriesPropsFromChildren} from 'utils/series-utils';
 import {getInnerDimensions, MarginPropType} from 'utils/chart-utils';
 import {checkIfStyleSheetIsImported} from 'utils/react-utils';
@@ -47,8 +52,6 @@ const ATTRIBUTES = [
   'opacity',
   'size'
 ];
-
-const OPTIONAL_SCALE_PROPS = ['Padding'];
 
 const DEFAULT_MARGINS = {
   left: 40,
@@ -281,21 +284,6 @@ class XYPlot extends React.Component {
   }
 
   /**
-   * Get the list of optional scale-related settings
-   * @param {Object} props Object of props.
-   * @returns {Object} Optional Props.
-   * @private
-   */
-  _getOptionalScaleProps(props) {
-    return Object.keys(props)
-      .filter(prop => OPTIONAL_SCALE_PROPS.map(option => prop.endsWith(option)).every(x => x))
-      .reduce((obj, key) => {
-        obj[key] = props[key];
-        return obj;
-      }, {});
-  }
-
-  /**
    * Get the map of scales from the props, apply defaults to them and then pass
    * them further.
    * @param {Object} data Array of all data.
@@ -309,7 +297,7 @@ class XYPlot extends React.Component {
     const allData = [].concat(...filteredData);
 
     const defaultScaleProps = this._getDefaultScaleProps(props);
-    const optionalScaleProps = this._getOptionalScaleProps(props);
+    const optionalScaleProps = getOptionalScaleProps(props);
     const userScaleProps = extractScalePropsFromProps(props, ATTRIBUTES);
     const missingScaleProps = getMissingScaleProps({
       ...defaultScaleProps,

--- a/src/utils/scales-utils.js
+++ b/src/utils/scales-utils.js
@@ -784,6 +784,27 @@ export function getXYPlotValues(props, children) {
   );
 }
 
+const OPTIONAL_SCALE_PROPS = ['Padding'];
+const OPTIONAL_SCALE_PROPS_REGS = OPTIONAL_SCALE_PROPS.map(str => new RegExp(`${str}$`, 'i'));
+/**
+ * Get the list of optional scale-related settings for XYPlot
+ * mostly just used to find padding properties
+ * @param {Object} props Object of props.
+ * @returns {Object} Optional Props.
+ * @private
+ */
+export function getOptionalScaleProps(props) {
+  return Object.keys(props)
+    .reduce((acc, prop) => {
+      const propIsNotOptional = OPTIONAL_SCALE_PROPS_REGS.every(reg => !prop.match(reg));
+      if (propIsNotOptional) {
+        return acc;
+      }
+      acc[prop] = props[prop];
+      return acc;
+    }, {});
+}
+
 export default {
   extractScalePropsFromProps,
   getAttributeScale,
@@ -793,6 +814,7 @@ export default {
   getDomainByAttr,
   getFontColorFromBackground,
   getMissingScaleProps,
+  getOptionalScaleProps,
   getScaleObjectFromProps,
   getScalePropTypesByAttribute,
   getXYPlotValues,

--- a/tests/utils/scales-utils-tests.js
+++ b/tests/utils/scales-utils-tests.js
@@ -28,6 +28,7 @@ import {
   getAttributeScale,
   getAttributeValue,
   getFontColorFromBackground,
+  getOptionalScaleProps,
   getXYPlotValues,
   _getSmallestDistanceIndex,
   getScaleFnFromScaleObject,
@@ -444,5 +445,14 @@ test('scales-utils #_adjustCategoricalScale', t => {
   }].forEach(({scale, distance}) => {
     t.deepEqual(_adjustCategoricalScale(scale), {...scale, distance}, 'should correctly adjust a categorical scale');
   });
+  t.end();
+});
+
+test('scale-utils #getOptionalScaleProps', t => {
+  const foundProps = getOptionalScaleProps({node: 1, x: 2, margins: 4});
+  t.deepEqual(foundProps, {}, 'should not find any non-padding optional props');
+
+  const paddingProps = getOptionalScaleProps({node: 1, x: 2, margins: 4, coolDogExplosionPadding: 10});
+  t.deepEqual(paddingProps, {coolDogExplosionPadding: 10}, 'should find only padding optional props');
   t.end();
 });


### PR DESCRIPTION
This PR addresses #663 by refactoring getOptioanlScaleProps into a little less cutting edge state, and pulling it into a utils file. In it's current state this function seems kinda unnesscary, like it seems like a lot of overkill just to test for the presence of a padding prop, but that's not the point of this PR. The point of this PR is to unbreak this function on IE11.