### PR TITLE
Adjust edge of complex chart

### DIFF
--- a/showcase/plot/complex-chart.js
+++ b/showcase/plot/complex-chart.js
@@ -170,7 +170,7 @@ export default class Example extends React.Component {
             getX={d => d.left}
             getY={d => d.top}
             onMouseLeave={this._mouseLeaveHandler}
-            xDomain={[0, series[0].data.length - 1]}
+            xDomain={[-0.5, series[0].data.length - 1]}
             height={300}>
             <HorizontalGridLines />
             <YAxis


### PR DESCRIPTION
It has always bother me how the edge of the complex chart would go over the axis. 

Before
![old-complex](https://user-images.githubusercontent.com/6854312/44434419-a0f2ff80-a570-11e8-8c76-d98434b9a544.gif)


After
![complex-adjust](https://user-images.githubusercontent.com/6854312/44434423-aa7c6780-a570-11e8-8399-8fd343275bae.gif)

