### PR TITLE
center sankey chart labels

### DIFF
--- a/src/sankey/index.js
+++ b/src/sankey/index.js
@@ -125,6 +125,7 @@ class Sankey extends Component {
             animation={animation}
             className={className}
             rotation={labelRotation}
+            labelAnchorY="text-before-edge"
             data={nodesCopy.map(node => {
               return {
                 x: node.x0 + (node.x0 < width / 2 ? nWidth + 10 : -10),


### PR DESCRIPTION
fix #914 

before:
<img width="896" alt="screen shot 2018-08-20 at 1 41 44 pm" src="https://user-images.githubusercontent.com/3478203/44365648-4f1e7c80-a47f-11e8-8ee3-fe5a6ea6a35a.png">

after:
<img width="906" alt="screen shot 2018-08-20 at 1 41 28 pm" src="https://user-images.githubusercontent.com/3478203/44365658-547bc700-a47f-11e8-9914-dc277c70b16a.png">
