### PR TITLE
Update HorizontalDiscreteColor example to show off stroke style properties

### DIFF
--- a/showcase/legends/horizontal-discrete-color.js
+++ b/showcase/legends/horizontal-discrete-color.js
@@ -21,19 +21,33 @@
 import React from 'react';
 
 import DiscreteColorLegend from 'legends/discrete-color-legend';
+import GradientDefs from 'plot/gradient-defs';
 
 const ITEMS = [
-  'Options',
-  'Buttons',
-  'Select boxes',
-  'Date inputs',
-  'Password inputs',
-  'Forms',
-  'Other'
+  {title: 'Dashed', color: "#45aeb1", strokeStyle: "dashed"},
+  {title: 'Dasharray', color: '#f93', strokeDasharray: "1 2 3 4 5 6 7"},
+  {title: 'Dots', color: 'url(#circles)', strokeWidth: 9},
+  {title: 'Stripes', color: 'url(#stripes)'},
+  {title: 'Wide stripes', color: 'url(#stripes)', strokeWidth: 13},
+  {title: 'Normal', color: 'purple'},
+  {title: 'Wide', color: 'powderblue', strokeWidth: 6},
 ];
 
 export default function DiscreteColorExample() {
   return (
+    <div>
+      <svg height={0} width={0}>
+        <GradientDefs>
+            <pattern id="stripes" width="4" height="4" patternUnits="userSpaceOnUse">
+                <path d="M 0, 0 l 5, 5" stroke="#45aeb1" strokeLinecap="square" />
+            </pattern>
+            <pattern id="circles" width="3" height="3" patternUnits="userSpaceOnUse">
+              <circle cx="1.5" cy="1.5" r="0.8" fill="magenta" />
+            </pattern>
+
+        </GradientDefs>
+      </svg>
     <DiscreteColorLegend orientation="horizontal" width={300} items={ITEMS} />
+    </div>
   );
 }

--- a/showcase/legends/searchable-discrete-color.js
+++ b/showcase/legends/searchable-discrete-color.js
@@ -27,10 +27,10 @@ export default class Example extends React.Component {
     super(props);
     this.state = {
       items: [
-        {title: 'Apples', color: '#3a3', strokeStyle: "dashed"},
+        {title: 'Apples', color: '#3a3'},
         {title: 'Bananas', color: '#fc0'},
         {title: 'Blueberries', color: '#337'},
-        {title: 'Carrots', color: '#f93', strokeWidth: 6},
+        {title: 'Carrots', color: '#f93'},
         {title: 'Eggplants', color: '#337'},
         {title: 'Limes', color: '#cf3'},
         {title: 'Potatoes', color: '#766'}

--- a/showcase/showcase-sections/legends-showcase.js
+++ b/showcase/showcase-sections/legends-showcase.js
@@ -17,7 +17,7 @@ const DISCRETE_LEGENDS = [
     componentName: 'VerticalDiscreteColorLegendExample'
   },
   {
-    name: 'Horizontal legend',
+    name: 'Horizontal legend with stroke styles',
     component: HorizontalDiscreteColorLegendExample,
     componentName: 'HorizontalDiscreteColorLegendExample'
   },

--- a/tests/components/legends-tests.js
+++ b/tests/components/legends-tests.js
@@ -61,22 +61,20 @@ test('Continuous Color Legend', t => {
 });
 
 test('Discrete Legends', t => {
-  [HorizontalDiscreteLegend, VerticalDiscreteLegend].forEach(Component => {
-    const $ = mount(<Component />);
-    t.equal(
-      $.text(),
-      'OptionsButtonsSelect boxesDate inputsPassword inputsFormsOther',
-      'should find the correct text content'
-    );
-    t.equal(
-      $.find('.rv-discrete-color-legend-item__color').length,
-      7,
-      'should find the right number of elements'
-    );
-  });
+  const verticalLegend = mount(<VerticalDiscreteLegend />);
+  t.equal(
+    verticalLegend.text(),
+    'OptionsButtonsSelect boxesDate inputsPassword inputsFormsOther',
+    'should find the correct text content'
+  );
+  t.equal(
+    verticalLegend.find('.rv-discrete-color-legend-item__color').length,
+    7,
+    'should find the right number of elements'
+  );
 
   t.deepEqual(
-    mount(<HorizontalDiscreteLegend />)
+    verticalLegend
       .find('.rv-discrete-color-legend-item__color__path')
       .first()
       .props().style,
@@ -105,17 +103,19 @@ test('Discrete Legends', t => {
     'should find the right number of element for the searchable legends'
   );
   t.deepEqual(
-    $.find('.rv-discrete-color-legend-item__color__path')
+    mount(<HorizontalDiscreteLegend />)
+      .find('.rv-discrete-color-legend-item__color__path')
       .first()
       .props().style,
-    {strokeDasharray: '6, 2', stroke: '#3a3'},
+    {strokeDasharray: '6, 2', stroke: '#45aeb1'},
     'should find the default dashed dasharray style'
   );
   t.deepEqual(
-    $.find('.rv-discrete-color-legend-item__color__path')
-      .at(3)
+    mount(<HorizontalDiscreteLegend />)
+      .find('.rv-discrete-color-legend-item__color__path')
+      .at(4)
       .props().style,
-    {strokeWidth: 6, stroke: '#f93'},
+    {strokeWidth: 13, stroke: 'url(#stripes)'},
     'should find the specified stroke width'
   );
   $.find('.rv-search-wrapper__form__input').simulate('change', {


### PR DESCRIPTION
I thought that adding another legend might crowd the examples, so I changed the horizontal legend example to use the new stroke style properties. Let me know if you think this is overloaded and I can break it out!

![image](https://user-images.githubusercontent.com/3506269/46711246-7c82dd80-cc19-11e8-88b5-6dd899494b6f.png)
