### PR TITLE
Avoid process reference error

### DIFF
--- a/src/utils/react-utils.js
+++ b/src/utils/react-utils.js
@@ -52,7 +52,7 @@ const HIDDEN_PROCESSES = {
  */
 export function warning(message, onlyShowMessageOnce = false) {
   /* eslint-disable no-undef, no-process-env */
-  if (process && HIDDEN_PROCESSES[process.env.NODE_ENV]) {
+  if (global.process && HIDDEN_PROCESSES[process.env.NODE_ENV]) {
     return;
   }
   /* eslint-enable no-undef, no-process-env */


### PR DESCRIPTION
Seems the typo in code. Similar issue was fixed here: #726

Exception output:

```
Uncaught (in promise) ReferenceError: process is not defined
    at warning (react-utils.js:75)
    at warnOnce (react-utils.js:92)
    at checkIfStyleSheetIsImported (react-utils.js:132)
    at XYPlot.componentDidMount (xy-plot.js:165)
    at eval (ReactCompositeComponent.js:262)
    at measureLifeCyclePerf (ReactCompositeComponent.js:73)
    at eval (ReactCompositeComponent.js:261)
    at CallbackQueue.notifyAll (CallbackQueue.js:74)
    at ReactReconcileTransaction.close (ReactReconcileTransaction.js:78)
    at ReactReconcileTransaction.closeAll (Transaction.js:207)
```