### PR TITLE
propagate props for discrete color legend

### DIFF
--- a/showcase/plot/clustered-stacked-bar-chart.js
+++ b/showcase/plot/clustered-stacked-bar-chart.js
@@ -55,7 +55,7 @@ export default class Example extends React.Component {
           height={300}
         >
           <DiscreteColorLegend
-            style={{position: 'absolute', left: '40px', top: '0px'}}
+            style={{position: 'absolute', left: '50px', top: '10px'}}
             orientation="horizontal"
             items={[
               {

--- a/src/legends/discrete-color-legend.js
+++ b/src/legends/discrete-color-legend.js
@@ -34,12 +34,13 @@ function DiscreteColorLegend({
   onItemMouseEnter,
   onItemMouseLeave,
   orientation,
+  style,
   width
 }) {
   return (
     <div
       className={`rv-discrete-color-legend ${orientation} ${className}`}
-      style={{width, height}}
+      style={{width, height, ...style}}
     >
       {items.map((item, i) => (
         <DiscreteColorLegendItem

--- a/tests/components/legends-tests.js
+++ b/tests/components/legends-tests.js
@@ -8,6 +8,7 @@ import HorizontalDiscreteLegend from '../../showcase/legends/horizontal-discrete
 import VerticalDiscreteLegend from '../../showcase/legends/vertical-discrete-color';
 import SearchableDiscreteLegend from '../../showcase/legends/searchable-discrete-color';
 import HorizontalDiscreteCustomPalette from '../../showcase/legends/horizontal-discrete-custom-palette';
+import ClusteredStackedVerticalBarChart from '../../showcase/plot/clustered-stacked-bar-chart';
 
 test('Discrete Legend has no clickable className while onItemClick is not passing', t => {
   const withOnClick$ = mount(<VerticalDiscreteLegend />);
@@ -130,6 +131,16 @@ test('Discrete Legends', t => {
     'before clicking, should find no items disabled'
   );
 
+
+  t.deepEqual(
+    mount(<ClusteredStackedVerticalBarChart />)
+      .find('.rv-discrete-color-legend')
+      .first()
+      .props().style,
+    {width: undefined, height: undefined, position: 'absolute', left: '50px', top: '10px' },
+    'discrete legend retains passed styles'
+  );
+
   t.end();
 });
 
@@ -163,3 +174,6 @@ test('Discrete Legends Showcase: HorizontalDiscreteCustomPalette', t => {
 
   t.end();
 });
+
+  const $ = mount(<ClusteredStackedVerticalBarChart />);
+

--- a/tests/components/legends-tests.js
+++ b/tests/components/legends-tests.js
@@ -137,7 +137,7 @@ test('Discrete Legends', t => {
       .find('.rv-discrete-color-legend')
       .first()
       .props().style,
-    {width: undefined, height: undefined, position: 'absolute', left: '50px', top: '10px' },
+    {width: undefined, height: undefined, position: 'absolute', left: '50px', top: '10px'},
     'discrete legend retains passed styles'
   );
 
@@ -175,5 +175,4 @@ test('Discrete Legends Showcase: HorizontalDiscreteCustomPalette', t => {
   t.end();
 });
 
-  const $ = mount(<ClusteredStackedVerticalBarChart />);
 


### PR DESCRIPTION
Fixes #893 

This should retain any `style`s passed to DiscreteColorLegend
I updated the example so the styles actually change the legend position, and didn't forget a test this time :raised_hands: 