### PR TITLE
add stroke properties to discrete color legend (#860)

### DIFF
--- a/docs/legends.md
+++ b/docs/legends.md
@@ -18,8 +18,8 @@ Currently following types of legends are supported:
 <!-- INJECT:"VerticalDiscreteColorLegendExampleWithLink" -->
 
 #### items (required)
-Type: `Array<string|{title: string, color: String, disabled: boolean}|react element>`
-Array of items that should be shown on the legend. The array should consist from either objects (`title`, optional `color` and optional `disabled` flag) or strings (treated as titles).
+Type: `Array<string|{title: string, color: String, strokeDasharray: string, strokeStyle: string, strokeWidth: number, disabled: boolean}|react element>`
+Array of items that should be shown on the legend. The array should consist from either objects (`title`, optional `color`, optional `strokeDasharray`, optional `strokeStyle`, optional `strokeWidth`, and optional `disabled` flag) or strings (treated as titles). The stroke properties should match those in your series (see [line series](line-mark-series.md))
 
 #### orientation (optional)
 Type: `(vertical|horizontal)`

--- a/showcase/legends/searchable-discrete-color.js
+++ b/showcase/legends/searchable-discrete-color.js
@@ -27,10 +27,10 @@ export default class Example extends React.Component {
     super(props);
     this.state = {
       items: [
-        {title: 'Apples', color: '#3a3'},
+        {title: 'Apples', color: '#3a3', strokeStyle: "dashed"},
         {title: 'Bananas', color: '#fc0'},
         {title: 'Blueberries', color: '#337'},
-        {title: 'Carrots', color: '#f93'},
+        {title: 'Carrots', color: '#f93', strokeWidth: 6},
         {title: 'Eggplants', color: '#337'},
         {title: 'Limes', color: '#cf3'},
         {title: 'Potatoes', color: '#766'}

--- a/src/legends/discrete-color-legend-item.js
+++ b/src/legends/discrete-color-legend-item.js
@@ -22,8 +22,16 @@ import React from 'react';
 
 import PropTypes from 'prop-types';
 
+const STROKE_STYLES = {
+  dashed: '6, 2',
+  solid: null
+};
+
 function DiscreteColorLegendItem({
   color,
+  strokeDasharray,
+  strokeStyle,
+  strokeWidth,
   disabled,
   onClick,
   orientation,
@@ -40,10 +48,18 @@ function DiscreteColorLegendItem({
   }
   return (
     <div {...{className, onClick, onMouseEnter, onMouseLeave}}>
-      <span
-        className="rv-discrete-color-legend-item__color"
-        style={disabled ? null : {background: color}}
-      />
+      <svg className="rv-discrete-color-legend-item__color" height={2} width={14}>
+        <path
+          className="rv-discrete-color-legend-item__color__path"
+          d="M 0, 1 L 14, 1"
+          style={{
+            strokeWidth,
+            strokeDasharray: STROKE_STYLES[strokeStyle] || strokeDasharray,
+            stroke: disabled ? null : color
+          }}
+
+        />
+      </svg>
       <span className="rv-discrete-color-legend-item__title">{title}</span>
     </div>
   );
@@ -56,10 +72,14 @@ DiscreteColorLegendItem.propTypes = {
   onClick: PropTypes.func,
   onMouseEnter: PropTypes.func,
   onMouseLeave: PropTypes.func,
-  orientation: PropTypes.oneOf(['vertical', 'horizontal']).isRequired
+  orientation: PropTypes.oneOf(['vertical', 'horizontal']).isRequired,
+  strokeDasharray: PropTypes.string,
+  strokeWidth: PropTypes.number,
+  strokeStyle: PropTypes.oneOf(Object.keys(STROKE_STYLES))
 };
 DiscreteColorLegendItem.defaultProps = {
-  disabled: false
+  disabled: false,
+  strokeStyle: 'solid'
 };
 DiscreteColorLegendItem.displayName = 'DiscreteColorLegendItem';
 

--- a/src/legends/discrete-color-legend-item.js
+++ b/src/legends/discrete-color-legend-item.js
@@ -46,6 +46,7 @@ function DiscreteColorLegendItem({
   if (onClick) {
     className += ' clickable';
   }
+  const strokeDasharrayStyle = STROKE_STYLES[strokeStyle] || strokeDasharray;
   return (
     <div {...{className, onClick, onMouseEnter, onMouseLeave}}>
       <svg className="rv-discrete-color-legend-item__color" height={2} width={14}>
@@ -53,8 +54,8 @@ function DiscreteColorLegendItem({
           className="rv-discrete-color-legend-item__color__path"
           d="M 0, 1 L 14, 1"
           style={{
-            strokeWidth,
-            strokeDasharray: STROKE_STYLES[strokeStyle] || strokeDasharray,
+            ...(strokeWidth ? {strokeWidth} : {}),
+            ...(strokeDasharrayStyle ? {strokeDasharray: strokeDasharrayStyle} : {}),
             stroke: disabled ? null : color
           }}
 

--- a/src/legends/discrete-color-legend.js
+++ b/src/legends/discrete-color-legend.js
@@ -45,6 +45,9 @@ function DiscreteColorLegend({
         <DiscreteColorLegendItem
           title={item.title ? item.title : item}
           color={item.color ? item.color : colors[i % colors.length]}
+          strokeDasharray={item.strokeDasharray}
+          strokeStyle={item.strokeStyle}
+          strokeWidth={item.strokeWidth}
           disabled={Boolean(item.disabled)}
           orientation={orientation}
           key={i}

--- a/src/styles/legends.scss
+++ b/src/styles/legends.scss
@@ -27,11 +27,14 @@ $rv-legend-disabled-color: #b8b8b8;
 }
 
 .rv-discrete-color-legend-item__color {
-  background: #dcdcdc;
   display: inline-block;
-  height: 2px;
   vertical-align: middle;
-  width: 14px;
+  overflow: visible;
+}
+
+.rv-discrete-color-legend-item__color__path {
+  stroke: #dcdcdc;
+  stroke-width: 2px;
 }
 
 .rv-discrete-color-legend-item__title {

--- a/tests/components/legends-tests.js
+++ b/tests/components/legends-tests.js
@@ -76,19 +76,19 @@ test('Discrete Legends', t => {
 
   t.deepEqual(
     mount(<HorizontalDiscreteLegend />)
-      .find('.rv-discrete-color-legend-item__color')
+      .find('.rv-discrete-color-legend-item__color__path')
       .first()
       .props().style,
-    {background: '#12939A'},
+    {stroke: '#12939A'},
     'normal discrete legend uses default palette'
   );
 
   t.deepEqual(
     mount(<HorizontalDiscreteCustomPalette />)
-      .find('.rv-discrete-color-legend-item__color')
+      .find('.rv-discrete-color-legend-item__color__path')
       .first()
       .props().style,
-    {background: '#6588cd'},
+    {stroke: '#6588cd'},
     'custom discrete legend uses custom palette'
   );
 
@@ -102,6 +102,20 @@ test('Discrete Legends', t => {
     $.find('.rv-discrete-color-legend-item__color').length,
     7,
     'should find the right number of element for the searchable legends'
+  );
+  t.deepEqual(
+    $.find('.rv-discrete-color-legend-item__color__path')
+      .first()
+      .props().style,
+    {strokeDasharray: '6, 2', stroke: '#3a3'},
+    'should find the default dashed dasharray style'
+  );
+  t.deepEqual(
+    $.find('.rv-discrete-color-legend-item__color__path')
+      .at(3)
+      .props().style,
+    {strokeWidth: 6, stroke: '#f93'},
+    'should find the specified stroke width'
   );
   $.find('.rv-search-wrapper__form__input').simulate('change', {
     target: {value: 'egg'}
@@ -135,9 +149,9 @@ test('Discrete Legends', t => {
 
 test('Discrete Legends Showcase: HorizontalDiscreteCustomPalette', t => {
   const $ = mount(<HorizontalDiscreteCustomPalette />);
-  const colors = $.find('.rv-discrete-color-legend-item__color')
+  const colors = $.find('.rv-discrete-color-legend-item__color__path')
     .map(colorBrick => {
-      return colorBrick.props().style.background;
+      return colorBrick.props().style.stroke;
     })
     .join(' ');
 


### PR DESCRIPTION
Added the ability to set stroke properties (strokeDasharray, strokeStyle, strokeWidth) of Discrete Color Legend items to match Line Series components. At first I considered mimicking the `colors` attribute and letting users add a `strokeWidths` array, but it seemed to over-complicate the api, so I settled with grabbing those properties from an `item`'s object.

The legend items now render an svg path instead of a 2x14px div, which was necessary to match the dash-array property, but it also might help keep the legend consistent with the chart.

I edited one of the legend examples to show the implementation - happy to remove it if it's too heavy-handed.

![image](https://user-images.githubusercontent.com/3506269/46590040-3fceaf00-ca7e-11e8-9a21-559540db9650.png)

Happy to hear any feedback, thanks!