### PR TITLE
Fixing BarSeries overlapped

### DIFF
--- a/src/plot/series/bar-series-canvas.js
+++ b/src/plot/series/bar-series-canvas.js
@@ -68,12 +68,14 @@ class BarSeriesCanvas extends AbstractSeries {
       const strokeColor = rgb(stroke(row));
       const rowOpacity = opacity(row) || DEFAULT_OPACITY;
 
-      const linePos = line(row) - itemSize + (itemSize * 2 / sameTypeTotal * sameTypeIndex);
+      const linePos = line(row) - itemSize +
+        (((itemSize * 2 / sameTypeTotal) - (1 - (1 / sameTypeTotal))) * sameTypeIndex) +
+        sameTypeIndex;
       const valuePos = Math.min(value0(row), value(row));
       const x = valuePosAttr === 'x' ? valuePos : linePos;
       const y = valuePosAttr === 'y' ? valuePos : linePos;
 
-      const lineSize = itemSize * 2 / sameTypeTotal;
+      const lineSize = ((itemSize * 2 / sameTypeTotal) - (1 - (1 / sameTypeTotal)));
       const valueSize = Math.abs(-value0(row) + value(row));
       const height = lineSizeAttr === 'height' ? lineSize : valueSize;
       const width = lineSizeAttr === 'width' ? lineSize : valueSize;

--- a/src/plot/series/bar-series.js
+++ b/src/plot/series/bar-series.js
@@ -94,8 +94,9 @@ class BarSeries extends AbstractSeries {
               ...style
             },
             [linePosAttr]: lineFunctor(d) - itemSize +
-            (itemSize * 2 / sameTypeTotal * sameTypeIndex),
-            [lineSizeAttr]: itemSize * 2 / sameTypeTotal,
+            (((itemSize * 2 / sameTypeTotal) - (1 - (1 / sameTypeTotal))) * sameTypeIndex) +
+            sameTypeIndex,
+            [lineSizeAttr]: ((itemSize * 2 / sameTypeTotal) - (1 - (1 / sameTypeTotal))),
             [valuePosAttr]: Math.min(value0Functor(d), valueFunctor(d)),
             [valueSizeAttr]: Math.abs(-value0Functor(d) + valueFunctor(d)),
             onClick: e => this._valueClickHandler(d, e),


### PR DESCRIPTION
This PR adjusts the calculation of bar width and starting position, to avoid bars "of same type" getting overlapped.
 
Reference: https://github.com/uber/react-vis/issues/936

### Before
![image](https://user-images.githubusercontent.com/6829313/44631167-d451d780-a93e-11e8-9adf-b945b39046b9.png)

### After
![image](https://user-images.githubusercontent.com/6829313/44762980-80eaaf80-ab1f-11e8-9259-6702eb945724.png)

