### PR TITLE
Fix scss import path

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,12 @@ Install react-vis via npm.
 
 Include the built main CSS file in your HTML page or via SASS:
 ```sass
-@import "./node_modules/react-vis/dist/style";
+@import "~react-vis/dist/style";
 ```
 
 You can also select only the styles you want to use. This helps minimize the size of the outputted CSS. Here's an example of importing only the legends styles:
 ```sass
-@import "./node_modules/react-vis/dist/styles/legends";
+@import "~react-vis/dist/styles/legends";
 ```
 
 Import the necessary components from the library...


### PR DESCRIPTION
Instead of ./node_modules which only works if the file is at root, ~ always resolves to the node_modules folder.