### PR TITLE
Expose scale and tickTotal to custom tickFormat function at axis

### DIFF
--- a/docs/axes.md
+++ b/docs/axes.md
@@ -35,28 +35,28 @@ Which is produced via
 ## API Reference
 
 #### title (optional)
-Type: `string`  
+Type: `string`
 Shows the title for the axis.
 
 #### orientation (optional)
-Type: `'top'|'left'|'bottom'|'right'`  
+Type: `'top'|'left'|'bottom'|'right'`
 The position of the axis inside the chart.
 By default **it is already set** to `'bottom'` for `XAxis` and to `'left'` for `YAxis`. Similar to how the axis are oriented in d3-axis.
 
 #### position (optional)
 Type: `'end'|'middle'|'start'`
-The position of the title relative to the axis. This value is set to `'end'` by default (i.e. towards the left of a horizontal axis, towards the top of a vertical axis.) 
- 
+The position of the title relative to the axis. This value is set to `'end'` by default (i.e. towards the left of a horizontal axis, towards the top of a vertical axis.)
+
 #### tickTotal (optional)
-Type: `number`  
+Type: `number`
 Total number of ticks on the axis. Already set by default. Similar to the `tickTotal()` method of d3-axis.
 
 #### tickValues (optional)
-Type: `Array<*>`  
+Type: `Array<*>`
 An array of values (not coordinates!) that where the ticks should be shown. Similar to the `tickValues()` method of d3-axis.
 
 #### tickFormat (optional)
-Type: `function(*)`  
+Type: `function(value, index, scale, tickTotal)`
 Format function for the tick label. Similar to the `tickFormat()` method of d3-axis. Typically the value that is return is a string or a number, however this function also supports rendering svg react elements. To wit, I could have formatting function like
 
 ```javascript
@@ -68,49 +68,56 @@ function myFormatter(t, i) {
 }
 ```
 
+Or you can customize the tick formatting by calling the `tickFormat()` function on the d3-scale by yourself and pass additional formatting parameters (e.g s for SI-prefix).
+```javascript
+function mySIPrefixFormatter(value, index, scale, tickTotal) {
+  return `${scale.tickFormat(tickTotal, 's')(value)}Wh`;// -> e.g. 1.2kWh
+}
+```
+
 #### tickSize (optional)
-Type: `number`  
-Default: `6`  
+Type: `number`
+Default: `6`
 Tick size for the axis. Sets both inner and outer sizes of the tick line. Similar to the `tickSize()` method of d3-axis.
 
 #### tickSizeOuter (optional)
-Type: `number`  
+Type: `number`
 Default: `null`
 Tick size for the axis. Sets the outer size of the tick line. Similar to the `tickSizeOuter()` method of d3-axis.
 
 NOTE: 1.0.0 and onwards now properly draws outer tick using this value. Previously, this value affected the drawing of inner tick.
 
 #### tickSizeInner (optional)
-Type: `number`  
+Type: `number`
 Default: `null`
 Tick size for the axis. Sets the inner size of the tick line. Similar to the `tickSizeInner()` method of d3-axis.
 
 NOTE: v1.0.0+ properly draws inner tick using this value. Previously, this value affected the drawing of outer tick.
 
 #### tickPadding (optional)
-Type: `number`  
-Default: `2`  
+Type: `number`
+Default: `2`
 Distance between the tick and the text of the tick in pixels. Similar to the `tickPadding()` method of d3-axis.
 
 #### tickLabelAngle (optional)
-Type: `number`  
-Default: `0`  
+Type: `number`
+Default: `0`
 The angle of the tick label. Can be used to fit the long labels of the axis without truncation.
 
 #### left (optional)
-Type: `number`  
+Type: `number`
 Horizontal position of the axis in pixels. **Already set by default**, but can be overridden by the user.
 
 #### top (optional)
-Type: `number`  
+Type: `number`
 Vertical position of the axis in pixels. **Already set by default**, but can be overridden by the user.
 
 #### width (optional)
-Type: `number`  
+Type: `number`
 Width of the axis in pixels. **Already set by default**, but can be overridden by the user.
 
 #### height (optional)
-Type: `number`  
+Type: `number`
 Height of the axis in pixels. **Already set by default**, but can be overridden by the user.
 
 #### animation (optional)

--- a/showcase/axes/custom-axis-tick-format.js
+++ b/showcase/axes/custom-axis-tick-format.js
@@ -1,0 +1,75 @@
+// Copyright (c) 2016 - 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import React from 'react';
+
+import {
+  XYPlot,
+  XAxis,
+  YAxis,
+  VerticalGridLines,
+  HorizontalGridLines,
+  LineSeries
+} from 'index';
+
+export default class Example extends React.Component {
+  static _xTickFormatValue(v, i, scale, tickTotal) {
+    // format axis tick with SI prefix (e.g. ms, µs)
+    // see https://github.com/d3/d3-scale#continuous_tickFormat
+    // and https://github.com/d3/d3-format#locale_format
+    return `${scale.tickFormat(tickTotal, 's')(v)}s`;
+  }
+
+  static _yTickFormatValue(v, i, scale, tickTotal) {
+    // format axis tick with SI prefix (e.g. kWh, MWh)
+    return `${scale.tickFormat(tickTotal, 's')(v)}Wh`;
+  }
+
+  render() {
+    const data = [
+      {x: 0.042, y: 100},
+      {x: 0.051, y: 1200},
+      {x: 0.063, y: 1600},
+      {x: 0.070, y: 1300},
+      {x: 0.073, y: 1220}
+    ];
+    const xMin = Math.min(...data.map(e => e.x));
+    const xMax = Math.max(...data.map(e => e.x));
+    const yMin = 0;
+    const yMax = Math.max(...data.map(e => e.y));
+
+    return (
+      <XYPlot
+        width={300}
+        height={300}
+        xType="linear"
+        xDomain={[xMin, xMax]}
+        yType="linear"
+        yDomain={[yMin, yMax]}
+        margin={{top: 10, right: 10, left: 60, bottom: 40}}>
+        <VerticalGridLines />
+        <HorizontalGridLines />
+        <XAxis tickFormat={Example._xTickFormatValue}/>
+        <YAxis tickFormat={Example._yTickFormatValue}/>
+        <LineSeries data={data}/>
+      </XYPlot>
+    );
+  }
+}

--- a/showcase/index.js
+++ b/showcase/index.js
@@ -91,6 +91,7 @@ import {FlexibleCharts} from './flexible/flexible-examples';
 import AxisOn0 from './axes/axis-on-0';
 import CustomAxesOrientation from './axes/custom-axes-orientation';
 import CustomAxisChart from './axes/custom-axis';
+import CustomAxisTickFormat from './axes/custom-axis-tick-format';
 import CustomAxes from './axes/custom-axes';
 import DecorativeAxisCrissCross from './axes/decorative-axes-criss-cross';
 import StaticHints from './axes/static-hints';
@@ -178,6 +179,7 @@ const mainShowCase = {
   CustomScales,
   CustomAxesOrientation,
   CustomAxisChart,
+  CustomAxisTickFormat,
   AxisWithTurnedLabels,
   GridLinesChart,
   StaticHints,

--- a/showcase/showcase-sections/axes-showcase.js
+++ b/showcase/showcase-sections/axes-showcase.js
@@ -8,6 +8,7 @@ const {
   CustomAxes,
   CustomAxisChart,
   CustomAxesOrientation,
+  CustomAxisTickFormat,
   DecorativeAxisCrissCross,
   DynamicComplexEdgeHints,
   DynamicCrosshair,
@@ -35,6 +36,9 @@ const AXES = [{
   name: 'Custom Axis',
   component: CustomAxisChart,
   componentName: 'CustomAxisChart'
+}, {
+  name: 'Custom axis tick format',
+  component: CustomAxisTickFormat
 }, {
   name: 'Even more Custom Axes',
   component: CustomAxes,

--- a/src/plot/axis/axis-ticks.js
+++ b/src/plot/axis/axis-ticks.js
@@ -176,7 +176,7 @@ class AxisTicks extends React.Component {
 
     const ticks = values.map((v, i) => {
       const pos = scale(v);
-      const text = tickFormatFn(v, i);
+      const text = tickFormatFn(v, i, scale, tickTotal);
 
       return (
         <g key={i} {...translateFn(pos, 0)}


### PR DESCRIPTION
In the `AxisTicks` component, the custom `tickFormat` method currently only gets passed a tick value and index. There are cases where one would want to change the formatting of the tick using the d3-scale tickFormat function with custom parameters. Which allows to format values using the various d3-format options on the scale (according to the actual value range) and make further custom adaptations to the tick label.  
e.g. use SI-prefix plus additional unit -> "1.2kWh"

**Existing behavior (from [docs](https://github.com/uber/react-vis/blob/master/docs/axes.md#tickformat-optional)):**
```javascript
function myFormatter(t, i) {
  return (<tspan>
    <tspan x="0" dy="1em">MY VALUE</tspan>
    <tspan x="0" dy="1em">{t}</tspan>
  </tspan>);
}
```
**Desired behavior:**
```javascript
function mySIPrefixFormatter(value, index, scale, tickTotal) {
  return `${scale.tickFormat(tickTotal, 's')(value)}Wh`;// -> e.g. 1.2kWh
}
```
![image](https://user-images.githubusercontent.com/25345228/39319068-3c1f783c-4980-11e8-8f7a-602d320c7ac9.png)


**This PR provides:**
- Exposed scale and tickTotal for custom tickFormat function at axis
- Showcase example for customized axis tickFormat using scale
- Extend tickFormat function documentation 


Related to #616 