### PR TITLE
Add RadarChartStraightGridLines - aka spider chart

### DIFF
--- a/showcase/radar-chart/radar-chart-series-tooltips.js
+++ b/showcase/radar-chart/radar-chart-series-tooltips.js
@@ -22,7 +22,9 @@ import React, {Component} from 'react';
 import {format} from 'd3-format';
 
 import RadarChart from 'radar-chart';
+import RadarChartStraightGridLines from 'radar-chart/radar-chart-straight-grid-lines';
 import {Hint} from 'index';
+
 
 const DATA = [
   {
@@ -93,11 +95,10 @@ export default class BasicRadarChart extends Component {
         ]}
         width={400}
         height={300}
-        onSeriesMouseOver={data => {
+        onSeriesMouseOver={(data) => {
           this.setState({hoveredCell: data.event[0]});
         }}
         onSeriesMouseOut={() => this.setState({hoveredCell: false})}
-        numberOfGridlines={5}
       >
         {hoveredCell && (
           <Hint value={{x: 0, y: 0}}>

--- a/showcase/radar-chart/radar-chart-series-tooltips.js
+++ b/showcase/radar-chart/radar-chart-series-tooltips.js
@@ -22,7 +22,6 @@ import React, {Component} from 'react';
 import {format} from 'd3-format';
 
 import RadarChart from 'radar-chart';
-import RadarChartStraightGridLines from 'radar-chart/radar-chart-straight-grid-lines';
 import {Hint} from 'index';
 
 

--- a/showcase/radar-chart/radar-chart-series-tooltips.js
+++ b/showcase/radar-chart/radar-chart-series-tooltips.js
@@ -24,7 +24,6 @@ import {format} from 'd3-format';
 import RadarChart from 'radar-chart';
 import {Hint} from 'index';
 
-
 const DATA = [
   {
     name: 'Mercedes',
@@ -94,10 +93,11 @@ export default class BasicRadarChart extends Component {
         ]}
         width={400}
         height={300}
-        onSeriesMouseOver={(data) => {
+        onSeriesMouseOver={data => {
           this.setState({hoveredCell: data.event[0]});
         }}
         onSeriesMouseOut={() => this.setState({hoveredCell: false})}
+        numberOfGridlines={5}
       >
         {hoveredCell && (
           <Hint value={{x: 0, y: 0}}>

--- a/showcase/radar-chart/radar-chart-with-tooltips.js
+++ b/showcase/radar-chart/radar-chart-with-tooltips.js
@@ -20,87 +20,31 @@
 
 import React, {Component} from 'react';
 import RadarChart from 'radar-chart';
+import RadarChartStraightGridLines from 'radar-chart/radar-chart-straight-grid-lines';
 import {Hint} from 'index';
 
-// The first 6 data elements here are to simulate a 'spider' type of radar chart -
-// similar to CircularGridLines, but straight edges instead.
 const DATA = [
-  {
-    name: 'Spider5',
-    mileage: 5,
-    price: 5,
-    safety: 5,
-    performance: 5,
-    interior: 5,
-    warranty: 5,
-    fill: '#f8f8f8',
-    stroke: '#cccccc'
-  },
-  {
-    name: 'Spider4',
-    mileage: 4,
-    price: 4,
-    safety: 4,
-    performance: 4,
-    interior: 4,
-    warranty: 4,
-    fill: 'white',
-    stroke: '#cccccc'
-  },
-  {
-    name: 'Spider3',
-    mileage: 3,
-    price: 3,
-    safety: 3,
-    performance: 3,
-    interior: 3,
-    warranty: 3,
-    fill: '#f8f8f8',
-    stroke: '#cccccc'
-  },
-  {
-    name: 'Spider2',
-    mileage: 2,
-    price: 2,
-    safety: 2,
-    performance: 2,
-    interior: 2,
-    warranty: 2,
-    fill: 'white',
-    stroke: '#cccccc'
-  },
-  {
-    name: 'Spider1',
-    mileage: 1,
-    price: 1,
-    safety: 1,
-    performance: 1,
-    interior: 1,
-    warranty: 1,
-    fill: '#f8f8f8',
-    stroke: '#cccccc'
-  },
-  {
-    name: 'Spider0',
-    mileage: 0.1,
-    price: 0.1,
-    safety: 0.1,
-    performance: 0.1,
-    interior: 0.1,
-    warranty: 0.1,
-    fill: '#f8f8f8',
-    stroke: '#cccccc'
-  },
   {
     name: 'Mercedes',
     mileage: 3,
-    price: 4,
-    safety: 5,
-    performance: 1.5,
+    price: 2.5,
+    safety: 8,
+    performance: 5,
     interior: 4,
     warranty: 4.5,
-    fill: 'rgba(114,172,240,0.5)',
+    fill: 'rgba(114,172,240,0.4)',
     stroke: 'rgba(114,172,240,0.2)'
+  },
+  {
+    name: 'Honda',
+    mileage: 4.5,
+    price: 5,
+    safety: 7.5,
+    performance: 2.5,
+    interior: 3,
+    warranty: 4,
+    fill: 'rgba(154,102,220,0.4)',
+    stroke: 'rgba(154,102,220,0.2)'
   }
 ];
 
@@ -142,18 +86,20 @@ export default class RadarChartWithTooltips extends Component {
             domain: [0, 5],
             getValue: d => d.price
           },
-          {name: 'safety', domain: [0, 5], getValue: d => d.safety},
+          {name: 'safety', domain: [0, 10], getValue: d => d.safety},
           {name: 'performance', domain: [0, 5], getValue: d => d.performance},
           {name: 'interior', domain: [0, 5], getValue: d => d.interior},
           {name: 'warranty', domain: [0, 5], getValue: d => d.warranty}
         ]}
-        width={300}
-        height={300}
+        width={450}
+        height={350}
         onValueMouseOver={v => {
           this.setState({hoveredCell: v});
         }}
         onValueMouseOut={v => this.setState({hoveredCell: false})}
+        margin={{top: 30, right: 60, left: 60, bottom: 30}}
         style={{
+          background: 'transparent',
           polygons: {
             strokeWidth: 1,
             strokeOpacity: 0.8,
@@ -164,9 +110,8 @@ export default class RadarChartWithTooltips extends Component {
           },
           axes: {
             line: {
-              fillOpacity: 0.8,
-              strokeWidth: 0.5,
-              strokeOpacity: 0.8
+              strokeWidth: 0,
+              strokeOpacity: 0
             },
             ticks: {
               fillOpacity: 0,
@@ -178,15 +123,28 @@ export default class RadarChartWithTooltips extends Component {
         colorRange={['transparent']}
         hideInnerMostValues={false}
         renderAxesOverPolygons={true}
+        numberOfGridlines={0}
       >
-        {hoveredCell &&
-          hoveredCell.dataName === 'Mercedes' && (
-            <Hint value={hoveredCell}>
-              <div style={tipStyle}>
-                {hoveredCell.domain}: {hoveredCell.value}
-              </div>
-            </Hint>
-          )}
+        {hoveredCell && (
+          <Hint value={hoveredCell}>
+            <div style={tipStyle}>
+              {hoveredCell.domain}: {hoveredCell.value}
+            </div>
+          </Hint>
+        )}
+        <RadarChartStraightGridLines
+          numberOfGridlines={5}
+          numberOfDomains={6}
+          width={450}
+          height={350}
+          margin={{top: 30, right: 60, left: 60, bottom: 30}}
+          style={{
+            marginTop: '-350px',
+            polygons: {
+              stroke: '#cccccc'
+            }
+          }}
+        />
       </RadarChart>
     );
   }

--- a/src/index.js
+++ b/src/index.js
@@ -67,6 +67,7 @@ export ContinuousSizeLegend from 'legends/continuous-size-legend';
 export Treemap from 'treemap';
 export RadialChart from 'radial-chart';
 export RadarChart from 'radar-chart';
+import RadarChartStraightGridLines from 'radar-chart/radar-chart-straight-grid-lines';
 export ParallelCoordinates from 'parallel-coordinates';
 export Sankey from 'sankey';
 export Sunburst from 'sunburst';

--- a/src/plot/xy-plot.js
+++ b/src/plot/xy-plot.js
@@ -545,11 +545,13 @@ class XYPlot extends React.Component {
       );
     }
     const components = this._getClonedChildComponents();
+    const xyPlotStyle = style ? style.XYPlot : {};
     return (
       <div
         style={{
           width: `${width}px`,
-          height: `${height}px`
+          height: `${height}px`,
+          ...xyPlotStyle
         }}
         className={`rv-xy-plot ${className}`}
       >

--- a/src/radar-chart/index.js
+++ b/src/radar-chart/index.js
@@ -138,20 +138,9 @@ function getLabels(props) {
  * @return {Array} the plotted axis components
  */
 function getPolygons(props) {
-  const {
-    animation,
-    colorRange,
-    domains,
-    data,
-    style,
-    startingAngle,
-    onSeriesMouseOver,
-    onSeriesMouseOut
-  } = props;
+  const {animation, colorRange, domains, data, style, startingAngle, onSeriesMouseOver, onSeriesMouseOut} = props;
   const scales = domains.reduce((acc, {domain, name}) => {
-    acc[name] = scaleLinear()
-      .domain(domain)
-      .range([0, 1]);
+    acc[name] = scaleLinear().domain(domain).range([0, 1]);
     return acc;
   }, {});
 
@@ -162,11 +151,7 @@ function getPolygons(props) {
       const angle = (index / domains.length) * Math.PI * 2 + startingAngle;
       // dont let the radius become negative
       const radius = Math.max(scales[name](dataPoint), 0);
-      return {
-        x: radius * Math.cos(angle),
-        y: radius * Math.sin(angle),
-        name: row.name
-      };
+      return {x: radius * Math.cos(angle), y: radius * Math.sin(angle), name: row.name};
     });
 
     return (
@@ -211,7 +196,7 @@ function getPolygonPoints(props) {
     onValueMouseOver,
     onValueMouseOut
   } = props;
-  if (!onValueMouseOver) {
+   if (!onValueMouseOver) {
     return;
   }
   const scales = domains.reduce((acc, {domain, name}) => {
@@ -220,19 +205,19 @@ function getPolygonPoints(props) {
       .range([0, 1]);
     return acc;
   }, {});
-  return data.map((row, rowIndex) => {
-    const mappedData = domains.map(({name, getValue}, index) => {
-      const dataPoint = getValue ? getValue(row) : row[name];
-      // error handling if point doesn't exist
-      const angle = (index / domains.length) * Math.PI * 2 + startingAngle;
-      // dont let the radius become negative
-      const radius = Math.max(scales[name](dataPoint), 0);
-      return {
-        x: radius * Math.cos(angle),
-        y: radius * Math.sin(angle),
-        domain: name,
-        value: dataPoint,
-        dataName: row.name
+return data.map((row, rowIndex) => {
+ const mappedData = domains.map(({name, getValue}, index) => {
+    const dataPoint = getValue ? getValue(row) : row[name];
+    // error handling if point doesn't exist
+    const angle = (index / domains.length) * Math.PI * 2 + startingAngle;
+    // dont let the radius become negative
+    const radius = Math.max(scales[name](dataPoint), 0);
+    return {
+      x: radius * Math.cos(angle),
+      y: radius * Math.sin(angle),
+      domain: name,
+      value: dataPoint,
+      dataName: row.name
       };
     });
 
@@ -251,7 +236,7 @@ function getPolygonPoints(props) {
         onValueMouseOver={onValueMouseOver}
         onValueMouseOut={onValueMouseOut}
       />
-    );
+  );
   });
 }
 
@@ -276,48 +261,46 @@ function RadarChart(props) {
     onValueMouseOver,
     onValueMouseOut,
     onSeriesMouseOver,
-    onSeriesMouseOut,
-    numberOfGridlines
+    onSeriesMouseOut
   } = props;
 
-  const axes = getAxes({
-    domains,
-    animation,
-    hideInnerMostValues,
-    startingAngle,
-    style,
-    tickFormat
-  });
+const axes = getAxes({
+  domains,
+  animation,
+  hideInnerMostValues,
+  startingAngle,
+  style,
+  tickFormat
+});
 
-  const polygons = getPolygons({
-    animation,
-    colorRange,
-    domains,
-    data,
-    startingAngle,
-    style,
-    onSeriesMouseOver,
-    onSeriesMouseOut
-  });
+const polygons = getPolygons({
+  animation,
+  colorRange,
+  domains,
+  data,
+  startingAngle,
+  style,
+  onSeriesMouseOver,
+  onSeriesMouseOut
+});
 
-  const polygonPoints = getPolygonPoints({
-    animation,
-    colorRange,
-    domains,
-    data,
-    startingAngle,
-    style,
-    onValueMouseOver,
-    onValueMouseOut
-  });
+const polygonPoints = getPolygonPoints({
+  animation,
+  colorRange,
+  domains,
+  data,
+  startingAngle,
+  style,
+  onValueMouseOver,
+  onValueMouseOut
+});
 
   const labelSeries = (
     <LabelSeries
       animation={animation}
       key={className}
       className={`${predefinedClassName}-label`}
-      data={getLabels({domains, style: style.labels, startingAngle})}
-    />
+      data={getLabels({domains, style: style.labels, startingAngle})} />
   );
   return (
     <XYPlot
@@ -403,8 +386,7 @@ RadarChart.defaultProps = {
     }
   },
   tickFormat: DEFAULT_FORMAT,
-  renderAxesOverPolygons: false,
-  numberOfGridlines: 0
+  renderAxesOverPolygons: false
 };
 
 export default RadarChart;

--- a/src/radar-chart/index.js
+++ b/src/radar-chart/index.js
@@ -138,9 +138,20 @@ function getLabels(props) {
  * @return {Array} the plotted axis components
  */
 function getPolygons(props) {
-  const {animation, colorRange, domains, data, style, startingAngle, onSeriesMouseOver, onSeriesMouseOut} = props;
+  const {
+    animation,
+    colorRange,
+    domains,
+    data,
+    style,
+    startingAngle,
+    onSeriesMouseOver,
+    onSeriesMouseOut
+  } = props;
   const scales = domains.reduce((acc, {domain, name}) => {
-    acc[name] = scaleLinear().domain(domain).range([0, 1]);
+    acc[name] = scaleLinear()
+      .domain(domain)
+      .range([0, 1]);
     return acc;
   }, {});
 
@@ -151,7 +162,11 @@ function getPolygons(props) {
       const angle = (index / domains.length) * Math.PI * 2 + startingAngle;
       // dont let the radius become negative
       const radius = Math.max(scales[name](dataPoint), 0);
-      return {x: radius * Math.cos(angle), y: radius * Math.sin(angle), name: row.name};
+      return {
+        x: radius * Math.cos(angle),
+        y: radius * Math.sin(angle),
+        name: row.name
+      };
     });
 
     return (
@@ -196,7 +211,7 @@ function getPolygonPoints(props) {
     onValueMouseOver,
     onValueMouseOut
   } = props;
-   if (!onValueMouseOver) {
+  if (!onValueMouseOver) {
     return;
   }
   const scales = domains.reduce((acc, {domain, name}) => {
@@ -205,19 +220,19 @@ function getPolygonPoints(props) {
       .range([0, 1]);
     return acc;
   }, {});
- return data.map((row, rowIndex) => {
-  const mappedData = domains.map(({name, getValue}, index) => {
-    const dataPoint = getValue ? getValue(row) : row[name];
-    // error handling if point doesn't exist
-    const angle = (index / domains.length) * Math.PI * 2 + startingAngle;
-    // dont let the radius become negative
-    const radius = Math.max(scales[name](dataPoint), 0);
-    return {
-      x: radius * Math.cos(angle),
-      y: radius * Math.sin(angle),
-      domain: name,
-      value: dataPoint,
-      dataName: row.name
+  return data.map((row, rowIndex) => {
+    const mappedData = domains.map(({name, getValue}, index) => {
+      const dataPoint = getValue ? getValue(row) : row[name];
+      // error handling if point doesn't exist
+      const angle = (index / domains.length) * Math.PI * 2 + startingAngle;
+      // dont let the radius become negative
+      const radius = Math.max(scales[name](dataPoint), 0);
+      return {
+        x: radius * Math.cos(angle),
+        y: radius * Math.sin(angle),
+        domain: name,
+        value: dataPoint,
+        dataName: row.name
       };
     });
 
@@ -236,7 +251,7 @@ function getPolygonPoints(props) {
         onValueMouseOver={onValueMouseOver}
         onValueMouseOut={onValueMouseOut}
       />
-  );
+    );
   });
 }
 
@@ -261,70 +276,76 @@ function RadarChart(props) {
     onValueMouseOver,
     onValueMouseOut,
     onSeriesMouseOver,
-    onSeriesMouseOut
+    onSeriesMouseOut,
+    numberOfGridlines
   } = props;
 
-const axes = getAxes({
-  domains,
-  animation,
-  hideInnerMostValues,
-  startingAngle,
-  style,
-  tickFormat
-});
+  const axes = getAxes({
+    domains,
+    animation,
+    hideInnerMostValues,
+    startingAngle,
+    style,
+    tickFormat
+  });
 
-const polygons = getPolygons({
-  animation,
-  colorRange,
-  domains,
-  data,
-  startingAngle,
-  style,
-  onSeriesMouseOver,
-  onSeriesMouseOut
-});
+  const polygons = getPolygons({
+    animation,
+    colorRange,
+    domains,
+    data,
+    startingAngle,
+    style,
+    onSeriesMouseOver,
+    onSeriesMouseOut
+  });
 
-const polygonPoints = getPolygonPoints({
-  animation,
-  colorRange,
-  domains,
-  data,
-  startingAngle,
-  style,
-  onValueMouseOver,
-  onValueMouseOut
-});
+  const polygonPoints = getPolygonPoints({
+    animation,
+    colorRange,
+    domains,
+    data,
+    startingAngle,
+    style,
+    onValueMouseOver,
+    onValueMouseOut
+  });
 
-const labelSeries = (
-  <LabelSeries
-    animation={animation}
-    key={className}
-    className={`${predefinedClassName}-label`}
-    data={getLabels({domains, style: style.labels, startingAngle})} />
-);
-return (
-  <XYPlot
-    height={height}
-    width={width}
-    margin={margin}
-    dontCheckIfEmpty
-    className={`${className} ${predefinedClassName}`}
-    onMouseLeave={onMouseLeave}
-    onMouseEnter={onMouseEnter}
-    xDomain={[-1, 1]}
-    yDomain={[-1, 1]}>
-    {children}
-    {!renderAxesOverPolygons &&
-      axes
-        .concat(polygons)
-        .concat(labelSeries)
-        .concat(polygonPoints)}
-    {renderAxesOverPolygons &&
-      polygons
-        .concat(labelSeries)
-        .concat(axes)
-        .concat(polygonPoints)}
-  </XYPlot>
+  const labelSeries = (
+    <LabelSeries
+      animation={animation}
+      key={className}
+      className={`${predefinedClassName}-label`}
+      data={getLabels({domains, style: style.labels, startingAngle})}
+    />
+  );
+  return (
+    <XYPlot
+      height={height}
+      width={width}
+      margin={margin}
+      dontCheckIfEmpty
+      className={`${className} ${predefinedClassName}`}
+      onMouseLeave={onMouseLeave}
+      onMouseEnter={onMouseEnter}
+      xDomain={[-1, 1]}
+      yDomain={[-1, 1]}
+      style={{
+        backgroundColor: 'transparent'
+      }}
+    >
+      {children}
+      {!renderAxesOverPolygons &&
+        axes
+          .concat(polygons)
+          .concat(labelSeries)
+          .concat(polygonPoints)}
+      {renderAxesOverPolygons &&
+        polygons
+          .concat(labelSeries)
+          .concat(axes)
+          .concat(polygonPoints)}
+    </XYPlot>
   );
 }
 
@@ -382,7 +403,8 @@ RadarChart.defaultProps = {
     }
   },
   tickFormat: DEFAULT_FORMAT,
-  renderAxesOverPolygons: false
+  renderAxesOverPolygons: false,
+  numberOfGridlines: 0
 };
 
 export default RadarChart;

--- a/src/radar-chart/index.js
+++ b/src/radar-chart/index.js
@@ -205,8 +205,8 @@ function getPolygonPoints(props) {
       .range([0, 1]);
     return acc;
   }, {});
-return data.map((row, rowIndex) => {
- const mappedData = domains.map(({name, getValue}, index) => {
+ return data.map((row, rowIndex) => {
+  const mappedData = domains.map(({name, getValue}, index) => {
     const dataPoint = getValue ? getValue(row) : row[name];
     // error handling if point doesn't exist
     const angle = (index / domains.length) * Math.PI * 2 + startingAngle;
@@ -295,40 +295,36 @@ const polygonPoints = getPolygonPoints({
   onValueMouseOut
 });
 
-  const labelSeries = (
-    <LabelSeries
-      animation={animation}
-      key={className}
-      className={`${predefinedClassName}-label`}
-      data={getLabels({domains, style: style.labels, startingAngle})} />
-  );
-  return (
-    <XYPlot
-      height={height}
-      width={width}
-      margin={margin}
-      dontCheckIfEmpty
-      className={`${className} ${predefinedClassName}`}
-      onMouseLeave={onMouseLeave}
-      onMouseEnter={onMouseEnter}
-      xDomain={[-1, 1]}
-      yDomain={[-1, 1]}
-      style={{
-        backgroundColor: 'transparent'
-      }}
-    >
-      {children}
-      {!renderAxesOverPolygons &&
-        axes
-          .concat(polygons)
-          .concat(labelSeries)
-          .concat(polygonPoints)}
-      {renderAxesOverPolygons &&
-        polygons
-          .concat(labelSeries)
-          .concat(axes)
-          .concat(polygonPoints)}
-    </XYPlot>
+const labelSeries = (
+  <LabelSeries
+    animation={animation}
+    key={className}
+    className={`${predefinedClassName}-label`}
+    data={getLabels({domains, style: style.labels, startingAngle})} />
+);
+return (
+  <XYPlot
+    height={height}
+    width={width}
+    margin={margin}
+    dontCheckIfEmpty
+    className={`${className} ${predefinedClassName}`}
+    onMouseLeave={onMouseLeave}
+    onMouseEnter={onMouseEnter}
+    xDomain={[-1, 1]}
+    yDomain={[-1, 1]}>
+    {children}
+    {!renderAxesOverPolygons &&
+      axes
+        .concat(polygons)
+        .concat(labelSeries)
+        .concat(polygonPoints)}
+    {renderAxesOverPolygons &&
+      polygons
+        .concat(labelSeries)
+        .concat(axes)
+        .concat(polygonPoints)}
+  </XYPlot>
   );
 }
 

--- a/src/radar-chart/radar-chart-straight-grid-lines.js
+++ b/src/radar-chart/radar-chart-straight-grid-lines.js
@@ -1,0 +1,166 @@
+// Copyright (c) 2016 - 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import {scaleLinear} from 'd3-scale';
+import {format} from 'd3-format';
+
+import {MarginPropType} from 'utils/chart-utils';
+import XYPlot from 'plot/xy-plot';
+import PolygonSeries from 'plot/series/polygon-series';
+
+const predefinedClassName = 'rv-radar-chart-grid-lines';
+
+/**
+ * Generate the actual polygons to be plotted
+ * @param {Object} props
+ - props.data {Array} array of object specifying what values are to be plotted
+ - props.domains {Array} array of object specifying the way each axis is to be plotted
+ - props.startingAngle {number} the initial angle offset
+ - props.style {object} style object for the whole chart
+ * @return {Array} the plotted axis components
+ */
+function getSpiderGridLines(props) {
+  const {
+    numberOfDomains,
+    data,
+    style,
+    startingAngle,
+    numberOfGridlines,
+    startAtZero
+  } = props;
+  const scales = [...Array(numberOfDomains)].reduce((acc, grid, index) => {
+    acc[index] = scaleLinear()
+      .domain([0, numberOfGridlines])
+      .range([0, 1]);
+    return acc;
+  }, {});
+
+  let totalCount = numberOfGridlines;
+  if (startAtZero) {
+    totalCount++;
+  }
+  return [...Array(totalCount)].map((row, rowIndex) => {
+    const mappedData = [...Array(numberOfDomains)].map((domain, index) => {
+      const angle = (index / numberOfDomains) * Math.PI * 2 + startingAngle;
+      // dont let the radius become negative
+      let radiusNumber = numberOfGridlines - rowIndex;
+      if (radiusNumber === 0) {
+        // rendering a polygon with a 0 radius won't show anything, add just a tiny bit to show a tiny polygon at 0
+        radiusNumber = 0.1;
+      }
+      const radius = Math.max(scales[index](radiusNumber), 0);
+      return {
+        x: radius * Math.cos(angle),
+        y: radius * Math.sin(angle)
+      };
+    });
+
+    return (
+      <PolygonSeries
+        className={`${predefinedClassName}-spider-grid-line`}
+        key={`${rowIndex}-spider-grid-line`}
+        data={mappedData}
+        style={{
+          stroke: style.spiderGridStroke || '#cccccc',
+          strokeWidth: 1,
+          fill: style.spiderGridFill || '#f3f3f3',
+          ...style.polygons
+        }}
+      />
+    );
+  });
+}
+
+function RadarChartStraightGridLines(props) {
+  const {
+    height,
+    width,
+    margin,
+    className,
+    numberOfDomains,
+    data,
+    startingAngle,
+    style,
+    numberOfGridlines,
+    startAtZero
+  } = props;
+
+  const spiderGridLines = getSpiderGridLines({
+    numberOfDomains,
+    data,
+    startingAngle,
+    style,
+    numberOfGridlines,
+    startAtZero
+  });
+
+  return (
+    <XYPlot
+      height={height}
+      width={width}
+      margin={margin}
+      style={{
+        ...style,
+        XYPlot: {
+          zIndex: -1
+        }
+      }}
+      dontCheckIfEmpty
+      className={`${className} ${predefinedClassName}`}
+      xDomain={[-1, 1]}
+      yDomain={[-1, 1]}
+    >
+      {spiderGridLines}
+    </XYPlot>
+  );
+}
+
+RadarChartStraightGridLines.displayName = 'RadarChartStraightGridLines';
+RadarChartStraightGridLines.propTypes = {
+  className: PropTypes.string,
+  numberOfDomains: PropTypes.number.isRequired,
+  height: PropTypes.number.isRequired,
+  margin: MarginPropType,
+  startingAngle: PropTypes.number,
+  style: PropTypes.shape({
+    polygons: PropTypes.object
+  }),
+  width: PropTypes.number.isRequired,
+  numberOfGridlines: PropTypes.number,
+  startAtZero: PropTypes.bool
+};
+
+RadarChartStraightGridLines.defaultProps = {
+  className: '',
+  startingAngle: Math.PI / 2,
+  style: {
+    polygons: {
+      strokeWidth: 0.5,
+      strokeOpacity: 1,
+      fillOpacity: 0.1
+    }
+  },
+  numberOfGridlines: 5,
+  startAtZero: true
+};
+
+export default RadarChartStraightGridLines;

--- a/tests/components/radar-chart-tests.js
+++ b/tests/components/radar-chart-tests.js
@@ -159,6 +159,13 @@ test('Radar: Showcase Example - Radar Chart with Tooltips', t => {
     .simulate('mouseOver');
   t.equal($.text(), `${chartText}${tooltipText}`, 'should display tooltip text');
   t.end();
+
+  // Spider graph lines
+  t.equal(
+    $.find('.rv-radar-chart-grid-lines-spider-grid-line').length,
+    6,
+    'should find the right number grid lines for the spider graph'
+  );
 });
 
 test('Radar: Showcase Example - series tooltips', t => {

--- a/tests/components/radar-chart-tests.js
+++ b/tests/components/radar-chart-tests.js
@@ -137,12 +137,12 @@ test('Radar: Showcase Example - Radar Chart with Tooltips', t => {
   );
   t.equal(
     $.find('.rv-radar-chart-polygon').length,
-    7,
+    2,
     'should find the right number of polygons'
   );
   t.equal(
     $.find('.rv-radar-chart-polygonPoint').length,
-    7,
+    2,
     'should find the right number of polygon points'
   );
   t.equal(
@@ -154,7 +154,7 @@ test('Radar: Showcase Example - Radar Chart with Tooltips', t => {
   // Tooltips
   const tooltipText = 'mileage: 3';
   $.find('.rv-xy-plot__series .rv-xy-plot__series--mark .rv-radar-chart-polygonPoint')
-    .at(6)
+    .at(0)
     .children().at(0)
     .simulate('mouseOver');
   t.equal($.text(), `${chartText}${tooltipText}`, 'should display tooltip text');


### PR DESCRIPTION
This is a potential solution for this: https://github.com/uber/react-vis/issues/1009

Basically, I wanted a solution that makes it easier to style a `RadarChart` as a "spider chart", similar to `CircularGridLines`, but with straight lines. I called it `RadarChartStraightGridLines` since this is specific to the `RadarChart`, but I don't really like that name, I'm definitely open to suggestions. Other notes:

- Although `line-series` could have been used, I used `polygon-series` so that the user can have more control over styling. Specifically, the polygon series allows a fill color for the polygons. 
- `radar-chart-straight-grid-lines` has it's own `XYPlot`. At first I tried it without this, but was getting errors about `xFunctor`. Maybe there's a better way to do that?
- Because the `XYPlot` is used, the `RadarChartStraightGridLines` needs to have a negative top margin to push it below the `RadarChart`. Additionally, a negative `z-index` is used to put it below the `RadarChart`.
- The `RadarChart` and `RadarChartStraightGridLines` need to have the same basic styling - height, width, starting angle, etc. Although it's possible for them to have different styling, that will make it the angles of the grid lines be different from the radar chart.
- The updated example looks like this:

<img width="495" alt="screen shot 2018-11-01 at 11 40 29 am" src="https://user-images.githubusercontent.com/3814546/47868862-fa767680-ddca-11e8-9aa0-8e506c5f5851.png">

- As an example, this is what it would look like when the domains have different ranges (this isn't committed to the examples):

<img width="503" alt="screen shot 2018-11-01 at 11 10 29 am" src="https://user-images.githubusercontent.com/3814546/47868949-34477d00-ddcb-11e8-8f8e-bb50d790142a.png">

Lastly, I haven't added this to the documentation, but I'd be glad to do so if you think this looks good.