### PR TITLE
Prevent Firefox from crashing if styleSheet doesn't get parsed fast enough. (Local development)

### DIFF
--- a/src/utils/react-utils.js
+++ b/src/utils/react-utils.js
@@ -86,7 +86,11 @@ function getCSSRules(styleSheet) {
       styleSheet.ownerNode.href &&
       styleSheet.ownerNode.href.startsWith(document.location.origin))
   ) {
-    return styleSheet.rules || styleSheet.cssRules;
+    try {
+      return styleSheet.rules || styleSheet.cssRules;
+    } catch (err) {
+      return [];
+    }
   }
   return [];
 }


### PR DESCRIPTION
In some cases when `npm start` is executed for local development, the 
`return styleSheet.rules || styleSheet.cssRules;` line will cause Firefox to crash with the issue presented below.

![firefox-crash](https://user-images.githubusercontent.com/16089710/33282048-4784b81a-d39f-11e7-818d-caa197205c34.png)

This happens when `checkIfStyleSheetIsImported();` is called in `XYPlot` class. 

What's interesting is that if any kind of a blocking call is added above the offending line, such as `alert()`, the page loads just fine, which leads me to believe that the `styleSheets` might not be parsed fast enough and it's property `cssRules` is accessed before that happens.

Possibly relevant bugs:
[https://bugzilla.mozilla.org/show_bug.cgi?id=625013](url) 
[https://bugzilla.mozilla.org/show_bug.cgi?id=761236](url)

However, as these were reported 6 years ago and no progress has been made since, I don't think that this is ever going to get fixed by Mozilla.

This small patch fixes the issue. If anyone has other ideas/solutions, you're welcome to post them.