### PR TITLE
Avoid process reference error

### DIFF
--- a/src/utils/react-utils.js
+++ b/src/utils/react-utils.js
@@ -100,7 +100,7 @@ function getCSSRules(styleSheet) {
 const MAGIC_CSS_RULE = '.react-vis-magic-css-import-rule';
 export function checkIfStyleSheetIsImported() {
   /* eslint-disable no-undef, no-process-env */
-  if (process && HIDDEN_PROCESSES[process.env.NODE_ENV]) {
+  if (global.process && HIDDEN_PROCESSES[process.env.NODE_ENV]) {
     return;
   }
   /* eslint-enable no-undef, no-process-env */


### PR DESCRIPTION
In browser render this was erroring: 

```
VM469 client-vendor.js:68616 Uncaught ReferenceError: process is not defined
    at checkIfStyleSheetIsImported (VM469 client-vendor.js:68616)
    at XYPlot.componentDidMount (VM469 client-vendor.js:65809)
    at commitLifeCycles (VM469 client-vendor.js:46266)
```