### PR TITLE
Make voronoi component automatically infer scales and extent

### DIFF
--- a/docs/voronoi.md
+++ b/docs/voronoi.md
@@ -15,12 +15,13 @@ Voronoi diagrams are useful for making a chart interactive by creating target ar
 
 ## API Reference
 
+
 <!-- INJECT:"DynamicCrosshairScatterplotLink" -->
 
-### extend (required)
+### extent
 Type: `Array`
 Sets the clip extent of the Voronoi layout to the specified bounds. The extent bounds are specified as an array [[x0, y0], [x1, y1]], where x0 is the left side of the extent, y0 is the top, x1 is the right and y1 is the bottom.
-Extent should take the dimensions of the accompanying XYPlot into account, so using the plot's width, height and margins: `[[marginLeft, marginTop], [width, height]]`
+Extent should take the dimensions of the accompanying XYPlot into account, so using the plot's width, height and margins: `[[marginLeft, marginTop], [width, height]]`, which coincidentally is the default extent.
 
 ### nodes (required)
 Type: `Array`
@@ -41,12 +42,12 @@ Example:
 ### x (optional)
 Type: `Function`
 Sets the x-coordinate accessor. Often you want to convert the coordinate-values to pixel values like
-`x={d => x(d.x)}`
+`x={d => x(d.x)}`. If not provided defaults to wrapping XYPlot's xScale.
 
 ### y (optional)
 Type: `Function`
 Sets the y-coordinate accessor. Often you want to convert the coordinate-values to pixel values like
-`y={d => y(d.y)}`
+`y={d => y(d.y)}`. If not provided defaults to wrapping XYPlot's yScale.
 
 ### onBlur (optional)
 Type: `Function`

--- a/showcase/axes/dynamic-crosshair-scatterplot.js
+++ b/showcase/axes/dynamic-crosshair-scatterplot.js
@@ -64,6 +64,7 @@ const margin = {top: 10, left: 40, bottom: 40, right: 10};
 const width = 300;
 const height = 300;
 
+// Intentionally using explicit sales here to show another way of using the voronoi
 const x = scaleLinear().domain(getDomain(DATA, 'x')).range([0, width]);
 const y = scaleLinear().domain(getDomain(DATA, 'y')).range([height, 0]);
 

--- a/showcase/misc/voronoi-line-chart.js
+++ b/showcase/misc/voronoi-line-chart.js
@@ -19,7 +19,6 @@
 // THE SOFTWARE.
 
 import React from 'react';
-import {scaleLinear} from 'd3-scale';
 
 import {
   XYPlot,
@@ -52,20 +51,19 @@ const lines = [
     {x: 4, y: 2}
   ]
 ].map((p, i) => p.map(d => ({...d, line: i})));
+const nodes = lines.reduce((acc, d) => [...acc, ...d], []);
 
-const margin = {top: 10, left: 40, bottom: 40, right: 10};
-const width = 300;
-const height = 300;
-
-const x = scaleLinear()
-  .domain([1, 4])
-  .range([0, width]);
-const y = scaleLinear()
-  .domain([2, 15])
-  .range([height, 0]);
+const getDomain = (data, key) => {
+  const {min, max} = data.reduce((acc, row) => ({
+    min: Math.min(acc.min, row[key]),
+    max: Math.max(acc.max, row[key])
+  }), {min: Infinity, max: -Infinity});
+  return [min, max];
+};
+const xDomain = getDomain(nodes, 'x');
+const yDomain = getDomain(nodes, 'y');
 
 export default class Example extends React.Component {
-
   state = {
     hoveredNode: null,
     showVoronoi: false
@@ -84,8 +82,11 @@ export default class Example extends React.Component {
           Show Voronoi
         </label>
         <XYPlot
-          width={width}
-          height={height}>
+          xDomain={xDomain}
+          yDomain={yDomain}
+          margin={{top: 10, left: 40, bottom: 40, right: 10}}
+          width={300}
+          height={300}>
           <HorizontalGridLines />
           <VerticalGridLines />
           <XAxis title="X Axis" />
@@ -97,22 +98,13 @@ export default class Example extends React.Component {
               data={d}
             />
           ))}
-          {hoveredNode ? (
-            <MarkSeries
-              data={[hoveredNode]}
-              xDomain={x.domain()}
-              yDomain={y.domain()}
-            />
-          ) : null}
+          {hoveredNode && (<MarkSeries data={[hoveredNode]} />)}
           <Voronoi
-            extent={[[margin.left, margin.top], [width - margin.right, height - margin.bottom]]}
             nodes={lines.reduce((acc, d) => [...acc, ...d], [])}
             onHover={node => this.setState({hoveredNode: node})}
             onBlur={() => this.setState({hoveredNode: null})}
             polygonStyle={{stroke: showVoronoi ? 'rgba(0, 0, 0, .2)' : null}}
-            x={d => x(d.x)}
-            y={d => y(d.y)}
-          />
+            />
         </XYPlot>
       </div>
     );

--- a/src/plot/voronoi.js
+++ b/src/plot/voronoi.js
@@ -1,11 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {voronoi} from 'd3-voronoi';
-import {scaleLinear} from 'd3-scale';
 
-import {
-  getAttributeFunctor
-} from 'utils/scales-utils';
+import {getAttributeFunctor} from 'utils/scales-utils';
 
 const NOOP = f => f;
 
@@ -22,12 +19,10 @@ function getNodeIndex(evt) {
 
 function getExtent(props) {
   const {
-    innerWidth, 
-    innerHeight, 
-    marginBottom, 
-    marginLeft, 
-    marginTop, 
-    marginRight
+    innerWidth,
+    innerHeight,
+    marginLeft,
+    marginTop
   } = props;
   return [
     [marginLeft, marginTop],
@@ -49,7 +44,7 @@ function Voronoi(props) {
     style,
     x,
     y
-  } = props
+  } = props;
   // Create a voronoi with each node center points
   const voronoiInstance = voronoi()
     .x(x || getAttributeFunctor(props, 'x'))

--- a/src/plot/voronoi.js
+++ b/src/plot/voronoi.js
@@ -17,13 +17,7 @@ function getNodeIndex(evt) {
   return Array.prototype.indexOf.call(parentNode.childNodes, target);
 }
 
-function getExtent(props) {
-  const {
-    innerWidth,
-    innerHeight,
-    marginLeft,
-    marginTop
-  } = props;
+function getExtent({innerWidth, innerHeight, marginLeft, marginTop}) {
   return [
     [marginLeft, marginTop],
     [innerWidth + marginLeft, innerHeight + marginTop]

--- a/src/plot/voronoi.js
+++ b/src/plot/voronoi.js
@@ -1,6 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {voronoi} from 'd3-voronoi';
+import {scaleLinear} from 'd3-scale';
+
+import {
+  getAttributeFunctor
+} from 'utils/scales-utils';
 
 const NOOP = f => f;
 
@@ -15,25 +20,41 @@ function getNodeIndex(evt) {
   return Array.prototype.indexOf.call(parentNode.childNodes, target);
 }
 
-function Voronoi({
-  className,
-  extent,
-  nodes,
-  onBlur,
-  onClick,
-  onMouseUp,
-  onMouseDown,
-  onHover,
-  polygonStyle,
-  style,
-  x,
-  y
-}) {
+function getExtent(props) {
+  const {
+    innerWidth, 
+    innerHeight, 
+    marginBottom, 
+    marginLeft, 
+    marginTop, 
+    marginRight
+  } = props;
+  return [
+    [marginLeft, marginTop],
+    [innerWidth + marginLeft, innerHeight + marginTop]
+  ];
+}
+
+function Voronoi(props) {
+  const {
+    className,
+    extent,
+    nodes,
+    onBlur,
+    onClick,
+    onMouseUp,
+    onMouseDown,
+    onHover,
+    polygonStyle,
+    style,
+    x,
+    y
+  } = props
   // Create a voronoi with each node center points
   const voronoiInstance = voronoi()
-    .x(x)
-    .y(y)
-    .extent(extent);
+    .x(x || getAttributeFunctor(props, 'x'))
+    .y(y || getAttributeFunctor(props, 'y'))
+    .extent(extent || getExtent(props));
 
   // Create an array of polygons corresponding to the cells in voronoi
   const polygons = voronoiInstance.polygons(nodes);
@@ -81,23 +102,21 @@ function Voronoi({
 }
 
 Voronoi.requiresSVG = true;
-
+Voronoi.displayName = 'Voronoi';
 Voronoi.defaultProps = {
   className: '',
   onBlur: NOOP,
   onClick: NOOP,
   onHover: NOOP,
   onMouseDown: NOOP,
-  onMouseUp: NOOP,
-  x: d => d.x,
-  y: d => d.y
+  onMouseUp: NOOP
 };
 
 Voronoi.propTypes = {
   className: PropTypes.string,
   extent: PropTypes.arrayOf(
     PropTypes.arrayOf(PropTypes.number)
-  ).isRequired,
+  ),
   nodes: PropTypes.arrayOf(PropTypes.object).isRequired,
   onBlur: PropTypes.func,
   onClick: PropTypes.func,

--- a/tests/components/voronoi-tests.js
+++ b/tests/components/voronoi-tests.js
@@ -2,11 +2,19 @@ import test from 'tape';
 import React from 'react';
 import {mount} from 'enzyme';
 import Voronoi from '../../src/plot/voronoi.js';
+import XYPlot from 'plot/xy-plot';
+import WhiskerChart from '../../showcase/plot/whisker-chart';
 
 import VoronoiLineChart from '../../showcase/misc/voronoi-line-chart';
 
-test('Voronoi: Basic Chart', t => {
-  const $ = mount(<Voronoi
+const StatelessVoronoiWrapper = () => (
+  <XYPlot 
+  height={300}
+  width={300}
+  dontCheckIfEmpty
+  xDomain={[-50, 250]} 
+  yDomain={[-50, 250]}>
+    <Voronoi
     extent={[[0, 0], [200, 200]]}
     nodes={Array(100).fill().map((e, x) => ({
       x,
@@ -14,7 +22,12 @@ test('Voronoi: Basic Chart', t => {
       className: `my-class-${x}`,
       style: {color: 'red'}
     }))}
-  />);
+    />
+  </XYPlot>
+);
+
+test('Voronoi: Basic Chart', t => {
+  const $ = mount(<StatelessVoronoiWrapper/>);
 
   t.equal($.find('.rv-voronoi__cell').at(30).prop('style').color, 'red', 'should apply inline styles');
   t.equal($.find('.rv-voronoi__cell').at(30).hasClass('my-class-30'), true, 'should apply css class');

--- a/tests/components/voronoi-tests.js
+++ b/tests/components/voronoi-tests.js
@@ -3,16 +3,15 @@ import React from 'react';
 import {mount} from 'enzyme';
 import Voronoi from '../../src/plot/voronoi.js';
 import XYPlot from 'plot/xy-plot';
-import WhiskerChart from '../../showcase/plot/whisker-chart';
 
 import VoronoiLineChart from '../../showcase/misc/voronoi-line-chart';
 
 const StatelessVoronoiWrapper = () => (
-  <XYPlot 
+  <XYPlot
   height={300}
   width={300}
   dontCheckIfEmpty
-  xDomain={[-50, 250]} 
+  xDomain={[-50, 250]}
   yDomain={[-50, 250]}>
     <Voronoi
     extent={[[0, 0], [200, 200]]}


### PR DESCRIPTION
At long last this PR addresses #355. It enables the voronoi component to automatically pick up the extent and scales for the current XYPlot. It also makes the API mostly conform to the rest of the react-vis style (#821). Finally, and most interestingly, I believe that this PR enables throwing voronois over non-linear scales. 

It is backwards compatible with the current usage, so nothing should break!