### PR TITLE
Fix typo in README (#812)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Install react-vis via npm.
 
 Include the built main CSS file in your HTML page or via SASS:
 ```sass
-@import "~react-vis/dist/style";
+@import "~react-vis/dist/styles";
 ```
 
 You can also select only the styles you want to use. This helps minimize the size of the outputted CSS. Here's an example of importing only the legends styles:


### PR DESCRIPTION
Closes #812. 

Changes `"~react-vis/dist/style"` to `"~react-vis/dist/styles"` to align with the actual file structure.
