### PR TITLE
Better PropType validation for data in AbstractSeries; Tests for using Accessors

### DIFF
--- a/docs/xy-plot.md
+++ b/docs/xy-plot.md
@@ -54,6 +54,24 @@ XYPlot is a wrapper for series, hints, axes and other components. Most of these 
 * `size` (optional)
 * `style` (optional) - css properties as an object.
 
+Accessors can also be used to retreieve the properties above from the `data` object. For instance, the `getX` and `getY` accessors can be passed to the XYPlot object to access the `x` and `y` properties from `data` for each series. 
+
+```jsx
+<XYPlot
+  width={300}
+  height={300}
+  getX={d => d[0]}
+  getY={d => d[1]>
+  <LineSeries
+    color="red"
+    data={[
+      [1, 0],
+      [2, 1],
+      [3, 2]
+    ]}/>
+</XYPlot>
+```
+
 If the property is not passed in any of the objects, the property is not visualized. The user can override the way how properties are visualized by passing custom range, domain or type of scales to the series or the entire chart (please see [Series](series.md) for more info).
 
 Not all properties can be visualized in each series. Here's a short comparison of them:

--- a/src/plot/series/abstract-series.js
+++ b/src/plot/series/abstract-series.js
@@ -39,7 +39,10 @@ const propTypes = {
   ...getScalePropTypesByAttribute('color'),
   width: PropTypes.number,
   height: PropTypes.number,
-  data: PropTypes.arrayOf(PropTypes.object),
+  data: PropTypes.arrayOf(PropTypes.oneOfType([
+    PropTypes.object,
+    PropTypes.array
+  ])),
   onValueMouseOver: PropTypes.func,
   onValueMouseOut: PropTypes.func,
   onValueClick: PropTypes.func,

--- a/src/plot/series/contour-series.js
+++ b/src/plot/series/contour-series.js
@@ -103,13 +103,10 @@ class ContourSeries extends AbstractSeries {
 }
 
 ContourSeries.propTypes = {
+  ...AbstractSeries.propTypes,
   animation: PropTypes.bool,
   bandwidth: PropTypes.number,
   className: PropTypes.string,
-  data: PropTypes.arrayOf(PropTypes.shape({
-    x: PropTypes.number.isRequired,
-    y: PropTypes.number.isRequired
-  })).isRequired,
   marginLeft: PropTypes.number,
   marginTop: PropTypes.number,
   style: PropTypes.object

--- a/tests/components/xy-plot-tests.js
+++ b/tests/components/xy-plot-tests.js
@@ -207,3 +207,37 @@ test('Render two stacked bar series with a non-stacked line series chart', t => 
 
   t.end();
 });
+
+test('Render a line series with data accessors', t => {
+  const $ = mount(
+    <XYPlot
+      width={300}
+      height={300}
+      getX={d => d[0]}
+      getY={d => d[1]}>
+      <LineSeries
+        data={[
+          [1, 0],
+          [2, 1],
+          [3, 2]
+        ]}
+      />
+    </XYPlot>
+  );
+
+  const renderedLineWrapper = $.find(LineSeries);
+  const dataProp = renderedLineWrapper.at(0).prop('data');
+  const getXProp = renderedLineWrapper.at(0).prop('getX');
+  const getYProp = renderedLineWrapper.at(0).prop('getY');
+  t.deepEqual(
+    dataProp.map(getXProp),
+    [1, 2, 3],
+    'X values should be mapped correctly'
+  );
+  t.deepEqual(
+    dataProp.map(getYProp),
+    [0, 1, 2],
+    'Y values should be mapped correctly'
+  );
+  t.end();
+});

--- a/tests/utils/scales-utils-tests.js
+++ b/tests/utils/scales-utils-tests.js
@@ -209,14 +209,19 @@ test('scales-utils #extractScalePropsFromProps', t => {
     aRange: [1, 2],
     _aValue: 10,
     somethingElse: [],
-    bDomain: [1, 2, 3]
+    bDomain: [1, 2, 3],
+    getA: d => d.a
   };
 
   const result = extractScalePropsFromProps(props, ['a', 'b']);
-
-  t.ok(Object.keys(result).length === 4 && result.aType === props.aType &&
-    result.aRange === props.aRange && result._aValue === props._aValue &&
-    result.bDomain === props.bDomain,
+  console.log(result.getA, props.getA);
+  t.ok(
+    Object.keys(result).length === 5 &&
+    result.aType === props.aType &&
+    result.aRange === props.aRange &&
+    result._aValue === props._aValue &&
+    result.bDomain === props.bDomain &&
+    result.getA === props.getA,
     'Should return valid object');
   t.end();
 });

--- a/tests/utils/scales-utils-tests.js
+++ b/tests/utils/scales-utils-tests.js
@@ -214,7 +214,6 @@ test('scales-utils #extractScalePropsFromProps', t => {
   };
 
   const result = extractScalePropsFromProps(props, ['a', 'b']);
-  console.log(result.getA, props.getA);
   t.ok(
     Object.keys(result).length === 5 &&
     result.aType === props.aType &&


### PR DESCRIPTION
Fixes #724. This change will prevent prop-validation for throwing a warning when users use `data` accessors (for using arrays, for example).