### PR TITLE
Check if stateless before adding ref

### DIFF
--- a/src/plot/xy-plot.js
+++ b/src/plot/xy-plot.js
@@ -476,7 +476,7 @@ class XYPlot extends React.Component {
       return React.cloneElement(child, {
         ...dimensions,
         animation,
-        ...(dataProps ?
+        ...(dataProps && (!child.prototype || !child.prototype.render) ?
         {
           ref: ref => (this[`series${seriesProps[index].seriesIndex}`] = ref)
         } :


### PR DESCRIPTION
This should solve #861.  

I am unsure why #867  did not succeed.  I thought I saw that solve the issue while `yarn link`-ed to an example.