### PR TITLE
Typecheck: fixed proptypes of the data coordinates in CustomSVGSeries

### DIFF
--- a/src/plot/series/custom-svg-series.js
+++ b/src/plot/series/custom-svg-series.js
@@ -180,8 +180,8 @@ CustomSVGSeries.propTypes = {
   customComponent: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   data: PropTypes.arrayOf(
     PropTypes.shape({
-      x: PropTypes.number.isRequired,
-      y: PropTypes.number.isRequired
+      x: PropTypes.oneOfType([PropTypes.string.isRequired, PropTypes.number.isRequired]),
+      y: PropTypes.oneOfType([PropTypes.string.isRequired, PropTypes.number.isRequired])
     })
   ).isRequired,
   marginLeft: PropTypes.number,

--- a/src/plot/series/custom-svg-series.js
+++ b/src/plot/series/custom-svg-series.js
@@ -180,8 +180,8 @@ CustomSVGSeries.propTypes = {
   customComponent: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   data: PropTypes.arrayOf(
     PropTypes.shape({
-      x: PropTypes.oneOfType([PropTypes.string.isRequired, PropTypes.number.isRequired]),
-      y: PropTypes.oneOfType([PropTypes.string.isRequired, PropTypes.number.isRequired])
+      x: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+      y: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired
     })
   ).isRequired,
   marginLeft: PropTypes.number,


### PR DESCRIPTION
Fixes #1010 

While using CustomSVGSeries with either x or y ordinal values, the AbstractSeries threw a warning - 
<img width="1440" alt="screenshot 2018-10-25 at 9 48 58 am" src="https://user-images.githubusercontent.com/10823530/47476204-f2538f80-d83c-11e8-8bb2-3d61d417a76d.png">
Fix in this PR allows the proptypes of the x, y values to be `string`|`number`