### PR TITLE
Make bar width (percentage) a prop for Bar Series

### DIFF
--- a/docs/bar-series.md
+++ b/docs/bar-series.md
@@ -126,6 +126,11 @@ Type: `object`
 
 A list of CSS properties to style the series outside of the explicitly set properties. Note that it will override all other properties (ie fill, stroke, opacity, color). See [style](style.md)
 
+#### barWidth
+Type: `Number`
+The percentage for which each bar fills the designated bucket. 1.0 means that the bar fills the whole bucket (no padding between bars), while a 
+smaller percentage means more whitespace between the bars.
+
 ## Interaction handlers
 #### onNearestX (optional)
 

--- a/src/plot/series/bar-series.js
+++ b/src/plot/series/bar-series.js
@@ -37,7 +37,14 @@ class BarSeries extends AbstractSeries {
       valuePosAttr: PropTypes.string,
       lineSizeAttr: PropTypes.string,
       valueSizeAttr: PropTypes.string,
-      cluster: PropTypes.string
+      cluster: PropTypes.string,
+      barWidth: PropTypes.number
+    };
+  }
+
+  static get defaultProps() {
+    return {
+      barWidth: 0.85
     };
   }
 
@@ -52,7 +59,8 @@ class BarSeries extends AbstractSeries {
       marginTop,
       style,
       valuePosAttr,
-      valueSizeAttr
+      valueSizeAttr,
+      barWidth
     } = this.props;
 
     if (!data) {
@@ -79,7 +87,7 @@ class BarSeries extends AbstractSeries {
       this._getAttributeFunctor('stroke') || this._getAttributeFunctor('color');
     const opacityFunctor = this._getAttributeFunctor('opacity');
 
-    const itemSize = (distance / 2) * 0.85;
+    const itemSize = (distance / 2) * barWidth;
 
     return (
       <g


### PR DESCRIPTION
Make the bar width percentage, which was hardcoded to 85% by default, a prop that is passed to the BarSeries class.