### PR TITLE
fix(docs): Fix source code link of history and force directed graph

### DIFF
--- a/docs/examples/building-things-other-than-charts.md
+++ b/docs/examples/building-things-other-than-charts.md
@@ -1,3 +1,3 @@
 <!-- INJECT:"ForceDirectedGraph" -->
 
-[Source code](https://github.com/uber/react-vis/blob/master/examples/force-directed-graph/force-directed-graph.js)
+[Source code](https://github.com/uber/react-vis/blob/master/showcase/examples/force-directed-graph/force-directed-graph.js)

--- a/docs/examples/history-example.md
+++ b/docs/examples/history-example.md
@@ -1,4 +1,4 @@
 <!-- STYLETYPE:"example-page" -->
 <!-- INJECT:"HistoryExample" -->
 
-[Source code](https://github.com/uber/react-vis/blob/master/examples/history/history-example.js)
+[Source code](https://github.com/uber/react-vis/blob/master/showcase/examples/history/history-example.js)


### PR DESCRIPTION
Fixed URLs for two example charts (git history graph and force directed graph)

I propose a page rendering after this PR is approved and merged so [https://uber.github.io/react-vis](https://uber.github.io/react-vis) will display the correct URLs for examples.

❤️btw, this library is my favorite among all visualization libraries I have tried in React. 
