### PR TITLE
Fixing some documentation links

### DIFF
--- a/docs/series.md
+++ b/docs/series.md
@@ -8,7 +8,7 @@ The library supports several types of series:
 * [ContourSeries](contour-series.md) for making contour density plots;
 * [HeatmapSeries](heatmap-series.md) for heat maps.
 * [LabelSeries](label-series.md) for adding annotations to charts
-* [LineMarkSeries](line-series.md) is a shorthand to place marks (e.g. circles) on lines;
+* [LineMarkSeries](line-mark-series.md) is a shorthand to place marks (e.g. circles) on lines;
 * [LineSeries](line-series.md) for lines;
 * [MarkSeries](mark-series.md) for scatterplots;
 * [PolygonSeries](polygon-series.md) for arbitrary SVG shapes

--- a/docs/xy-plot.md
+++ b/docs/xy-plot.md
@@ -79,13 +79,13 @@ Not all properties can be visualized in each series. Here's a short comparison o
 |                      | `x` | `y` | `color` | `opacity` | `size` |
 |----------------------|-----|-----|---------|-----------|--------|
 | [LineSeries](line-series.md)  |  +  |  +  | +       |           |        |
-| `AreaSeries`         |  +  |  +  | +       |           |        |
-| [LineMarkSeries](line-series.md)     |  +  |  +  | +       |     +     | +      |
-| `MarkSeries`         |  +  |  +  | +       |     +     | +      |
+| [AreaSeries](area-series.md)         |  +  |  +  | +       |           |        |
+| [LineMarkSeries](line-mark-series.md)     |  +  |  +  | +       |     +     | +      |
+| [MarkSeries](mark-series.md)         |  +  |  +  | +       |     +     | +      |
 | [VerticalBarSeries](bar-series.md)  |  +  |  +  | +       |     +     |        |
 | [HorizontalBarSeries](bar-series.md)|  +  |  +  | +       |     +     |        |
-| `VerticalRectSeries`  |  +  |  +  | +       |     +     |        |
-| `HorizontalRectSeries`|  +  |  +  | +       |     +     |        |
+| [VerticalRectSeries](rect-series.md)  |  +  |  +  | +       |     +     |        |
+| [HorizontalRectSeries](rect-series.md)|  +  |  +  | +       |     +     |        |
 | [HeatmapSeries](heatmap-series.md)      |  +  |  +  | +       |     +     |        |      |
 
 


### PR DESCRIPTION
A few links inside documentation were pointing to the wrong place. 
I also added some more links for consistency.
