### PR TITLE
Fixes RadarChart axes (#796)

### DIFF
--- a/src/radar-chart/index.js
+++ b/src/radar-chart/index.js
@@ -68,7 +68,7 @@ function getAxes(props) {
         animation={animation}
         key={`${index}-axis`}
         axisStart={{x: 0, y: 0}}
-        axisEnd={{x: Math.cos(angle), y: Math.sin(angle)}}
+        axisEnd={{x: getCoordinate(Math.cos(angle)), y: getCoordinate(Math.sin(angle))}}
         axisDomain={sortedDomain}
         numberOfTicks={5}
         tickValue={domainTickFormat}
@@ -76,6 +76,29 @@ function getAxes(props) {
         />
     );
   });
+}
+
+/**
+ * Generate x or y coordinate for axisEnd
+ * @param {Number} axisEndPoint
+ - epsilon is an arbitrarily chosen small number to approximate axisEndPoints
+ - to true values resulting from trigonometry functions (sin, cos) on angles
+ * @return {Number} the x or y coordinate accounting for exact trig values
+ */
+function getCoordinate(axisEndPoint) {
+  const epsilon = 10e-13;
+  if (Math.abs(axisEndPoint) <= epsilon) {
+    axisEndPoint = 0;
+  } else if (axisEndPoint > 0) {
+    if (Math.abs(axisEndPoint - 0.5) <= epsilon) {
+      axisEndPoint = 0.5;
+    }
+  } else if (axisEndPoint < 0) {
+    if (Math.abs(axisEndPoint + 0.5) <= epsilon) {
+      axisEndPoint = -0.5;
+    }
+  }
+  return axisEndPoint;
 }
 
 /**

--- a/src/utils/axis-utils.js
+++ b/src/utils/axis-utils.js
@@ -120,6 +120,7 @@ export function generatePoints({axisStart, axisEnd, numberOfTicks, axisDomain}) 
         }
         return {x: val, y: slope * val + offset, text: axisScale(val)};
       })
+      .slice(0, numberOfTicks + 1)
   };
 }
 


### PR DESCRIPTION
I ran into the same issue (#796).  The RadarChart axes does not show or is displayed incorrectly (ex. wrong number of ticks) depending on what the startingAngle is.  Rotating your graph a certain degree can cause these problems, because JavaScript's trigonometric functions (ex. Math.sin & Math.cos) can return numbers with floating point errors (see table below). These floating point numbers can cause calculation errors.

Trig Function | Angle | JavaScript Value | True Value
--- | --- | --- | ---
*sin* | PI | 1.2246467991473532e-16 | 0
*cos* | PI/3 | 0.5000000000000001 | 0.5

Shown below is what I used for my RadarChart.

```
class App extends Component {
  render() {
    const RADAR_PROPS = {
      data: [{
        C: 30,
        VisualBasics: 60,
        Excel: 40,
        Access: 40
      }],
      domains: [
        {name: 'C', domain: [0, 100]},
        {name: 'VisualBasics', domain: [0, 100]},
        {name: 'Excel', domain: [0, 100]},
        {name: 'Access', domain: [0, 100]}
      ],
      height: 300,
      width: 400,
    };
    return (
      <div>
        <RadarChart
          data={RADAR_PROPS.data}
          domains={RADAR_PROPS.domains}
          height={RADAR_PROPS.height}
          width={RADAR_PROPS.height}
          startingAngle={Math.PI/4}
          className='overflow-okay horizontally-centered'
          style={{
              labels: {
                  fontSize: 13
              },
              polygons: {
                  fillOpacity: 0.1,
                  strokeOpacity: 1,
                  strokeWidth: 0.5,
              },
          }}
        />
      </div>
    );
  }
}
```

For the `src/utils/axis-utils.js`, I wanted to make sure the axes displayed the correct number of ticks, because there could be cases where maybe more ticks would be generated than what was specified.  Let me know what you think.  Thanks.