### PR TITLE
sankey chart: fix labels' horizontal position

### DIFF
--- a/src/sankey/index.js
+++ b/src/sankey/index.js
@@ -132,6 +132,7 @@ class Sankey extends Component {
                 y: (node.y0 + node.y1) / 2 - marginTop,
                 label: node.name,
                 style: {
+                  textAnchor: node.x0 < width / 2 ? 'start' : 'end',
                   dy: '-.5em',
                   ...style.labels
                 }


### PR DESCRIPTION
fix #906

before:
<img width="210" alt="screen shot 2018-08-20 at 2 14 58 pm" src="https://user-images.githubusercontent.com/3478203/44367369-614ee980-a484-11e8-8667-8b6e6c9ed9e3.png">

after:
<img width="201" alt="screen shot 2018-08-20 at 2 15 27 pm" src="https://user-images.githubusercontent.com/3478203/44367375-657b0700-a484-11e8-816b-17ab06b4d01e.png">
