### PR TITLE
Make props in documentation easier to parse (#984)

### DIFF
--- a/docs/axes.md
+++ b/docs/axes.md
@@ -123,7 +123,7 @@ Height of the axis in pixels. **Already set by default**, but can be overridden 
 #### animation (optional)
 See the [XYPlot](xy-plot.md)'s `animation` section for more information.
 
-### style (optional)
+#### style (optional)
 Type: `object`
 An object that contains CSS properties with which the axis component can be entirely re-styled.
 As the Axis component is composite, it is possible to style its different parts individually. See [style](style.md)

--- a/docs/bar-series.md
+++ b/docs/bar-series.md
@@ -94,7 +94,7 @@ The opacity for all elements in the series, this property will be over-ridden by
 Type: `string|number`
 The outer color for all elements in the series, this property will be over-ridden by stroke specified in the data attribute. See [colors](colors.md)
 
-### style
+#### style
 Type: `object`
 A list of CSS properties to style the series outside of the explicitly set properties. Note that it will override all other properties (ie fill, stroke, opacity, color). See [style](style.md)
 

--- a/docs/borders.md
+++ b/docs/borders.md
@@ -35,11 +35,11 @@ would cause the first area series to be truncated underneath the borders, while 
 
 ## API Reference
 
-### className (optional)
+#### className (optional)
 Type: `String`
 A class name to apply to each of the borders, as well as the root border container. It will be enumerates on top the borders using suffixes, eg if className={"my-cool-class"} the top rectangle will have a class name "my-cool-class-top".
 
-### Style (optional)
+#### style (optional)
 Type: `Object`
 You can pass a style object to your Hint component to apply your own styles. See [style](style.md)
 ```jsx

--- a/docs/colors.md
+++ b/docs/colors.md
@@ -33,7 +33,7 @@ So it goes like this:
 
 ### Cases
 
-#### We do nothing:
+We do nothing:
 
 <!-- INJECT:"SensibleDefaultsWithLink" -->
 
@@ -41,7 +41,7 @@ With no color instruction, colors are automatically set by series according to t
 
 <!-- INJECT:"ReactVis5WithLink" -->
 
-#### We specify color in XYPlot
+We specify color in XYPlot
 
 ```jsx
 <XYPlot height={200} width={200} color="red">
@@ -65,7 +65,7 @@ With no color instruction, colors are automatically set by series according to t
 
 Without any further instruction, all the series are red. Note that in the case of LineSeries, we have to use stroke instead of color for this effect to work.
 
-#### We specify color by series
+We specify color by series
 
 The next step is passing colors to by series. When we do that, we add a color prop to each series component:
 
@@ -76,7 +76,8 @@ The next step is passing colors to by series. When we do that, we add a color pr
 
 How this color information is going to be treated depends on a number of factors.
 
-##### Color scales
+Color scales
+
 Once it's passed through series, color works like a [scale](scales-and-data.md); in other words, it transforms data into a visual representation.
 There are several types of scales.
 
@@ -93,7 +94,7 @@ For instance, if a categorical color scale has the domain: ['yes', 'maybe', 'no'
 
 Finally, the literal color scale just returns whatever is provided as is. With a literal color scale, we can have color names in the dataset, and they will be used without transformation.
 
-##### Categorical colors at series level
+Categorical colors at series level
 
 <!-- INJECT:"CategoryColorAtSeriesLevelWithLink" -->
 
@@ -131,7 +132,7 @@ For this example, the XYPlot props are:
 
 As you can see, __using categorical color at the series level doesn't work for bar charts or scatterplots__. It does for line charts though.
 
-##### Linear colors at series level
+Linear colors at series level
 
 <!-- INJECT:"LinearColorAtSeriesLevelWithLink" -->
 
@@ -167,7 +168,7 @@ As you can see, __using categorical color at the series level doesn't work for b
 
 Likewise, __using linear color at the series level only works for line charts__.
 
-##### Literal colors at series level
+Literal colors at series level
 
 <!-- INJECT:"LiteralColorAtSeriesLevelWithLink" -->
 
@@ -191,7 +192,7 @@ Likewise, __using linear color at the series level only works for line charts__.
 
 However, setting color at the series level works for all kinds of charts. It's not even necessary to specify a color type, a domain or a range.
 
-#### We specify color information at mark level
+We specify color information at mark level
 
 For this second series of charts, we are going to specify color information inside of our dataset (ie the series which will be passed to the props "data").
 Previously, our datasets only included x and y information:
@@ -208,7 +209,7 @@ Now, they will have a color information as well.
 * Finally, for our literal example, the color information will be the name of a color in hex format.
 
 
-##### Categorical colors at mark level
+Categorical colors at mark level
 <!-- INJECT:"CategoryColorAtMarkLevelWithLink" -->
 
 ```jsx
@@ -242,7 +243,7 @@ Here, I have specified the colorType prop at the XYPlot level. I could have done
 It's going to use the default extended palette as the color range. We'll override this in the next example. As for domain, it's going to associate the first color value it finds in the dataset with the first color of the palette, the second distinct color it finds with the second color of the palette, and so on and so forth.
 With this syntax, we'll render marks which have different color information in different colors, but we don't control which color. If we want to control which color a specific value is going to be associated with, we have to pass a colorDomain.
 
-##### Categorical colors at mark level, custom palette
+Categorical colors at mark level, custom palette
 <!-- INJECT:"CategoryColorAtMarkLevelCustomPaletteWithLink" -->
 
 ```jsx
@@ -269,7 +270,7 @@ This time, I'm passing a custom palette:
 
 Behavior for line chart is still identical, but the colors are different for our bar charts and scatterplots. As I'm not passing a color domain, I still don't control which value will be associated with which color - not super important since my color values are random numbers. But if order matters, a colorDomain is required.
 
-##### Linear colors at mark level, default palette
+Linear colors at mark level, default palette
 
 <!-- INJECT:"LinearColorAtMarkLevelNoPaletteWithLink" -->
 
@@ -299,7 +300,7 @@ I haven't specified the color range either. React-Vis will compute it by looking
 
 The line charts are still unaffected.
 
-##### Linear colors at mark level, custom palette
+Linear colors at mark level, custom palette
 
 <!-- INJECT:"LinearColorAtMarkLevelWithLink" -->
 
@@ -323,7 +324,7 @@ The line charts are still unaffected.
 
 Here's the same code, but we define the color range. This green palette comes from ColorBrewer.
 
-##### Literal colors at mark level, default palette
+Literal colors at mark level, default palette
 
 <!-- INJECT:"LiteralColorAtMarkLevelWithLink" -->
 
@@ -349,7 +350,7 @@ Finally, we can pass literal color names in our dataset from our custom palette.
 
 ### Going beyond
 
-#### Independently control fill and stroke
+Independently control fill and stroke
 
 The line chart series (LineSeries) is only a line, but most other series (AreaSeries, ArcSeries, BarSeries, HeatmapSeries, HexbinSeries, MarkSeries, RectSeries and their derivatives, including LineMarkSeries) involve 2D shapes that have both a fill color and a stroke color.
 
@@ -405,11 +406,11 @@ Note that in the case of a LineMarkSeries (a combination of a LineSeries and a M
 Here, I want my dots to have a white outline.
 Why did I specify the color of each of my series? You might have to scroll all the way to the top for the answer! If I had done nothing all the colors of my series would have been taken from the default palette for each new series. So the first line series would have had the first color, then the first mark series would have had the _second_ color... and so on and so forth. By specifying a color, we are guaranteeing that the dots and the lines have the same color.
 
-#### Using styles
+Using styles
 
 We can pass style information to anything - XYPlot, series, mark - and override the look and feel of that element. Styles don't have to be static objects - they can be computed at run time. Styles are a different way to control colors. While using the color prop, or a color property in a dataset, can be much more concise, everything can be affected by styles - including non-mark elements such as ticks or gridlines. See [style](style.md) for more info.
 
-#### Using specificity
+Using specificity
 
 We've seen that we can set color information at the plot level, at the series level and at the mark level. But what happens when we do it at several levels at the same time? The most specific wins.
 
@@ -439,7 +440,7 @@ Notes:
 * For the line series, which behave differently than other series, you must use stroke instead of color for this to work.
 * For the scatterplot series, I'm using specificity twice: there's a color at the plot level, overridden by a color at the first series level, overridden by a color on the 7th mark of the series.
 
-#### Using gradients
+Using gradients
 
 Why use a boring solid color when you can use gradients? We're not sure either! Once you define gradients (see [gradients](gradients.md)) you can use them instead of color (or fill, or stroke) at the series level.
 

--- a/docs/contour-series.md
+++ b/docs/contour-series.md
@@ -29,10 +29,10 @@ The ContourSeries expects a similar data input as would be fed to either the Mar
 
 ## API reference
 
-#### animation (optional)  
+#### animation (optional)
 See the [XYPlot](xy-plot.md)'s `animation` section for more information.
 
-#### bandwidth (optional)  
+#### bandwidth (optional)
 A parameter that directly maps into d3-contour's bandwidth parameter. See the [docs for more](https://github.com/d3/d3-contour#density_bandwidth)
 
 #### className (optional)
@@ -43,7 +43,7 @@ Provide an additional class name for the series.
 Type: `Array<Object>`
 Array of data for the series. Follows the usual pattern of an array of objects formatted with x and y coordinates, [{x: 0, y: 0}, ...].
 
-### style
+#### style
 Type: `object`
 A list of CSS properties to style the series outside of the explicitly set properties. Note that it will override all other properties (ie fill, stroke, opacity, color). See [style](style.md)
 

--- a/docs/crosshair.md
+++ b/docs/crosshair.md
@@ -24,7 +24,7 @@ Type: `function`
 The function that formats the list of items for the crosshair. Receives the list of data points, should return an array of objects containing `title` and `value` properties.
 _Note: please pass custom contents in case if you need different look for the crosshair._
 
-### style (optional)
+#### style (optional)
 Type: `object`
 An object that contains objects of CSS properties with which the component can be entirely re-styled.
 As the Crosshair is composed of several elements, it is possible to provide style objects for any and all parts of the tree. See [style](style.md)

--- a/docs/custom-svg-series.md
+++ b/docs/custom-svg-series.md
@@ -51,7 +51,7 @@ If using a function to defined your mark, it is important to note that the funct
 
 ## API reference
 
-#### animation (optional)  
+#### animation (optional)
 See the [XYPlot](xy-plot.md)'s `animation` section for more information.
 
 #### className (optional)
@@ -66,7 +66,7 @@ Provides the mark type for the entire series. Defaults to a 'circle'. See `Defin
 Type: `Array<Object>`
 Array of data for the series. See above data format reference.
 
-### style
+#### style
 Type: `object`
 A list of CSS properties to style the series outside of the explicitly set properties. Note that it will override all other properties (ie fill, stroke, opacity, color). See [style](style.md)
 

--- a/docs/decorative-axis.md
+++ b/docs/decorative-axis.md
@@ -56,7 +56,7 @@ Format function for the tick label. Similar to the `tickFormat()` method of d3-a
 #### animation (optional)
 See the [XYPlot](xy-plot.md)'s `animation` section for more information.
 
-### style (optional)
+#### style (optional)
 Type: `object`
 An object that contains CSS properties with which the axis component can be entirely re-styled.
 As the Axis component is composite, it is possible to style its different parts individually. See [style](style.md)

--- a/docs/heatmap-series.md
+++ b/docs/heatmap-series.md
@@ -96,7 +96,7 @@ The color of a box in the series. By default the color is interpreted as number 
 
 ## Series API Reference
 
-#### animation (optional)  
+#### animation (optional)
 See the [XYPlot](xy-plot.md)'s `animation` section for more information.
 
 #### color
@@ -123,7 +123,7 @@ The opacity for all elements in the series, this property will be over-ridden by
 Type: `string|number`
 The outer color for all elements in the series, this property will be over-ridden by color specified in the data attribute. See [colors](colors.md)
 
-### style
+#### style
 Type: `object`
 A list of CSS properties to style the series outside of the explicitly set properties. Note that it will override all other properties (ie fill, stroke, opacity, color). See [style](style.md)
 

--- a/docs/hexbin-series.md
+++ b/docs/hexbin-series.md
@@ -35,7 +35,7 @@ Points are binned into hexagonal containers, which are then rendered as svg path
 
 ## API reference
 
-#### animation (optional)  
+#### animation (optional)
 Type: `Boolean`
 See the [Animation](animation.md)'s `animation` section for more information.
 
@@ -59,20 +59,20 @@ Array of data for the series. Follows the usual pattern of an array of objects f
 Type: `Number`
 The maximum size of the hexagon, specified in pixels.
 
-### style
+#### style
 Type: `object`
 A list of CSS properties to style the series outside of the explicitly set properties. These style elements are applied directly to each individual hexagon. Note that it will override all other properties (ie fill, stroke, opacity, color). See [style](style.md) for more information.
 
-### sizeHexagonsWithCount
+#### sizeHexagonsWithCount
 Type: `Boolean`
 Size the hexagons based on the number of values in side of the hexagon. Ranges between [0, <radius prop>].
 
-### xOffset (optional)
+#### xOffset (optional)
 Type: `Number`
 Default: 0
 Size of aggregation offset form base value, this enables fine tuning along the x axis.
 
-### yOffset (optional)
+#### yOffset (optional)
 Type: `Number`
 Default: 0
 Size of aggregation offset form base value, this enables fine tuning along the y axis.

--- a/docs/highlight.md
+++ b/docs/highlight.md
@@ -53,64 +53,64 @@ It is important to note that brushing over non-continuous scales is not supporte
 <!-- INJECT:"SelectionPlotExampleWithLink" -->
 
 
-### className (optional)
+#### className (optional)
 Type: `String`
 Add css class to Voronoi container
 
-### drag (optional)
+#### drag (optional)
 Type: `Boolean`
 Enable dragging interactions
 
-### enableX (optional)
+#### enableX (optional)
 Type: `Boolean`
 Defaults to `true`
 Enable brushing and dragging in the x direction
 
-### enableY (optional)
+#### enableY (optional)
 Type: `Boolean`
 Defaults to `true`
 Enable brushing and dragging in the y direction
 
-### highlightX (optional)
+#### highlightX (optional)
 Type: `String or Number`
 Defaults to left edge
 Position in x coordinate space to place the left edge of the highlight bar.
 
-### highlightY (optional)
+#### highlightY (optional)
 Type: `String or Number`
 Defaults to top edge
 Position in y coordinate space to place the top edge of the highlight bar.
 
-### highlightHeight (optional)
+#### highlightHeight (optional)
 Type: `Number`
 Defaults to full height
 The height of highlight bar in pixels.
 
-### highlightWidth (optional)
+#### highlightWidth (optional)
 Type: `Number`
 Defaults to full width
 The width of highlight bar in pixels.
 
-### onBrushStart (optional)
+#### onBrushStart (optional)
 Type: `Function`
 Function called on the start of brushing.
 
-### onBrush (optional)
+#### onBrush (optional)
 Type: `Function`
 Function called on the start of brushing.
 
-### onBrushEnd (optional)
+#### onBrushEnd (optional)
 Type: `Function`
 Function called on the start of brushing.
 
-### onDragStart (optional)
+#### onDragStart (optional)
 Type: `Function`
 Function called on the start of dragging.
 
-### onDrag (optional)
+#### onDrag (optional)
 Type: `Function`
 Function called on the start of dragging.
 
-### onDragEnd (optional)
+#### onDragEnd (optional)
 Type: `Function`
 Function called on the start of dragging.

--- a/docs/hint.md
+++ b/docs/hint.md
@@ -42,7 +42,7 @@ The way to align the hint inside the chart. Within the object, specify the horiz
 
 <!-- INJECT:"DynamicSimpleTopEdgeHintsWithLink" -->
 
-### Style (optional)
+#### style (optional)
 Type: `Object`
 You can pass a style object to your Hint component to apply your own styles. See [style](style.md)
 ```jsx

--- a/docs/interaction.md
+++ b/docs/interaction.md
@@ -45,44 +45,44 @@ In all cases, onNearestX and onNearestXY can be implemented at the series level,
 
 ### XYPlot event handlers
 
-### onMouseDown
+#### onMouseDown
 Type: `function`
 Default: none
 This event handler is triggered whenever the mousebutton of the user is down while their mouse cursor is in the plot area. It passes a mouse event.
 
-### onMouseUp
+#### onMouseUp
 Type: `function`
 Default: none
 This event handler is triggered whenever the user release the mouse button while their mouse cursor is in the plot area. It passes a mouse event.
 
-### onMouseEnter
+#### onMouseEnter
 Type: `function`
 Default: none
 This event handler is triggered whenever the mouse of the user enters the plot area. It passes a mouse event.
 
-### onMouseLeave
+#### onMouseLeave
 Type: `function`
 Default: none
 This event handler is triggered whenever the mouse of the user exits the plot area. It passes a mouse event.
 
-### onMouseMove
+#### onMouseMove
 Type: `function`
 Default: none
 This event handler is triggered whenever the mouse of the user moves while in the plot area. It passes a mouse event.
 
-### onTouchStart
+#### onTouchStart
 Type: `function`
 The event handler is triggered whenever the finger of the user first touches the plot area. It passes a touch event.
 
-### onTouchMove
+#### onTouchMove
 Type: `function`
 This event handler is triggered whenever the finger of the user moves while in the plot area. It passes a touch event.
 
-### onTouchEnd
+#### onTouchEnd
 Type: `function`
 This event handler is triggered when a touch point of the user lifts off the plot area. It passes a touch event.
 
-### onTouchCancel
+#### onTouchCancel
 Type: `function`
 This event handler is triggered when a touch point of the user has been disrupted in an implementation-specific manner
 

--- a/docs/label-series.md
+++ b/docs/label-series.md
@@ -56,10 +56,10 @@ Number in degrees for the text to be rotated about its xy point.
 
 ## Series API Reference
 
-#### animation (optional)  
+#### animation (optional)
 See the [XYPlot](xy-plot.md)'s `animation` section for more information.
 
-### allowOffsetToBeReversed (optional)
+#### allowOffsetToBeReversed (optional)
 The allows the offset specified on the data rows to flipped if the label is too close to an edge. This allows you to make sure your labels never get randomly clipped by going offscreen.
 
 #### className (optional)

--- a/docs/parallel-coordinates.md
+++ b/docs/parallel-coordinates.md
@@ -98,7 +98,7 @@ Type: `Boolean`
 Default: false
 Enable stateful brushing on parallel coordinates
 
-### style (optional)
+#### style (optional)
 Type: `object`
 An object that contains CSS properties with which the axis component can be entirely re-styled.
 As the ParallelCoordinates is composite of several composite elements, it is possible to provide style objects for any and all parts of the tree. See [style](style.md)

--- a/docs/radar-chart.md
+++ b/docs/radar-chart.md
@@ -72,7 +72,7 @@ Type: `Object`
 Default: `{left: 40, right: 10, top: 10, bottom: 40}`
 Margin around the chart.
 
-### style (optional)
+#### style (optional)
 Type: `object`
 An object that contains CSS properties with which the axis component can be entirely re-styled.
 As the RadarChart is composite of several composite elements, it is possible to provide style objects for any and all parts of the tree. See [style](style.md)

--- a/docs/rect-series.md
+++ b/docs/rect-series.md
@@ -115,7 +115,7 @@ The opacity for all elements in the series, this property will be over-ridden by
 Type: `string|number`
 The outer color for all elements in the series, this property will be over-ridden by color specified in the data attribute.
 
-### style
+#### style
 Type: `object`
 A list of CSS properties to style the series outside of the explicitly set properties. Note that it will override all other properties (ie fill, stroke, opacity, color). See [style](style.md)
 

--- a/docs/sankey.md
+++ b/docs/sankey.md
@@ -190,7 +190,7 @@ This handler is triggered when the user's exits a link. Callback accepts the dat
 />
 ```
 
-### style (optional)
+#### style (optional)
 Type: `object`
 An object that contains CSS properties with which the axis component can be entirely re-styled.
 As the Sankey is composite of several composite elements, it is possible to provide style objects for any and all parts of the tree. See [style](style.md)

--- a/docs/style.md
+++ b/docs/style.md
@@ -13,7 +13,7 @@ Non-series elements (i.e. [gridlines](grids.md) or [hints](hint.md)) do not take
 ### Component-specific properties
 Virtually every component accept several properties that affects its appearance. For instance, [line series](line-series.md) take a `color` property to control the stroke color of the line, but others as well such as strokeWidth that controls its thickness. Each of these is described in detail for each component. 
 
-### Style property
+#### style property
 Finally, components can also accept a special property called `style`. This let you pass an object to the component. The keys of that object are CSS properties, camel-cased (ie `stroke-width` would be written `strokeWidth`) and values are what you'd want to set those properties to. These are the same conventions than when [passing style](https://facebook.github.io/react/docs/dom-elements.html) to a standard DOM element with React.
 
 ```javascript

--- a/docs/voronoi.md
+++ b/docs/voronoi.md
@@ -18,12 +18,12 @@ Voronoi diagrams are useful for making a chart interactive by creating target ar
 
 <!-- INJECT:"DynamicCrosshairScatterplotWithLink" -->
 
-### extent
+#### extent
 Type: `Array`
 Sets the clip extent of the Voronoi layout to the specified bounds. The extent bounds are specified as an array [[x0, y0], [x1, y1]], where x0 is the left side of the extent, y0 is the top, x1 is the right and y1 is the bottom.
 Extent should take the dimensions of the accompanying XYPlot into account, so using the plot's width, height and margins: `[[marginLeft, marginTop], [width, height]]`, which coincidentally is the default extent.
 
-### nodes (required)
+#### nodes (required)
 Type: `Array`
 The array must consist of `{x, y}` objects. These are often identical to the data passed to a series in the accompanying plot.
 
@@ -39,45 +39,45 @@ Example:
 ];
 ```
 
-### x (optional)
+#### x (optional)
 Type: `Function`
 Sets the x-coordinate accessor. Often you want to convert the coordinate-values to pixel values like
 `x={d => x(d.x)}`. If not provided defaults to wrapping XYPlot's xScale.
 
-### y (optional)
+#### y (optional)
 Type: `Function`
 Sets the y-coordinate accessor. Often you want to convert the coordinate-values to pixel values like
 `y={d => y(d.y)}`. If not provided defaults to wrapping XYPlot's yScale.
 
-### onBlur (optional)
+#### onBlur (optional)
 Type: `Function`
 Add `blur`-event to Voronoi cells
 
-### onClick (optional)
+#### onClick (optional)
 Type: `Function`
 Add `click`-event to Voronoi cells
 
-### onMouseUp (optional)
+#### onMouseUp (optional)
 Type: `Function`
 Add `mouseUp`-event to Voronoi cells
 
-### onMouseDown (optional)
+#### onMouseDown (optional)
 Type: `Function`
 Add `mouseDown`-event to Voronoi cells
 
-### onHover (optional)
+#### onHover (optional)
 Type: `Function`
 Add `hover`-event to Voronoi cells
 
-### className (optional)
+#### className (optional)
 Type: `String`
 Add css class to Voronoi container
 
-### style (optional)
+##### style (optional)
 Type: `Object`
 Add css styles to Voronoi container
 
-### polygonStyle (optional)
+#### polygonStyle (optional)
 Type: `Object`
 Add css styles to Voronoi cells.
 

--- a/docs/xy-plot.md
+++ b/docs/xy-plot.md
@@ -151,7 +151,7 @@ Margin around the chart.
 Type: `string`
 Stack the chart by the given attribute. If the attribute is `y`, the chart is stacked vertically; if the attribute is `x` then it's stacked horizontally. See the [Series](series.md) API reference for series level stack opt-in.
 
-### style (optional)
+#### style (optional)
 Type: `object`
 CSS properties that will affect this wrapper component. Those will be applied to the SVG element in which other react-vis components will be created.
 

--- a/website/src/styles/index.scss
+++ b/website/src/styles/index.scss
@@ -60,6 +60,42 @@
     display: none;
   }
 
+  &.markdown-body {
+    h2 + h4,
+    h2 + h5 {
+      margin-top: 0;
+    }
+
+    h4,
+    h5 {
+      display: block;
+      width: max-content;
+      width: -moz-max-content;
+      padding: 0.2em 0.6em;
+      margin-top: 2em;
+      font-size: 1em;
+      line-height: 1.5em;
+      font-weight: 600;
+      background: rgba(#00ADE6, 0.09);
+
+      & ~ p,
+      & ~ pre,
+      & ~ ul {
+        margin-left: 2em;
+        font-size: 0.9em;
+        line-height: 1.5em;
+
+        @media (max-width: 400px) {
+          margin-left: 1em;
+        }
+
+        & + h2 {
+          margin-top: 2em;
+        }
+      }
+    }
+  }
+
   .Contributors.m-top {
     margin-top: 0;
 


### PR DESCRIPTION
I took a stab at making the props in the docs easier to parse - I like when the attributes are very visible, but totally understand if the style is too bold.

![image](https://user-images.githubusercontent.com/3506269/46587756-f91d8c80-ca5e-11e8-85a5-7ddeb981412f.png)

Since props in the docs are just generic headers (h3, h4, h5), I targeted h4 and h5s to prevent changing headers in other parts of the docs. There are a few prop declarations that use `h3`s, which are updated in the second commit :raised_hands: 
