### PR TITLE
Expose `className` prop on Crosshair component and update docs

### DIFF
--- a/docs/crosshair.md
+++ b/docs/crosshair.md
@@ -15,22 +15,26 @@ In case if custom representation of crosshair is needed, the component is able t
 </Crosshair>
 ```
 
+#### className (optional)
+Type: `string`
+Provide an additional class name for the series.
+
 #### values
-Type: `Array<Object>`  
+Type: `Array<Object>`
 The array of data points to show the crosshair at. Crosshair will automatically align to the horizontal position of the points passed there.
 
 #### titleFormat (optional)
-Type: `function`  
-The function that formats the title for the crosshair. Receives the list of data points, should return an object containing `title` and `value` properties.  
+Type: `function`
+The function that formats the title for the crosshair. Receives the list of data points, should return an object containing `title` and `value` properties.
 _Note: please pass custom contents in case if you need different look for the crosshair._
 
 #### itemsFormat (optional)
-Type: `function`  
-The function that formats the list of items for the crosshair. Receives the list of data points, should return an array of objects containing `title` and `value` properties.  
+Type: `function`
+The function that formats the list of items for the crosshair. Receives the list of data points, should return an array of objects containing `title` and `value` properties.
 _Note: please pass custom contents in case if you need different look for the crosshair._
 
 ### style (optional)
-Type: `object`  
+Type: `object`
 An object that contains objects of CSS properties with which the component can be entirely re-styled.
 As the Crosshair is composed of several elements, it is possible to provide style objects for any and all parts of the tree. See [style](style.md)
 Most generally, there are three top level keys: `line`, `title`, and `box`. These in turn lead to their corresponding style objects.

--- a/docs/crosshair.md
+++ b/docs/crosshair.md
@@ -19,15 +19,6 @@ In case if custom representation of crosshair is needed, the component is able t
 Type: `string`
 Provide an additional class name for the series.
 
-#### values
-Type: `Array<Object>`
-The array of data points to show the crosshair at. Crosshair will automatically align to the horizontal position of the points passed there.
-
-#### titleFormat (optional)
-Type: `function`
-The function that formats the title for the crosshair. Receives the list of data points, should return an object containing `title` and `value` properties.
-_Note: please pass custom contents in case if you need different look for the crosshair._
-
 #### itemsFormat (optional)
 Type: `function`
 The function that formats the list of items for the crosshair. Receives the list of data points, should return an array of objects containing `title` and `value` properties.
@@ -38,3 +29,12 @@ Type: `object`
 An object that contains objects of CSS properties with which the component can be entirely re-styled.
 As the Crosshair is composed of several elements, it is possible to provide style objects for any and all parts of the tree. See [style](style.md)
 Most generally, there are three top level keys: `line`, `title`, and `box`. These in turn lead to their corresponding style objects.
+
+#### titleFormat (optional)
+Type: `function`
+The function that formats the title for the crosshair. Receives the list of data points, should return an object containing `title` and `value` properties.
+_Note: please pass custom contents in case if you need different look for the crosshair._
+
+#### values
+Type: `Array<Object>`
+The array of data points to show the crosshair at. Crosshair will automatically align to the horizontal position of the points passed there.

--- a/showcase/axes/dynamic-crosshair.js
+++ b/showcase/axes/dynamic-crosshair.js
@@ -87,7 +87,7 @@ export default class DynamicCrosshair extends React.Component {
           data={DATA[0]}/>
         <LineSeries
           data={DATA[1]}/>
-        <Crosshair values={this.state.crosshairValues}/>
+        <Crosshair values={this.state.crosshairValues} className={'test-class-name'}/>
       </XYPlot>
     );
   }

--- a/src/plot/crosshair.js
+++ b/src/plot/crosshair.js
@@ -65,6 +65,7 @@ class Crosshair extends PureComponent {
 
   static get propTypes() {
     return {
+      className: PropTypes.string,
       values: PropTypes.array,
       series: PropTypes.object,
       innerWidth: PropTypes.number,
@@ -139,6 +140,7 @@ class Crosshair extends PureComponent {
   render() {
     const {
       children,
+      className,
       values,
       marginTop,
       marginLeft,
@@ -160,7 +162,7 @@ class Crosshair extends PureComponent {
 
     return (
       <div
-        className="rv-crosshair"
+        className={`rv-crosshair ${className}`}
         style={{left: `${left}px`, top: `${top}px`}}>
 
         <div

--- a/tests/components/crosshair-tests.js
+++ b/tests/components/crosshair-tests.js
@@ -1,0 +1,17 @@
+import test from 'tape';
+import React from 'react';
+import {mount} from 'enzyme';
+
+import DynamicCrosshair from '../../showcase/axes/dynamic-crosshair';
+
+test.only('Crosshair: Dynamic Crosshair exmaple', t => {
+  const $ = mount(<DynamicCrosshair />);
+  simulateMouseMove(100);
+  t.equal($.find('.rv-crosshair').hasClass('test-class-name'), true, 'should find the class name passed as a prop');
+  t.end();
+
+  function simulateMouseMove(x) {
+    $.find('.rv-xy-plot__inner')
+      .simulate('mousemove', {nativeEvent: {clientX: x, clientY: 150}});
+  }
+});

--- a/tests/components/crosshair-tests.js
+++ b/tests/components/crosshair-tests.js
@@ -4,7 +4,7 @@ import {mount} from 'enzyme';
 
 import DynamicCrosshair from '../../showcase/axes/dynamic-crosshair';
 
-test.only('Crosshair: Dynamic Crosshair exmaple', t => {
+test('Crosshair: Dynamic Crosshair exmaple', t => {
   const $ = mount(<DynamicCrosshair />);
   simulateMouseMove(100);
   t.equal($.find('.rv-crosshair').hasClass('test-class-name'), true, 'should find the class name passed as a prop');

--- a/tests/index.js
+++ b/tests/index.js
@@ -39,6 +39,7 @@ import './components/canvas-component-tests';
 import './components/circular-grid-lines-tests';
 import './components/color-article-tests';
 import './components/contour-series-tests';
+import './components/crosshair-tests';
 import './components/custom-svg-series-tests';
 import './components/data-article-tests';
 import './components/decorative-axis-tests';


### PR DESCRIPTION
For apps that use inline styles, the cross does not get positioned correctly because the crosshair is positioned absolutely. Expose `className` on this component so that applications using inline styles can hook into this component