### PR TITLE
Modified getStackData function to also work with partial data

### DIFF
--- a/src/utils/series-utils.js
+++ b/src/utils/series-utils.js
@@ -130,7 +130,7 @@ export function getStackedData(children, attr) {
     const baseAttr = attr === 'y' ? 'x' : 'y';
 
     accumulator.push(preppedData.map((d, dIndex) => {
-      if (!(cluster in latestAttrPositions)) {
+      if (!latestAttrPositions[cluster]) {
         latestAttrPositions[cluster] = {};
       }
 

--- a/src/utils/series-utils.js
+++ b/src/utils/series-utils.js
@@ -108,10 +108,13 @@ function prepareData(data) {
  * @returns {Array} New array of children for the series.
  */
 export function getStackedData(children, attr) {
+  // It stores the last segment position added to each bar, separated by cluster.
+  const latestAttrPositions = {};
+
   return children.reduce((accumulator, series, seriesIndex) => {
     // Skip the children that are not series (e.g. don't have any data).
     if (!series) {
-      accumulator.result.push(null);
+      accumulator.push(null);
       return accumulator;
     }
 
@@ -119,33 +122,46 @@ export function getStackedData(children, attr) {
     const preppedData = prepareData(data, attr);
 
     if (!attr || !preppedData || !preppedData.length) {
-      accumulator.result.push(preppedData);
+      accumulator.push(preppedData);
       return accumulator;
     }
 
     const attr0 = `${attr}0`;
+    const baseAttr = attr === 'y' ? 'x' : 'y';
 
-    accumulator.result.push(preppedData.map((d, dIndex) => {
-      // In case if it's the first series don't try to override any values.
-      if (!accumulator.seriesPointers[cluster]) {
+    accumulator.push(preppedData.map((d, dIndex) => {
+      if (!(cluster in latestAttrPositions)) {
+        latestAttrPositions[cluster] = {};
+      }
+
+      const prevD = latestAttrPositions[cluster][d[baseAttr]];
+      // It is the first segment of a bar.
+      if (!prevD) {
+        latestAttrPositions[cluster][d[baseAttr]] = {
+          [attr0]: d[attr0],
+          [attr]: d[attr]
+        };
+
         return {...d};
       }
-      // get the previous series in this cluster
-      const prevSeries = accumulator.seriesPointers[cluster].slice().pop();
-      // get the previous data point in that series
-      const prevD = accumulator.result[prevSeries][dIndex];
-      return {
+
+      // Calculate the position of the next segment in a bar.
+      const nextD = {
         ...d,
         [attr0]: prevD[attr],
         [attr]: prevD[attr] + d[attr] - (d[attr0] || 0)
       };
+
+      latestAttrPositions[cluster][d[baseAttr]] = {
+        [attr0]: nextD[attr0],
+        [attr]: nextD[attr]
+      };
+
+      return nextD;
     }));
-    accumulator.seriesPointers[cluster] = (accumulator.seriesPointers[cluster] || []).concat([seriesIndex]);
+
     return accumulator;
-  }, {
-    result: [],
-    seriesPointers: {}
-  }).result;
+  }, []);
 }
 
 /**


### PR DESCRIPTION
I just created a PR so we can further discuss the code. I am not sure if I misunderstand something, but the tests fail while the changes render the example stacked charts nicely. It also works well with a bunch of data on my project (gives the result I have shown in the Issue). 

I am not sure if there is a difference between VerticalBarSeries and HorizontalBarSeries regarding the stackBy value, but from my understanding setting stackBy='y' on HorizontalBarSeries doesn't make much sense, thus the following test code will not work correctly:
```
 let children = [
    (<HorizontalBarSeries
      data={yData[0]}
    />),
    (<HorizontalBarSeries
      data={yData[1]}/>),
    (<div> i think i will by that lamp </div>)
  ];
  let results = getStackedData(children, 'y');
  let expectedResults = [[
    {x: 10, y: 2},
    {x: 5, y: 4},
    {x: 15, y: 5}
  ], [
    {x: 12, y: 4, y0: 2},
    {x: 2, y: 8, y0: 4},
    {x: 11, y: 10, y0: 5}
  ], undefined];
```
It is also weird how the HorizontalBarSeries is imported.

```
import HorizontalBarSeries from 'plot/series/vertical-rect-series';
```

As nothing is rendered and basically HorizontalBarSeries is used just as a plain object, we can ignore that. Still, to me it seems that the tests are wrong, and the above test should instead be: 

```
   let children = [
    (<HorizontalBarSeries
      data={xData[0]}
    />),
    (<HorizontalBarSeries
      data={xData[1]}/>),
    (<div> i think i will by that lamp </div>)
  ];
  let results = getStackedData(children, 'y');
  let expectedResults = [[
   {x: 2, y: 10},
   {x: 4, y: 5},
   {x: 5, y: 15}
  ], [
   {x: 2, y: 22, y0: 10},
   {x: 4, y: 7, y0: 5},
   {x: 5, y: 26, y0: 15}
  ], undefined];
```

This applies to all the tests for getStackedData. It is possible that I haven't understood the use case well, so I will be waiting for any of the maintainers' discussion.