### PR TITLE
Website: Fixes broken links. Docs: Fixes typo on links to interaction.md

### DIFF
--- a/docs/area-series.md
+++ b/docs/area-series.md
@@ -123,7 +123,7 @@ See [interaction](interaction.md)
 #### onSeriesClick
 Type: `function`  
 Default: none  
-This handler fires when the user clicks somewhere on an AreaSeries, and provides the corresponding event. See [interaction](interaction.nd)
+This handler fires when the user clicks somewhere on an AreaSeries, and provides the corresponding event. See [interaction](interaction.md)
 
 ```jsx
 <AreaSeries
@@ -137,7 +137,7 @@ This handler fires when the user clicks somewhere on an AreaSeries, and provides
 #### onSeriesMouseOut
 Type: `function`  
 Default: none  
-This handler fires when the user's mouse cursor leaves an AreaSeries, and provides the corresponding event. See [interaction](interaction.nd)
+This handler fires when the user's mouse cursor leaves an AreaSeries, and provides the corresponding event. See [interaction](interaction.md)
 
 ```jsx
 <AreaSeries
@@ -151,7 +151,7 @@ This handler fires when the user's mouse cursor leaves an AreaSeries, and provid
 #### onSeriesMouseOver
 Type: `function`
 Default: none  
-This handler fires when the user mouses over an AreaSeries, and provides the corresponding event. See [interaction](interaction.nd)
+This handler fires when the user mouses over an AreaSeries, and provides the corresponding event. See [interaction](interaction.md)
 
 ```jsx
 <AreaSeries

--- a/docs/line-series.md
+++ b/docs/line-series.md
@@ -115,7 +115,7 @@ See [interaction](interaction.md)
 #### onSeriesClick
 Type: `function`  
 Default: none  
-This handler fires when the user clicks somewhere on a LineSeries, and provides the corresponding event. See [interaction](interaction.nd)
+This handler fires when the user clicks somewhere on a LineSeries, and provides the corresponding event. See [interaction](interaction.md)
 
 ```jsx
 <LineSeries
@@ -129,7 +129,7 @@ This handler fires when the user clicks somewhere on a LineSeries, and provides 
 #### onSeriesMouseOut
 Type: `function`  
 Default: none  
-This handler fires when the user's mouse cursor leaves a LineSeries, and provides the corresponding event. See [interaction](interaction.nd)
+This handler fires when the user's mouse cursor leaves a LineSeries, and provides the corresponding event. See [interaction](interaction.md)
 
 ```jsx
 LineSeries
@@ -143,7 +143,7 @@ LineSeries
 #### onSeriesMouseOver
 Type: `function`
 Default: none  
-This handler fires when the user mouses over a LineSeries, and provides the corresponding event. See [interaction](interaction.nd)
+This handler fires when the user mouses over a LineSeries, and provides the corresponding event. See [interaction](interaction.md)
 
 ```jsx
 <LineSeries
@@ -157,7 +157,7 @@ This handler fires when the user mouses over a LineSeries, and provides the corr
 #### onSeriesRightClick
 Type: `function`  
 Default: none  
-This handler fires when the user right-clicks somewhere on a LineSeries, and provides the corresponding event. See [interaction](interaction.nd)
+This handler fires when the user right-clicks somewhere on a LineSeries, and provides the corresponding event. See [interaction](interaction.md)
 
 ```jsx
 <LineSeries

--- a/website/src/mdRoutes.js
+++ b/website/src/mdRoutes.js
@@ -62,6 +62,15 @@ import responsiveVis from '../../docs/examples/responsive-vis.md';
 import zoomableChart from '../../docs/examples/zoomable-chart.md';
 import gitHistory from '../../docs/examples/history-example.md';
 
+// Ocular searches for links with at least one '/' and replaces them
+// with the first route it finds that includes the same markdown name
+// (that is error prone, and that's why current Axes links will all
+// point to Example Axes page instead of Documentation Axes page)
+const fixMarkdownLinks = (markdown) => {
+  const markdownLinksRegex = /(?:\(([^()/\n]+\.md)\))/g;
+  return markdown.replace(markdownLinksRegex, '(/$1)');
+};
+
 export default [
   {
     name: 'Examples',
@@ -72,39 +81,39 @@ export default [
         children: [
           {
             name: 'Plots',
-            markdown: plotsEx
+            markdown: fixMarkdownLinks(plotsEx)
           },
           {
             name: 'Axes',
-            markdown: axesEx
+            markdown: fixMarkdownLinks(axesEx)
           },
           {
             name: 'Legends',
-            markdown: legendsEx
+            markdown: fixMarkdownLinks(legendsEx)
           },
           {
             name: 'Sunbursts',
-            markdown: sunburstEx
+            markdown: fixMarkdownLinks(sunburstEx)
           },
           {
             name: 'Radial',
-            markdown: radialEx
+            markdown: fixMarkdownLinks(radialEx)
           },
           {
             name: 'Sankeys',
-            markdown: sankeyEx
+            markdown: fixMarkdownLinks(sankeyEx)
           },
           {
             name: 'Treemaps',
-            markdown: treemapEx
+            markdown: fixMarkdownLinks(treemapEx)
           },
           {
             name: 'Radar Charts',
-            markdown: radarEx
+            markdown: fixMarkdownLinks(radarEx)
           },
           {
             name: 'Misc',
-            markdown: miscEx
+            markdown: fixMarkdownLinks(miscEx)
           }
         ]
       },
@@ -113,27 +122,27 @@ export default [
         children: [
           {
             name: 'Candlestick',
-            markdown: extensibility
+            markdown: fixMarkdownLinks(extensibility)
           },
           {
             name: 'Force Directed Graph',
-            markdown: otherThings
+            markdown: fixMarkdownLinks(otherThings)
           },
           {
             name: 'Streamgraph',
-            markdown: streamGraph
+            markdown: fixMarkdownLinks(streamGraph)
           },
           {
             name: 'Responsive Vis',
-            markdown: responsiveVis
+            markdown: fixMarkdownLinks(responsiveVis)
           },
           {
             name: 'Zoomable Chart',
-            markdown: zoomableChart
+            markdown: fixMarkdownLinks(zoomableChart)
           },
           {
             name: 'Git History',
-            markdown: gitHistory
+            markdown: fixMarkdownLinks(gitHistory)
           }
         ]
       }
@@ -145,26 +154,26 @@ export default [
     data: [
       {
         name: 'Welcome to React-vis',
-        markdown: presentation
+        markdown: fixMarkdownLinks(presentation)
       },
       {
         name: 'Getting Started',
         children: [
           {
             name: 'React-vis in codepen',
-            markdown: codepen
+            markdown: fixMarkdownLinks(codepen)
           },
           {
             name: 'Installing react-vis',
-            markdown: install
+            markdown: fixMarkdownLinks(install)
           },
           {
             name: 'Creating a new react-vis project',
-            markdown: newProject
+            markdown: fixMarkdownLinks(newProject)
           },
           {
             name: 'Your first chart',
-            markdown: first
+            markdown: fixMarkdownLinks(first)
           }
         ]
       },
@@ -173,23 +182,23 @@ export default [
         children: [
           {
             name: 'Scales and data',
-            markdown: scalesAndData
+            markdown: fixMarkdownLinks(scalesAndData)
           },
           {
             name: 'Colors',
-            markdown: colors
+            markdown: fixMarkdownLinks(colors)
           },
           {
             name: 'Interaction',
-            markdown: interaction
+            markdown: fixMarkdownLinks(interaction)
           },
           {
             name: 'Animation',
-            markdown: animation
+            markdown: fixMarkdownLinks(animation)
           },
           {
             name: 'Style',
-            markdown: style
+            markdown: fixMarkdownLinks(style)
           }
         ]
       },
@@ -198,51 +207,51 @@ export default [
         children: [
           {
             name: 'XY-Plot',
-            markdown: xy
+            markdown: fixMarkdownLinks(xy)
           },
           {
             name: 'Series',
-            markdown: series
+            markdown: fixMarkdownLinks(series)
           },
           {
             name: 'Legends',
-            markdown: legends
+            markdown: fixMarkdownLinks(legends)
           },
           {
             name: 'Crosshair',
-            markdown: crosshair
+            markdown: fixMarkdownLinks(crosshair)
           },
           {
             name: 'Grids',
-            markdown: grids
+            markdown: fixMarkdownLinks(grids)
           },
           {
             name: 'Hint',
-            markdown: hint
+            markdown: fixMarkdownLinks(hint)
           },
           {
             name: 'Axes',
-            markdown: axes
+            markdown: fixMarkdownLinks(axes)
           },
           {
             name: 'DecorativeAxis',
-            markdown: decorativeAxis
+            markdown: fixMarkdownLinks(decorativeAxis)
           },
           {
             name: 'Gradients',
-            markdown: gradients
+            markdown: fixMarkdownLinks(gradients)
           },
           {
             name: 'Flexible plots',
-            markdown: flexiblePlots
+            markdown: fixMarkdownLinks(flexiblePlots)
           },
           {
             name: 'Borders',
-            markdown: borders
+            markdown: fixMarkdownLinks(borders)
           },
           {
             name: 'Voronoi',
-            markdown: voronoi
+            markdown: fixMarkdownLinks(voronoi)
           }
         ]
       },
@@ -251,55 +260,55 @@ export default [
         children: [
           {
             name: 'Arc Series',
-            markdown: arcSeries
+            markdown: fixMarkdownLinks(arcSeries)
           },
           {
             name: 'Area Series',
-            markdown: areaSeries
+            markdown: fixMarkdownLinks(areaSeries)
           },
           {
             name: 'Bar Series',
-            markdown: barSeries
+            markdown: fixMarkdownLinks(barSeries)
           },
           {
             name: 'Contour Series',
-            markdown: contourSeries
+            markdown: fixMarkdownLinks(contourSeries)
           },
           {
             name: 'Custom SVG Series',
-            markdown: customSvgSeries
+            markdown: fixMarkdownLinks(customSvgSeries)
           },
           {
             name: 'Heatmap Series',
-            markdown: heatmapSeries
+            markdown: fixMarkdownLinks(heatmapSeries)
           },
           {
             name: 'Label Series',
-            markdown: labelSeries
+            markdown: fixMarkdownLinks(labelSeries)
           },
           {
             name: 'Line Series',
-            markdown: lineSeries
+            markdown: fixMarkdownLinks(lineSeries)
           },
           {
             name: 'Line-Mark Series',
-            markdown: lineMarkSeries
+            markdown: fixMarkdownLinks(lineMarkSeries)
           },
           {
             name: 'Mark Series',
-            markdown: markSeries
+            markdown: fixMarkdownLinks(markSeries)
           },
           {
             name: 'Polygon Series',
-            markdown: polygonSeries
+            markdown: fixMarkdownLinks(polygonSeries)
           },
           {
             name: 'Rect Series',
-            markdown: rectSeries
+            markdown: fixMarkdownLinks(rectSeries)
           },
           {
             name: 'Whisker Series',
-            markdown: whiskerSeries
+            markdown: fixMarkdownLinks(whiskerSeries)
           }
         ]
       },
@@ -308,27 +317,27 @@ export default [
         children: [
           {
             name: 'Parallel Coordinates',
-            markdown: parallel
+            markdown: fixMarkdownLinks(parallel)
           },
           {
             name: 'Radar Chart',
-            markdown: radar
+            markdown: fixMarkdownLinks(radar)
           },
           {
             name: 'Radial Chart',
-            markdown: radial
+            markdown: fixMarkdownLinks(radial)
           },
           {
             name: 'Sankey Diagram',
-            markdown: sankey
+            markdown: fixMarkdownLinks(sankey)
           },
           {
             name: 'Sunburst Diagram',
-            markdown: sunburst
+            markdown: fixMarkdownLinks(sunburst)
           },
           {
             name: 'Treemap',
-            markdown: treemap
+            markdown: fixMarkdownLinks(treemap)
           }
         ]
       }


### PR DESCRIPTION
Relates to: https://github.com/uber/react-vis/issues/886

This PR fixes most of the broken links on the website, an also a few typos inside area-series and linea-series docs.

I say "most" because there are some links that are not pointing to the right page (for example the ones for Axes). 
Ocular is having an issue with how it replace markdown links for actual <a> tags: It searches for the markdown filename used on the link, inside the array of routes it generates. When it finds a route that includes that text, is uses that URL as the href value of the anchor tag. 
As there is an Axes route for Example page (https://uber.github.io/react-vis/examples/showcases/axes), and another for Documentation page (https://uber.github.io/react-vis/documentation/api-reference/axes), it always stays with the first match (Example) so all the links to Axes are pointing to the Axes Example page.
The same issue applies to MarkSeries (because it finds LineMarkSeries first)
