### PR TITLE
Implement touch behaviors

### DIFF
--- a/docs/interaction.md
+++ b/docs/interaction.md
@@ -2,7 +2,7 @@
 
 Interaction in react-vis happens through _event handlers_ which are triggered by certain interactive events, such as mouse movement or clicks.
 
-These events can be implemented either at the XYPlot level or at the plot level:  
+These events can be implemented either at the XYPlot level or at the plot level:
 * At the plot level: this is for events that affect the whole chart. The mouse events that can be captured are: down, enter, leave, move. For instance, you can use `onMouseLeave` to reset the visualization when the user's mouse cursor is no longer on it.
 
 * At the series level, there are three kind of handlers.
@@ -44,33 +44,49 @@ In all cases, onNearestX and onNearestXY can be implemented at the series level,
 ### XYPlot event handlers
 
 ### onMouseDown
-Type: `function`  
-Default: none  
+Type: `function`
+Default: none
 This event handler is triggered whenever the mousebutton of the user is down while their mouse cursor is in the plot area. It passes a mouse event.
 
 ### onMouseEnter
-Type: `function`  
-Default: none  
+Type: `function`
+Default: none
 This event handler is triggered whenever the mouse of the user enters the plot area. It passes a mouse event.
 
 ### onMouseLeave
-Type: `function`  
-Default: none  
+Type: `function`
+Default: none
 This event handler is triggered whenever the mouse of the user exits the plot area. It passes a mouse event.
 
 ### onMouseMove
-Type: `function`  
-Default: none  
+Type: `function`
+Default: none
 This event handler is triggered whenever the mouse of the user moves while in the plot area. It passes a mouse event.
+
+### onTouchStart
+Type: `function`
+The event handler is triggered whenever the finger of the user first touches the plot area. It passes a touch event.
+
+### onTouchMove
+Type: `function`
+This event handler is triggered whenever the finger of the user moves while in the plot area. It passes a touch event.
+
+### onTouchEnd
+Type: `function`
+This event handler is triggered when a touch point of the user lifts off the plot area. It passes a touch event.
+
+### onTouchCancel
+Type: `function`
+This event handler is triggered when a touch point of the user has been disrupted in an implementation-specific manner
 
 ### Series event handlers
 
 #### onNearestX
-Type: `function`  
-Default: none  
-This handler fires when the user moves their mouse somewhere on the plot. The handler fires a function that takes two argument: the datapoint with the x value closest to the cursor, and a second object containing: the `innerX` value (x coordinates of the cursor relative to the left of the plot), `index` (position of this datapoint in the dataset, where 0 is the first datapoint, 1 is the second, etc) plus the actual event as `event`.
+Type: `function`
+Default: none
+This handler fires when the user moves their mouse somewhere on the plot. The handler fires a function that takes two argument: the datapoint with the x value closest to the cursor or touch point, and a second object containing: the `innerX` value (x coordinates of the cursor relative to the left of the plot), `index` (position of this datapoint in the dataset, where 0 is the first datapoint, 1 is the second, etc) plus the actual event as `event`.
 
-onNearestX is at the series level, not at the plot level. If you attach onNearestX to several series, each time the user moves their mouse, each onNearestX handler will be triggered once with the closest mark of each series.
+onNearestX is at the series level, not at the plot level. If you attach onNearestX to several series, each time the user moves their mouse or touch point, each onNearestX handler will be triggered once with the closest mark of each series.
 
 ```jsx
 <LineSeries
@@ -82,15 +98,15 @@ onNearestX is at the series level, not at the plot level. If you attach onNeares
 ```
 
 #### onNearestXY
-Type: `function`  
-Default: none  
-This handler is nearly identical to `onNearestX`. The difference is that it will return datapoint corresponding to the mark closest to the cursor, not just the one with the closest x coordinate.
+Type: `function`
+Default: none
+This handler is nearly identical to `onNearestX`. The difference is that it will return datapoint corresponding to the mark closest to the cursor or touch point, not just the one with the closest x coordinate.
 
 onNearestXY will supersede onNearestX, so if both exist for the same series, only onNearestXY will be fired.
 
-This handler fires when the user moves their mouse somewhere on the plot. The handler fires a function that takes two argument: the datapoint which is closest to the cursor, and a second object containing: the `innerX` and `innerY` value (x, y coordinates of the cursor relative to the top left of the plot), `index` (position of this datapoint in the dataset, where 0 is the first datapoint, 1 is the second, etc) plus the actual event as `event`.
+This handler fires when the user moves their mouse or touch point somewhere on the plot. The handler fires a function that takes two argument: the datapoint which is closest to the cursor or touch point, and a second object containing: the `innerX` and `innerY` value (x, y coordinates of the cursor or touch point relative to the top left of the plot), `index` (position of this datapoint in the dataset, where 0 is the first datapoint, 1 is the second, etc) plus the actual event as `event`.
 
-onNearestXY is at the series level, not at the plot level. If you attach onNearestX to several series, each time the user moves their mouse, each onNearestX handler will be triggered once with the closest mark of each series.
+onNearestXY is at the series level, not at the plot level. If you attach onNearestX to several series, each time the user moves their mouse or touch point, each onNearestX handler will be triggered once with the closest mark of each series.
 
 ```jsx
 <LineSeries
@@ -102,8 +118,8 @@ onNearestXY is at the series level, not at the plot level. If you attach onNeare
 ```
 
 #### onSeriesClick
-Type: `function`  
-Default: none  
+Type: `function`
+Default: none
 This handler fires when the user clicks somewhere on a series, and provides the corresponding event. Unlike onValueClick, it doesn't pass a specific datapoint.
 
 ```jsx
@@ -116,8 +132,8 @@ This handler fires when the user clicks somewhere on a series, and provides the 
 ```
 
 #### onSeriesRightClick
-Type: `function`  
-Default: none  
+Type: `function`
+Default: none
 This handler fires when the user right-clicks somewhere on a series, and provides the corresponding event. Unlike onValueRightClick, it doesn't pass a specific datapoint.
 
 ```jsx
@@ -131,8 +147,8 @@ This handler fires when the user right-clicks somewhere on a series, and provide
 
 
 #### onSeriesMouseOut
-Type: `function`  
-Default: none  
+Type: `function`
+Default: none
 This handler fires when the user's mouse cursor leaves a series, and provides the corresponding event. Unlike onValueMouseOut, it doesn't pass a specific datapoint.
 
 ```jsx
@@ -146,7 +162,7 @@ This handler fires when the user's mouse cursor leaves a series, and provides th
 
 #### onSeriesMouseOver
 Type: `function`
-Default: none  
+Default: none
 This handler fires when the user mouses over a series, and provides the corresponding event. Unlike onMouseOver, it doesn't pass a specific datapoint.
 
 ```jsx
@@ -159,8 +175,8 @@ This handler fires when the user mouses over a series, and provides the correspo
 ```
 
 #### onValueClick
-Type: `function`  
-Default: none  
+Type: `function`
+Default: none
 This handler is triggered either when the user clicks on a mark.
 The handler passes two arguments, the corresponding datapoint and the actual event.
 ```jsx
@@ -173,8 +189,8 @@ The handler passes two arguments, the corresponding datapoint and the actual eve
 ```
 
 #### onValueRightClick
-Type: `function`  
-Default: none  
+Type: `function`
+Default: none
 This handler is triggered either when the user right-clicks on a mark.
 The handler passes two arguments, the corresponding datapoint and the actual event.
 ```jsx
@@ -187,8 +203,8 @@ The handler passes two arguments, the corresponding datapoint and the actual eve
 ```
 
 #### onValueMouseOut
-Type: `function`  
-Default: none  
+Type: `function`
+Default: none
 This handler is triggered either when the user's mouse leaves a mark.
 The handler passes two arguments, the corresponding datapoint and the actual event.
 ```jsx
@@ -202,7 +218,7 @@ The handler passes two arguments, the corresponding datapoint and the actual eve
 
 #### onValueMouseOver
 Type: `function`
-Default: none  
+Default: none
 This handler is triggered either when the user's mouse enters a mark.
 The handler passes two arguments, the corresponding datapoint and the actual event.
 ```jsx
@@ -335,7 +351,7 @@ class LineChartMouseOverSeries extends Component {
   }
 }
 ```
-Here, we are going to explore 2 strategies to handle highlighting one line series among several on screen.  
+Here, we are going to explore 2 strategies to handle highlighting one line series among several on screen.
 We could do that with a simple onSeriesMouseOver but, again, that would require mousing over exactly on a line series, which are notoriously narrow.
 Instead, we create a second set of LineSeries whose only purpose is to handle interaction. That second set of LineSeries is thicker (here, the stroke width is set at a generous 10px) and is also transparent. In the embedded example, I'm highlighting each lineSeries as it is moused over, but I'm not reflecting this on the snippet of code.
 

--- a/docs/xy-plot.md
+++ b/docs/xy-plot.md
@@ -104,19 +104,19 @@ The TLDR here is that *ORDER MATTERS*! If you want the elements to appear in a d
 
 ### XYPlot
 
-`XYPlot` is a component that wraps series, axis and grids, hints, etc and seamlessly provides necessary dimensions, sizes and scales into its children.  
+`XYPlot` is a component that wraps series, axis and grids, hints, etc and seamlessly provides necessary dimensions, sizes and scales into its children.
 `XYPlot` may or may not contain axes, grids, hints, crosshairs or series.
 
 #### width
-Type: `number`  
+Type: `number`
 Width of the chart. The width should be passed.
 
 #### height
-Type: `number`  
+Type: `number`
 Height of the component. The height should be passed.
 
 #### className (optional)
-Type: `string`  
+Type: `string`
 DOM classNames to be added to the wrapper component.
 
 #### hasTreeStructure (optional)
@@ -124,17 +124,17 @@ Type: `Boolean`
 Flag declaring whether or not react-vis should try to remove potential cyclic deps from tree structures created by d3. Specifically references to "parent" are removed. This is generally used as an internal prop, checkout the treemap or sunburst if you are curious.
 
 #### margin (optional)
-Type: `Object`  
+Type: `Object`
 Default: `{left: 40, right: 10, top: 10, bottom: 40}`
 Margin around the chart.
 
 #### stackBy (optional)
-Type: `string`  
+Type: `string`
 Stack the chart by the given attribute. If the attribute is `y`, the chart is stacked vertically; if the attribute is `x` then it's stacked horizontally. See the [Series](series.md) API reference for series level stack opt-in.
 
 ### style (optional)
 Type: `object`
-CSS properties that will affect this wrapper component. Those will be applied to the SVG element in which other react-vis components will be created.  
+CSS properties that will affect this wrapper component. Those will be applied to the SVG element in which other react-vis components will be created.
 
 ```jsx
 <XYPlot
@@ -201,33 +201,49 @@ const seriesThree = [
 Will render beautifully!
 
 #### onClick (optional)
-Type: `function()`  
+Type: `function()`
 The function that is triggered each time the mouse clicks the component.
 
 #### onDoubleClick (optional)
-Type: `function()`  
+Type: `function()`
 The function that is triggered each time the mouse double-clicks the component.
 
 #### onMouseLeave (optional)
-Type: `function()`  
+Type: `function()`
 The function that is triggered each time the mouse leaves the component.
 
 #### onMouseMove (optional)
-Type: `function()`  
+Type: `function()`
 The function that is triggered each time mouse moves over at the component.
 
 #### onMouseEnter (optional)
-Type: `function()`  
+Type: `function()`
 The function that is triggered each time the mouse enters the component.
 
+#### onTouchStart (optional)
+Type: `function()`
+The function that is triggered each time the touch starts.
+
+#### onTouchMove (optional)
+Type: `function()`
+The function that is triggered each time the touch moves.
+
+#### onTouchEnd (optional)
+Type: `function()`
+The function that is triggered each time the touch ends.
+
+#### onTouchCancel (optional)
+Type: `function()`
+The function that is triggered each time the touch cancels.
+
 #### onWheel (optional)
-Type: `function()`  
+Type: `function()`
 The function that is triggered each time a wheel button is rotated on the component.
 
 #### animation (optional)
 Type: `{duration: number}|boolean`
-Default: `false`  
-Animation config, which is automatically passed to all children, but can be overridden for the each child.  
-If `false` is passed, then the child components *will not be* animated.  
-If `true` is passed then the child components *will be* animated with the default settings.  
+Default: `false`
+Animation config, which is automatically passed to all children, but can be overridden for the each child.
+If `false` is passed, then the child components *will not be* animated.
+If `true` is passed then the child components *will be* animated with the default settings.
 If an object is passed, then the child components *will be* animated with the given settings.

--- a/showcase/examples/zoomable-chart/highlight.js
+++ b/showcase/examples/zoomable-chart/highlight.js
@@ -36,7 +36,11 @@ export default class Highlight extends AbstractSeries {
 
   onParentMouseDown(e) {
     const {marginLeft, innerHeight, onBrushStart} = this.props;
-    const location = e.nativeEvent.offsetX - marginLeft;
+    let offsetX = e.nativeEvent.offsetX;
+    if (e.nativeEvent.type === 'touchstart') {
+      offsetX = e.nativeEvent.pageX;
+    }
+    const location = offsetX - marginLeft;
 
     // TODO: Eventually support drawing as a full rectangle, if desired. Currently the code supports 'x' only
     this.setState({
@@ -53,6 +57,11 @@ export default class Highlight extends AbstractSeries {
     if (onBrushStart) {
       onBrushStart(e);
     }
+  }
+
+  onParentTouchStart(e) {
+    e.preventDefault();
+    this.onParentMouseDown(e);
   }
 
   stopDrawing() {
@@ -95,7 +104,11 @@ export default class Highlight extends AbstractSeries {
   onParentMouseMove(e) {
     const {marginLeft, onBrush} = this.props;
     const {drawing} = this.state;
-    const loc = e.nativeEvent.offsetX - marginLeft;
+    let offsetX = e.nativeEvent.offsetX;
+    if (e.nativeEvent.type === 'touchmove') {
+      offsetX = e.nativeEvent.pageX;
+    }
+    const loc = offsetX - marginLeft;
 
     if (drawing) {
       const newDrawArea = this._getDrawArea(loc);
@@ -107,6 +120,11 @@ export default class Highlight extends AbstractSeries {
     }
   }
 
+  onParentTouchMove(e) {
+    e.preventDefault();
+    this.onParentMouseMove(e);
+  }
+
   render() {
     const {marginLeft, marginTop, innerWidth, innerHeight, color, opacity} = this.props;
     const {drawArea: {left, right, top, bottom}} = this.state;
@@ -114,8 +132,17 @@ export default class Highlight extends AbstractSeries {
     return (
       <g transform={`translate(${marginLeft}, ${marginTop})`}
          className="highlight-container"
-         onMouseUp={(e) => this.stopDrawing()}
-         onMouseLeave={(e) => this.stopDrawing()}
+         onMouseUp={() => this.stopDrawing()}
+         onMouseLeave={() => this.stopDrawing()}
+         // preventDefault() so that mouse event emulation does not happen
+         onTouchEnd={(e) => {
+           e.preventDefault();
+           this.stopDrawing();
+         }}
+         onTouchCancel={(e) => {
+           e.preventDefault();
+           this.stopDrawing();
+         }}
       >
         <rect
           className="mouse-target"

--- a/src/plot/series/abstract-series.js
+++ b/src/plot/series/abstract-series.js
@@ -246,11 +246,17 @@ class AbstractSeries extends PureComponent {
 
   _getXYCoordinateInContainer(event) {
     const {marginTop = 0, marginLeft = 0} = this.props;
-    const {nativeEvent: {clientX, clientY}, currentTarget} = event;
+    const {nativeEvent: evt, currentTarget} = event;
     const rect = currentTarget.getBoundingClientRect();
+    let x = evt.clientX;
+    let y = evt.clientY;
+    if (evt.type === 'touchmove') {
+      x = evt.touches[0].pageX;
+      y = evt.touches[0].pageY;
+    }
     return {
-      x: clientX - rect.left - currentTarget.clientLeft - marginLeft,
-      y: clientY - rect.top - currentTarget.clientTop - marginTop
+      x: x - rect.left - currentTarget.clientLeft - marginLeft,
+      y: y - rect.top - currentTarget.clientTop - marginTop
     };
   }
 
@@ -318,6 +324,16 @@ class AbstractSeries extends PureComponent {
     } else {
       this._handleNearestX(event);
     }
+  }
+
+  onParentTouchMove(e) {
+    e.preventDefault();
+    this.onParentMouseMove(e);
+  }
+
+  onParentTouchStart(e) {
+    // prevent mouse event emulation
+    e.preventDefault();
   }
 }
 

--- a/src/plot/xy-plot.js
+++ b/src/plot/xy-plot.js
@@ -109,6 +109,10 @@ class XYPlot extends React.Component {
       onMouseEnter: PropTypes.func,
       onMouseLeave: PropTypes.func,
       onMouseMove: PropTypes.func,
+      onTouchStart: PropTypes.func,
+      onTouchMove: PropTypes.func,
+      onTouchEnd: PropTypes.func,
+      onTouchCancel: PropTypes.func,
       onWheel: PropTypes.func,
       stackBy: PropTypes.oneOf(ATTRIBUTES),
       style: PropTypes.object,
@@ -132,6 +136,8 @@ class XYPlot extends React.Component {
     this._mouseMoveHandler = this._mouseMoveHandler.bind(this);
     this._touchStartHandler = this._touchStartHandler.bind(this);
     this._touchMoveHandler = this._touchMoveHandler.bind(this);
+    this._touchEndHandler = this._touchEndHandler.bind(this);
+    this._touchCancelHandler = this._touchCancelHandler.bind(this);
     this._wheelHandler = this._wheelHandler.bind(this);
     const {stackBy} = props;
     const children = getSeriesChildren(props.children);
@@ -218,6 +224,30 @@ class XYPlot extends React.Component {
   }
 
   /**
+   * Trigger onMouseLeave handler if it was passed in props.
+   * @param {Event} event Native event.
+   * @private
+   */
+  _mouseLeaveHandler(event) {
+    const {onMouseLeave} = this.props;
+    if (onMouseLeave) {
+      onMouseLeave({event});
+    }
+  }
+
+  /**
+   * Trigger onMouseEnter handler if it was passed in props.
+   * @param {Event} event Native event.
+   * @private
+   */
+  _mouseEnterHandler(event) {
+    const {onMouseEnter} = this.props;
+    if (onMouseEnter) {
+      onMouseEnter({event});
+    }
+  }
+
+  /**
    * Trigger touch-start related callbacks if they are available.
    * @param {React.SyntheticEvent} event Touch start event.
    * @private
@@ -256,26 +286,26 @@ class XYPlot extends React.Component {
   }
 
   /**
-   * Trigger onMouseLeave handler if it was passed in props.
+   * Trigger onTouchEnd handler if it was passed in props.
    * @param {Event} event Native event.
    * @private
    */
-  _mouseLeaveHandler(event) {
-    const {onMouseLeave} = this.props;
-    if (onMouseLeave) {
-      onMouseLeave({event});
+  _touchEndHandler(event) {
+    const {onTouchEnd} = this.props;
+    if (onTouchEnd) {
+      onTouchEnd({event});
     }
   }
 
   /**
-   * Trigger onMouseEnter handler if it was passed in props.
+   * Trigger onTouchCancel handler if it was passed in props.
    * @param {Event} event Native event.
    * @private
    */
-  _mouseEnterHandler(event) {
-    const {onMouseEnter} = this.props;
-    if (onMouseEnter) {
-      onMouseEnter({event});
+  _touchCancelHandler(event) {
+    const {onTouchCancel} = this.props;
+    if (onTouchCancel) {
+      onTouchCancel({event});
     }
   }
 
@@ -489,6 +519,8 @@ class XYPlot extends React.Component {
           onMouseEnter={this._mouseEnterHandler}
           onTouchStart={this._mouseDownHandler}
           onTouchMove={this._touchMoveHandler}
+          onTouchEnd={this._touchEndHandler}
+          onTouchCancel={this._touchCancelHandler}
           onWheel={this._wheelHandler}>
           {components.filter(c => c && c.type.requiresSVG)}
         </svg>

--- a/src/plot/xy-plot.js
+++ b/src/plot/xy-plot.js
@@ -130,6 +130,8 @@ class XYPlot extends React.Component {
     this._mouseLeaveHandler = this._mouseLeaveHandler.bind(this);
     this._mouseEnterHandler = this._mouseEnterHandler.bind(this);
     this._mouseMoveHandler = this._mouseMoveHandler.bind(this);
+    this._touchStartHandler = this._touchStartHandler.bind(this);
+    this._touchMoveHandler = this._touchMoveHandler.bind(this);
     this._wheelHandler = this._wheelHandler.bind(this);
     const {stackBy} = props;
     const children = getSeriesChildren(props.children);
@@ -211,6 +213,44 @@ class XYPlot extends React.Component {
       const component = this.refs[`series${index}`];
       if (component && component.onParentMouseMove) {
         component.onParentMouseMove(event);
+      }
+    });
+  }
+
+  /**
+   * Trigger touch-start related callbacks if they are available.
+   * @param {React.SyntheticEvent} event Touch start event.
+   * @private
+   */
+  _touchStartHandler(event) {
+    const {onMouseDown, children} = this.props;
+    if (onMouseDown) {
+      onMouseDown(event);
+    }
+    const seriesChildren = getSeriesChildren(children);
+    seriesChildren.forEach((child, index) => {
+      const component = this.refs[`series${index}`];
+      if (component && component.onParentTouchStart) {
+        component.onParentTouchStart(event);
+      }
+    });
+  }
+
+  /**
+   * Trigger touch movement-related callbacks if they are available.
+   * @param {React.SyntheticEvent} event Touch move event.
+   * @private
+   */
+  _touchMoveHandler(event) {
+    const {onTouchMove, children} = this.props;
+    if (onTouchMove) {
+      onTouchMove(event);
+    }
+    const seriesChildren = getSeriesChildren(children);
+    seriesChildren.forEach((child, index) => {
+      const component = this.refs[`series${index}`];
+      if (component && component.onParentTouchMove) {
+        component.onParentTouchMove(event);
       }
     });
   }
@@ -447,6 +487,8 @@ class XYPlot extends React.Component {
           onMouseMove={this._mouseMoveHandler}
           onMouseLeave={this._mouseLeaveHandler}
           onMouseEnter={this._mouseEnterHandler}
+          onTouchStart={this._mouseDownHandler}
+          onTouchMove={this._touchMoveHandler}
           onWheel={this._wheelHandler}>
           {components.filter(c => c && c.type.requiresSVG)}
         </svg>

--- a/tests/components/crosshair-tests.js
+++ b/tests/components/crosshair-tests.js
@@ -4,7 +4,7 @@ import {mount} from 'enzyme';
 
 import DynamicCrosshair from '../../showcase/axes/dynamic-crosshair';
 
-test('Crosshair: Dynamic Crosshair exmaple', t => {
+test('Crosshair: Dynamic Crosshair - Example', t => {
   const $ = mount(<DynamicCrosshair />);
   simulateMouseMove(100);
   t.equal($.find('.rv-crosshair').hasClass('test-class-name'), true, 'should find the class name passed as a prop');
@@ -13,5 +13,17 @@ test('Crosshair: Dynamic Crosshair exmaple', t => {
   function simulateMouseMove(x) {
     $.find('.rv-xy-plot__inner')
       .simulate('mousemove', {nativeEvent: {clientX: x, clientY: 150}});
+  }
+});
+
+test('Crosshair: Dynamic Crosshair - Touch Example', t => {
+  const $ = mount(<DynamicCrosshair />);
+  simulateMouseMove(100);
+  t.equal($.find('.rv-crosshair').hasClass('test-class-name'), true, 'should find the class name passed as a prop');
+  t.end();
+
+  function simulateMouseMove(x) {
+    $.find('.rv-xy-plot__inner')
+      .simulate('touchmove', {nativeEvent: {type: 'touchmove', touches: [{pageX: x, pageY: 150}]}});
   }
 });

--- a/tests/components/dragable-chart-tests.js
+++ b/tests/components/dragable-chart-tests.js
@@ -25,3 +25,41 @@ test('Showcase Examples: DragableExample', t => {
   t.equal($.find('.drag-marker').exists(), false, 'should not have drag marker after releasing');
   t.end();
 });
+
+test('Showcase Examples: DragableExample - Touch Example', t => {
+  const $ = mount(<DragableExample />).setState({width: 500});
+
+  // Because JSDOM has no layout engine, there is no way to implement a polyfill
+  // for document.elementFromPoint(). To get around this issue we monkey patch the
+  // function and return the voronoi cell at the provided x/y.
+  //
+  // See https://github.com/jsdom/jsdom/issues/1435 for JSDOM limitation
+  const monkeyPatchElementFromPoint = (at) => {
+    document.elementFromPoint = () => $.find('.rv-voronoi__cell').at(at).getDOMNode();
+  };
+
+  t.equal($.find('.drag-marker').exists(), false, 'should not have drag marker before clicking');
+
+  monkeyPatchElementFromPoint(25);
+  $.find('.rv-voronoi').simulate('touchStart', {nativeEvent: {pageX: 125, pageY: 100}});
+  monkeyPatchElementFromPoint(50);
+  $.find('.rv-voronoi').simulate('touchMove', {nativeEvent: {pageX: 250, pageY: 100}});
+
+  t.equal($.find('.drag-marker').exists(), true, 'should have drag marker after clicking');
+  t.equal($.find('.drag-marker').props().x, 160, 'should have correct x position for drag marker');
+  t.equal($.find('.drag-marker').props().width, 110, 'should have correct width for drag marker');
+
+  monkeyPatchElementFromPoint(75);
+  $.find('.rv-voronoi').simulate('touchMove', {nativeEvent: {pageX: 375, pageY: 100}});
+
+  t.equal($.find('.drag-marker').props().x, 160, 'should keep the x position for drag marker');
+  t.equal($.find('.drag-marker').props().width, 220, 'should increase the with for drag marker');
+
+  monkeyPatchElementFromPoint(75);
+  $.find('.rv-voronoi').simulate('touchEnd', {nativeEvent: {pageX: 375, pageY: 100}});
+
+  t.equal($.find('.drag-marker').exists(), false, 'should not have drag marker after releasing');
+  t.end();
+
+  document.elementFromPoint = null;
+});


### PR DESCRIPTION
This PR resolves https://github.com/uber/react-vis/issues/751 and adds support for touch devices for the following features:

- Crosshair functionality
- Draggable charts
- Zoomable charts

It does so in a manor that is unobtrusive and allows for some flexibility. The main gotcha with touch events is that `touchmove` is very different from the way `mouseover` and `mouseout` work, in the sense of you have to listen for `touchmove` on a larger container of elements, and use DOM APIs at our disposal to determine which child nodes the user is currently touching. We are unable to bind listeners for `touchmove` on the child components, as the target originates from the node `touchstart` was fired on.

I have added some documentation around new props on the XY Plot and I have also added tests. Please let me know if there is anything else you'd like me to add, or any concerns you may have with my implementation, and I would be happy to make changes.