### PR TITLE
No documentation on how to make empty charts

### DIFF
--- a/docs/xy-plot.md
+++ b/docs/xy-plot.md
@@ -273,3 +273,8 @@ Animation config, which is automatically passed to all children, but can be over
 If `false` is passed, then the child components *will not be* animated.
 If `true` is passed then the child components *will be* animated with the default settings.
 If an object is passed, then the child components *will be* animated with the given settings.
+
+#### dontCheckIfEmpty (optional)
+Type: `Boolean`
+Default: `false`
+If this prop is provided then the XYPlot with not check if the plot is empty before rendering. This can be useful if you have a variable amount of data, especially when that variable can be zero.

--- a/docs/xy-plot.md
+++ b/docs/xy-plot.md
@@ -278,3 +278,5 @@ If an object is passed, then the child components *will be* animated with the gi
 Type: `Boolean`
 Default: `false`
 If this prop is provided then the XYPlot with not check if the plot is empty before rendering. This can be useful if you have a variable amount of data, especially when that variable can be zero.
+
+<!-- INJECT:"EmptyChartWithLink" -->

--- a/showcase/axes/empty-chart.js
+++ b/showcase/axes/empty-chart.js
@@ -1,0 +1,52 @@
+// Copyright (c) 2016 - 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import React from 'react';
+
+import {
+  XYPlot,
+  XAxis,
+  YAxis,
+  VerticalGridLines,
+  HorizontalGridLines
+} from 'index';
+
+export default class EmptyChart extends React.Component {
+  render() {
+
+    return (
+      <XYPlot
+        dontCheckIfEmpty
+        xDomain={[0, 3]}
+        yDomain={[10, 3]}
+        width={300}
+        height={300}>
+        <VerticalGridLines />
+        <HorizontalGridLines />
+        <XAxis
+          hideLine
+          title="Empty Chart Right Here"
+          tickFormat={v => `${v}!`}
+          tickValues={[1, 1.5, 2, 3]} />
+        <YAxis hideTicks/>
+      </XYPlot>
+    );
+  }
+}

--- a/showcase/axes/empty-chart.js
+++ b/showcase/axes/empty-chart.js
@@ -28,7 +28,7 @@ import {
   HorizontalGridLines
 } from 'index';
 
-export default function EmptyChart(){
+export default function EmptyChart() {
   return (
     <XYPlot
       dontCheckIfEmpty

--- a/showcase/axes/empty-chart.js
+++ b/showcase/axes/empty-chart.js
@@ -28,25 +28,22 @@ import {
   HorizontalGridLines
 } from 'index';
 
-export default class EmptyChart extends React.Component {
-  render() {
-
-    return (
-      <XYPlot
-        dontCheckIfEmpty
-        xDomain={[0, 3]}
-        yDomain={[10, 3]}
-        width={300}
-        height={300}>
-        <VerticalGridLines />
-        <HorizontalGridLines />
-        <XAxis
-          hideLine
-          title="Empty Chart Right Here"
-          tickFormat={v => `${v}!`}
-          tickValues={[1, 1.5, 2, 3]} />
-        <YAxis hideTicks/>
-      </XYPlot>
-    );
-  }
+export default function EmptyChart(){
+  return (
+    <XYPlot
+      dontCheckIfEmpty
+      xDomain={[0, 3]}
+      yDomain={[10, 3]}
+      width={300}
+      height={300}>
+      <VerticalGridLines />
+      <HorizontalGridLines />
+      <XAxis
+        hideLine
+        title="Empty Chart Right Here"
+        tickFormat={v => `${v}!`}
+        tickValues={[1, 1.5, 2, 3]} />
+      <YAxis hideTicks/>
+    </XYPlot>
+  );
 }

--- a/showcase/index.js
+++ b/showcase/index.js
@@ -94,6 +94,7 @@ import CustomAxisChart from './axes/custom-axis';
 import CustomAxisTickFormat from './axes/custom-axis-tick-format';
 import CustomAxes from './axes/custom-axes';
 import DecorativeAxisCrissCross from './axes/decorative-axes-criss-cross';
+import EmptyChart from './axes/empty-chart';
 import StaticHints from './axes/static-hints';
 import DynamicHints from './axes/dynamic-hints';
 import DynamicComplexEdgeHints from './axes/dynamic-complex-edge-hints';
@@ -191,6 +192,7 @@ const mainShowCase = {
   DynamicSimpleEdgeHints,
   DynamicSimpleTopEdgeHints,
   DynamicProgrammaticRightEdgeHints,
+  EmptyChart,
   StaticCrosshair,
   DynamicCrosshair,
   DynamicCrosshairScatterplot,

--- a/showcase/showcase-links.js
+++ b/showcase/showcase-links.js
@@ -60,6 +60,7 @@ export const SHOWCASE_LINKS = {
   CustomScales: 'https://github.com/uber/react-vis/blob/master/showcase/plot/custom-scales.js',
   GridLinesChart: 'https://github.com/uber/react-vis/blob/master/showcase/plot/grid.js',
   FauxScatterplotChart: 'https://github.com/uber/react-vis/blob/master/showcase/plot/faux-radial-scatterplot.js',
+  EmptyChart: 'https://github.com/uber/react-vis/blob/master/showcase/plot/empty-chart.js',
   // RADAR CHART SHOWCASE LINKS
   AnimatedRadarChart: 'https://github.com/uber/react-vis/blob/master/showcase/radar-chart/animated-radar-chart.js',
   BasicRadarChart: 'https://github.com/uber/react-vis/blob/master/showcase/radar-chart/basic-radar-chart.js',

--- a/showcase/showcase-sections/plots-showcase.js
+++ b/showcase/showcase-sections/plots-showcase.js
@@ -14,6 +14,7 @@ const {
   CustomSVGExample,
   CustomSVGAllTheMarks,
   CustomSVGRootLevel,
+  EmptyChart,
   FauxScatterplotChart,
   GridLinesChart,
   HeatmapChart,
@@ -151,6 +152,10 @@ const BASIC_COMPONENTS = [{
   name: 'Custom scales',
   component: CustomScales,
   componentName: 'CustomScales'
+}, {
+  name: 'Empty Chart',
+  component: EmptyChart,
+  componentName: 'EmptyChart'
 }, {
   name: 'Custom GridLines',
   component: GridLinesChart,

--- a/tests/components/xy-plot-tests.js
+++ b/tests/components/xy-plot-tests.js
@@ -31,6 +31,7 @@ import XYPlot from 'plot/xy-plot';
 
 import MixedStackedChart from '../../showcase/plot/mixed-stacked-chart';
 import {FlexibleCharts} from '../../showcase/flexible/flexible-examples';
+import EmptyChart from '../../showcase/axes/empty-chart';
 import {testRenderWithProps} from '../test-utils';
 
 const XYPLOT_PROPS = {width: 10, height: 10};
@@ -302,4 +303,13 @@ test('Trigger all onParentMouse handlers on Series components', t => {
   $.find('svg').at(0).simulate('mouseleave');
   $.find('svg').at(0).simulate('touchstart');
   $.find('svg').at(0).simulate('touchmove');
+
+  t.end();
+});
+
+test('XYPlot dontCheckIfEmpty - Showcase example EmptyChart', t => {
+  const $ = mount(<EmptyChart />);
+  t.equal($.find('.rv-xy-plot__series').length, 0, 'should find no series');
+  t.equal($.text(), '1!1.5!2!3!Empty Chart Right Here', 'should find the correct text');
+  t.end();
 });


### PR DESCRIPTION
Addresses some points raised in #845. I built this feature a long time ago, but never documented it because it was mostly for internal use. In between now and then I had forgotten I made it, and had frequently wished for it to exist, this documentation will hopefully be a reminder this function is around.