### PR TITLE
more flexibility when rendering tick labels with tickFormat

### DIFF
--- a/docs/axes.md
+++ b/docs/axes.md
@@ -87,7 +87,7 @@ function mySIPrefixFormatter(value, index, scale, tickTotal) {
 }
 ```
 
-**Note!** The return value will be wrapped with a `<text>` node if it's a string, `<tspan>`, or `<textPath>`. In all other cases the returned element will replace the `<text>` node and receive two additional props: `containerWidth` and `tickCount`. This way you can e.g. render a `<div>` to truncate long labels:
+**Note!** The return value will be wrapped with a `<text>` node if it's a string, `<tspan>`, or `<textPath>`. In all other cases the returned element will replace the `<text>` node. In case it's a custom React element it will also receive two additional props: `containerWidth` and `tickCount`. This way you can e.g. render a `<div>` to truncate long labels:
 
 ```javascript
 const MyLabel = props => (
@@ -107,7 +107,11 @@ const MyLabel = props => (
 function myFormatter(value) {
   return <MyLabel>{value}</MyLabel>;
 }
+
+<XAxis tickFormat={myFormatter} />
 ```
+
+<!-- INJECT:"CustomAxisTickElement" -->
 
 #### tickSize (optional)
 

--- a/docs/axes.md
+++ b/docs/axes.md
@@ -69,7 +69,7 @@ An array of values (not coordinates!) that where the ticks should be shown. Simi
 
 Type: `function(value, index, scale, tickTotal)`
 
-Format function for the tick label. Similar to the `tickFormat()` method of d3-axis. Typically the value that is return is a string or a number, however this function also supports rendering svg react elements. To wit, I could have formatting function like
+Format function for the tick label. Similar to the `tickFormat()` method of d3-axis. Typically the value that is returned is a string or a number, however this function also supports rendering SVG React elements. To wit, I could have formatting function like
 
 ```javascript
 function myFormatter(t, i) {
@@ -84,6 +84,28 @@ Or you can customize the tick formatting by calling the `tickFormat()` function 
 ```javascript
 function mySIPrefixFormatter(value, index, scale, tickTotal) {
   return `${scale.tickFormat(tickTotal, 's')(value)}Wh`;// -> e.g. 1.2kWh
+}
+```
+
+**Note!** The return value will be wrapped with a `<text>` node if it's a string, `<tspan>`, or `<textPath>`. In all other cases the returned element will replace the `<text>` node and receive two additional props: `containerWidth` and `tickCount`. This way you can e.g. render a `<div>` to truncate long labels:
+
+```javascript
+const MyLabel = props => (
+  <foreignObject>
+    <div
+      xmlns="http://www.w3.org/1999/xhtml"
+      style={{
+        width: props.containerWidth / props.tickCount, overflow: 'hidden',
+        whiteSpace: 'nowrap'
+      }}
+    >
+      {props.children}
+    </div>
+  </foreignObject>
+);
+
+function myFormatter(value) {
+  return <MyLabel>{value}</MyLabel>;
 }
 ```
 

--- a/showcase/axes/custom-axis-tick-element.js
+++ b/showcase/axes/custom-axis-tick-element.js
@@ -52,9 +52,7 @@ export default class Example extends React.Component {
       <XYPlot
         width={300}
         height={300}
-        xType="linear"
         xDomain={[0, 4]}
-        yType="linear"
         yDomain={[0, 1000]}
         margin={{top: 10, right: 10, left: 60, bottom: 40}}
       >

--- a/showcase/axes/custom-axis-tick-element.js
+++ b/showcase/axes/custom-axis-tick-element.js
@@ -1,0 +1,69 @@
+// Copyright (c) 2016 - 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import React from 'react';
+
+import {
+  XYPlot,
+  XAxis,
+  YAxis,
+  VerticalGridLines,
+  HorizontalGridLines,
+  LineSeries
+} from 'index';
+
+export default class Example extends React.Component {
+  state = {
+    data: [
+      {x: 0, y: 100, label: <circle cx={0} cy={10} r={5} fill="darksalmon" />},
+      {x: 1, y: 200, label: <rect x={-5} y={5} width={10} height={10} fill="slateblue" />},
+      {x: 2, y: 500, label: <tspan>Label</tspan>},
+      {x: 3, y: 900, label: <path d="M0 5 L5 15 L-5 15 Z" fill="sandybrown" />},
+      {x: 4, y: 1000, label: 'Label'}
+    ]
+  };
+
+  formatX = (v, i, scale, tickTotal) => {
+    if (i < this.state.data.length) {
+      return this.state.data[i].label;
+    }
+    return null;
+  }
+
+  render() {
+    return (
+      <XYPlot
+        width={300}
+        height={300}
+        xType="linear"
+        xDomain={[0, 4]}
+        yType="linear"
+        yDomain={[0, 1000]}
+        margin={{top: 10, right: 10, left: 60, bottom: 40}}
+      >
+        <VerticalGridLines />
+        <HorizontalGridLines />
+        <XAxis tickTotal={this.state.data.length} tickFormat={this.formatX} />
+        <YAxis />
+        <LineSeries data={this.state.data} />
+      </XYPlot>
+    );
+  }
+}

--- a/showcase/index.js
+++ b/showcase/index.js
@@ -96,6 +96,7 @@ import AxisOn0 from './axes/axis-on-0';
 import CustomAxesOrientation from './axes/custom-axes-orientation';
 import CustomAxisChart from './axes/custom-axis';
 import CustomAxisTickFormat from './axes/custom-axis-tick-format';
+import CustomAxisTickElement from './axes/custom-axis-tick-element';
 import CustomAxes from './axes/custom-axes';
 import DecorativeAxisCrissCross from './axes/decorative-axes-criss-cross';
 import EmptyChart from './axes/empty-chart';
@@ -199,6 +200,7 @@ const mainShowCase = {
   CustomAxesOrientation,
   CustomAxisChart,
   CustomAxisTickFormat,
+  CustomAxisTickElement,
   AxisWithTurnedLabels,
   GridLinesChart,
   StaticHints,

--- a/showcase/showcase-sections/axes-showcase.js
+++ b/showcase/showcase-sections/axes-showcase.js
@@ -9,6 +9,7 @@ const {
   CustomAxisChart,
   CustomAxesOrientation,
   CustomAxisTickFormat,
+  CustomAxisTickElement,
   DecorativeAxisCrissCross,
   DynamicComplexEdgeHints,
   DynamicCrosshair,
@@ -43,6 +44,10 @@ const AXES = [
   {
     name: 'Custom axis tick format',
     component: CustomAxisTickFormat
+  },
+  {
+    name: 'Custom axis tick label element',
+    component: CustomAxisTickElement
   },
   {
     name: 'Even more Custom Axes',

--- a/src/plot/axis/axis-ticks.js
+++ b/src/plot/axis/axis-ticks.js
@@ -182,8 +182,9 @@ class AxisTicks extends React.Component {
 
     const ticks = values.map((v, i) => {
       const pos = scale(v);
-      const text = tickFormatFn(v, i, scale, tickTotal);
-      const textIsReactNode = React.isValidElement(text);
+      const labelNode = tickFormatFn(v, i, scale, tickTotal);
+      const shouldRenderAsOwnNode = React.isValidElement(labelNode) &&
+        !['tspan', 'textPath'].includes(labelNode.type)
 
       return (
         <g
@@ -197,8 +198,8 @@ class AxisTicks extends React.Component {
             className="rv-xy-plot__axis__tick__line"
             style={{...style, ...style.line}}
           />
-          {textIsReactNode
-            ? React.cloneElement(text, {
+          {shouldRenderAsOwnNode
+            ? React.cloneElement(labelNode, {
               ...textProps,
               containerWidth: width,
               tickCount: values.length
@@ -209,7 +210,7 @@ class AxisTicks extends React.Component {
                 className="rv-xy-plot__axis__tick__text"
                 style={{...style, ...style.text}}
               >
-                {text}
+                {labelNode}
               </text>
             )}
         </g>

--- a/src/plot/axis/axis-ticks.js
+++ b/src/plot/axis/axis-ticks.js
@@ -183,6 +183,7 @@ class AxisTicks extends React.Component {
     const ticks = values.map((v, i) => {
       const pos = scale(v);
       const text = tickFormatFn(v, i, scale, tickTotal);
+      const textIsReactNode = React.isValidElement(text);
 
       return (
         <g
@@ -196,13 +197,15 @@ class AxisTicks extends React.Component {
             className="rv-xy-plot__axis__tick__line"
             style={{...style, ...style.line}}
           />
-          <text
+          {textIsReactNode
+            ? React.cloneElement(text, {...textProps, containerWidth: width, tickCount: values.length})
+            : <text
             {...textProps}
             className="rv-xy-plot__axis__tick__text"
             style={{...style, ...style.text}}
           >
             {text}
-          </text>
+          </text>}
         </g>
       );
     });

--- a/src/plot/axis/axis-ticks.js
+++ b/src/plot/axis/axis-ticks.js
@@ -184,8 +184,8 @@ class AxisTicks extends React.Component {
       const pos = scale(v);
       const labelNode = tickFormatFn(v, i, scale, tickTotal);
       const shouldRenderAsOwnNode = React.isValidElement(labelNode) &&
-        !['tspan', 'textPath'].includes(labelNode.type)
-
+        !['tspan', 'textPath'].includes(labelNode.type);
+      const shouldAddProps = labelNode && typeof labelNode.type !== 'string';
       return (
         <g
           key={i}
@@ -199,11 +199,11 @@ class AxisTicks extends React.Component {
             style={{...style, ...style.line}}
           />
           {shouldRenderAsOwnNode
-            ? React.cloneElement(labelNode, {
+            ? React.cloneElement(labelNode, shouldAddProps ? {
               ...textProps,
               containerWidth: width,
               tickCount: values.length
-            })
+            } : undefined)
             : (
               <text
                 {...textProps}

--- a/src/plot/axis/axis-ticks.js
+++ b/src/plot/axis/axis-ticks.js
@@ -198,14 +198,20 @@ class AxisTicks extends React.Component {
             style={{...style, ...style.line}}
           />
           {textIsReactNode
-            ? React.cloneElement(text, {...textProps, containerWidth: width, tickCount: values.length})
-            : <text
-            {...textProps}
-            className="rv-xy-plot__axis__tick__text"
-            style={{...style, ...style.text}}
-          >
-            {text}
-          </text>}
+            ? React.cloneElement(text, {
+              ...textProps,
+              containerWidth: width,
+              tickCount: values.length
+            })
+            : (
+              <text
+                {...textProps}
+                className="rv-xy-plot__axis__tick__text"
+                style={{...style, ...style.text}}
+              >
+                {text}
+              </text>
+            )}
         </g>
       );
     });

--- a/tests/components/axis-tick-format-tests.js
+++ b/tests/components/axis-tick-format-tests.js
@@ -1,0 +1,47 @@
+import test from 'tape';
+import React from 'react';
+import {mount} from 'enzyme';
+
+import CustomAxisTickElement from '../../showcase/axes/custom-axis-tick-element';
+
+test('Axis Format: correctly renders return values from tickFormat', t => {
+  const element = mount(<CustomAxisTickElement />);
+  const ticks = element.find('.rv-xy-plot__axis--horizontal .rv-xy-plot__axis__tick');
+  t.deepEqual(
+    ticks.map(tick => tick.find('text').length),
+    [0, 0, 1, 0, 1],
+    'renders custom element without text node'
+  );
+  t.equal(
+    ticks.at(2).find('text').find('tspan').length,
+    1,
+    'renders tspan inside text node'
+  );
+  t.equal(
+    ticks.at(4).find('text').text(),
+    'Label',
+    'renders text inside text node'
+  );
+  t.end();
+});
+
+test('Axis Format: passes props to custom element', t => {
+  const CustomLabel = props => {
+    t.deepEqual(
+      Object.keys(props).sort(),
+      ['containerWidth', 'dy', 'textAnchor', 'tickCount', 'transform'],
+      'custom element received correct props'
+    );
+    return <text>Custom Label</text>;
+  };
+  const element = mount(<CustomAxisTickElement />);
+  element.setState({
+    data: [...element.state().data, {x: 5, y: 600, label: <CustomLabel />}]
+  });
+  t.equal(
+    element.find('.rv-xy-plot__axis--horizontal .rv-xy-plot__axis__tick').at(5).find('text').text(),
+    'Custom Label',
+    'renders custom label contents'
+  );
+  t.end();
+});

--- a/tests/index.js
+++ b/tests/index.js
@@ -33,6 +33,7 @@ import './components/animation-tests';
 import './components/area-series-tests';
 import './components/arc-series-tests';
 import './components/axes-tests';
+import './components/axis-tick-format-tests';
 import './components/axis-title-tests';
 import './components/bar-series-tests';
 import './components/borders-tests';


### PR DESCRIPTION
right now the value rendered from `tickFormat` will always be wrapped in a `<text>` node which is quite limiting if you want to do more flexible stuff. this change checks if the value that's returned from `tickFormat` is a React element and renders it instead of the `<text>` in case it is one. the custom element also gets passed the width of the tick container and the total amount of ticks as props in case it wants to do some responsive stuff.

~as such, this would be a breaking change, but it could also be pretty easily modified to wrap those SVG elements with a `<text>` that can be descendants of `<text>` per spec.~ 

if you think this change is OK, i'll write some tests for it and then hopefully it could be merged :)