### PR TITLE
[Documentation] Fix reference to CSS styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Install react-vis via npm.
 
 Include the built main CSS file in your HTML page or via SASS:
 ```sass
-@import "./node_modules/react-vis/dist/style";
+@import "./node_modules/react-vis/dist/styles";
 ```
 
 You can also select only the styles you want to use. This helps minimize the size of the outputted CSS. Here's an example of importing only the legends styles:


### PR DESCRIPTION
The scss files are located under `styles`, not `style`