### PR TITLE
Fix documentation links in docs/series.md and docs/xy-plot.md

### DIFF
--- a/docs/series.md
+++ b/docs/series.md
@@ -2,17 +2,17 @@
 
 The library supports several types of series:
 
-* [ArcSeries](documentation/series-reference/arc-series.md) for radial arcs such as might be found in pie charts.
-* [AreaSeries](documentation/series-reference/area-series.md) for area charts;
-* [BarSeries](documentation/series-reference/bar-series.md) for discrete bar charts, covers (covers HorizontalBarSeries and VerticalBarSeries);
-* [ContourSeries](documentation/series-reference/contour-series.md) for making contour density plots;
-* [HeatmapSeries](documentation/series-reference/heatmap-series.md) for heat maps.
-* [LabelSeries](documentation/series-reference/label-series.md) for adding annotations to charts
-* [LineMarkSeries](documentation/series-reference/line-series.md) is a shorthand to place marks (e.g. circles) on lines;
-* [LineSeries](documentation/series-reference/line-series.md) for lines;
-* [MarkSeries](documentation/series-reference/mark-series.md) for scatterplots;
-* [PolygonSeries](documentation/series-reference/polygon-series.md) for arbitrary SVG shapes
-* [RectSeries](documentation/series-reference/rect-series.md) for arbitrary histograms and other continuous variable boxes. (covers HorizontalRectSeries and VerticalRectSeries)
+* [ArcSeries](arc-series.md) for radial arcs such as might be found in pie charts.
+* [AreaSeries](area-series.md) for area charts;
+* [BarSeries](bar-series.md) for discrete bar charts, covers (covers HorizontalBarSeries and VerticalBarSeries);
+* [ContourSeries](contour-series.md) for making contour density plots;
+* [HeatmapSeries](heatmap-series.md) for heat maps.
+* [LabelSeries](label-series.md) for adding annotations to charts
+* [LineMarkSeries](line-series.md) is a shorthand to place marks (e.g. circles) on lines;
+* [LineSeries](line-series.md) for lines;
+* [MarkSeries](mark-series.md) for scatterplots;
+* [PolygonSeries](polygon-series.md) for arbitrary SVG shapes
+* [RectSeries](rect-series.md) for arbitrary histograms and other continuous variable boxes. (covers HorizontalRectSeries and VerticalRectSeries)
 
 Each series provides following API:
 
@@ -118,10 +118,10 @@ Note that style information passed through the style property will override thos
 ```
 
 #### animation (optional)
-See the [XYPlot](documentation/api-reference/xy-plot.md)'s `animation` section for more information.
+See the [XYPlot](xy-plot.md)'s `animation` section for more information.
 
 #### stack (optional)
 Type: `Boolean`
 Default: `false`
 Opt-in for stacking series and mix stacked and non-stacked series in a single chart. If all series have the `stack` prop set to `false` (which is default behaviour), they will all be considered stackable. Otherwise if at least two of the series have the `stack` prop set to `true`, they will be stacked together and the other series will be considered non stackable.
-See the [XYPlot](documentation/api-reference/xy-plot.md)'s `stackBy` section for more information.
+See the [XYPlot](xy-plot.md)'s `stackBy` section for more information.

--- a/docs/xy-plot.md
+++ b/docs/xy-plot.md
@@ -5,11 +5,11 @@ XYPlot allows you to make line charts, area charts, scatterplots, heat maps, etc
 Currently following components are used for this purpose:
 
 * XYPlot to wrap all the items.
-* [Grids](documentation/api-reference/grids.md) to show vertical and horizontal grids.
-* [Axes](documentation/api-reference/axes.md) to show X and Y axis.
-* [Different kinds of series](documentation/api-reference/series.md) for line/area/bar charts, scatterplots, heat maps, etc.
-* [Hint](documentation/api-reference/hint.md) to show the selected hint.
-* [Crosshair](documentation/api-reference/crosshair.md) for crosshairs.
+* [Grids](grids.md) to show vertical and horizontal grids.
+* [Axes](axes.md) to show X and Y axis.
+* [Different kinds of series](series.md) for line/area/bar charts, scatterplots, heat maps, etc.
+* [Hint](hint.md) to show the selected hint.
+* [Crosshair](crosshair.md) for crosshairs.
 
 ## Usage
 
@@ -72,21 +72,21 @@ Accessors can also be used to retreieve the properties above from the `data` obj
 </XYPlot>
 ```
 
-If the property is not passed in any of the objects, the property is not visualized. The user can override the way how properties are visualized by passing custom range, domain or type of scales to the series or the entire chart (please see [Series](/documentation/api-reference/series.md) for more info).
+If the property is not passed in any of the objects, the property is not visualized. The user can override the way how properties are visualized by passing custom range, domain or type of scales to the series or the entire chart (please see [Series](series.md) for more info).
 
 Not all properties can be visualized in each series. Here's a short comparison of them:
 
 |                      | `x` | `y` | `color` | `opacity` | `size` |
 |----------------------|-----|-----|---------|-----------|--------|
-| [LineSeries](/documentation/series-reference/line-series.md)  |  +  |  +  | +       |           |        |
+| [LineSeries](line-series.md)  |  +  |  +  | +       |           |        |
 | `AreaSeries`         |  +  |  +  | +       |           |        |
-| [LineMarkSeries](/documentation/series-reference/line-series.md)     |  +  |  +  | +       |     +     | +      |
+| [LineMarkSeries](line-series.md)     |  +  |  +  | +       |     +     | +      |
 | `MarkSeries`         |  +  |  +  | +       |     +     | +      |
-| [VerticalBarSeries](/documentation/series-reference/bar-series.md)  |  +  |  +  | +       |     +     |        |
-| [HorizontalBarSeries](/documentation/series-reference/bar-series.md)|  +  |  +  | +       |     +     |        |
+| [VerticalBarSeries](bar-series.md)  |  +  |  +  | +       |     +     |        |
+| [HorizontalBarSeries](bar-series.md)|  +  |  +  | +       |     +     |        |
 | `VerticalRectSeries`  |  +  |  +  | +       |     +     |        |
 | `HorizontalRectSeries`|  +  |  +  | +       |     +     |        |
-| [HeatmapSeries](/documentation/series-reference/heatmap-series.md)      |  +  |  +  | +       |     +     |        |      |
+| [HeatmapSeries](heatmap-series.md)      |  +  |  +  | +       |     +     |        |      |
 
 
 ### A note on ordering
@@ -148,7 +148,7 @@ Margin around the chart.
 
 #### stackBy (optional)
 Type: `string`
-Stack the chart by the given attribute. If the attribute is `y`, the chart is stacked vertically; if the attribute is `x` then it's stacked horizontally. See the [Series](/documentation/api-reference/series.md) API reference for series level stack opt-in.
+Stack the chart by the given attribute. If the attribute is `y`, the chart is stacked vertically; if the attribute is `x` then it's stacked horizontally. See the [Series](series.md) API reference for series level stack opt-in.
 
 ### style (optional)
 Type: `object`


### PR DESCRIPTION
Currently these links point to files in nonexistent directories. This pull request resolves those references so that they no longer 404.