### PR TITLE
Use dominant baseline instead of alignment for consistent rendering

### DIFF
--- a/docs/label-series.md
+++ b/docs/label-series.md
@@ -102,7 +102,7 @@ This attribute is used to align (start-, middle- or end-alignment) the label tex
 
 Type: `string`
 
-This attribute is used to align the label text vertically relative to the datapoint. (Sets the alignment-baseline attribute for the element https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/alignment-baseline)
+This attribute is used to align the label text vertically relative to the datapoint. (Sets the dominant-baseline attribute for the element https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/dominant-baseline)
 
 ## Interaction handlers
 #### onNearestX (optional)

--- a/src/plot/series/label-series.js
+++ b/src/plot/series/label-series.js
@@ -28,7 +28,7 @@ const predefinedClassName = 'rv-xy-plot__series rv-xy-plot__series--label';
 const getTextAnchor = (labelAnchorX, leftOfMiddle) => {
   return labelAnchorX ? labelAnchorX : leftOfMiddle ? 'start' : 'end';
 };
-const getAlignmentBaseline = (labelAnchorY, aboveMiddle) => {
+const getDominantBaseline = (labelAnchorY, aboveMiddle) => {
   return labelAnchorY
     ? labelAnchorY
     : aboveMiddle
@@ -95,7 +95,7 @@ class LabelSeries extends AbstractSeries {
           const hasRotationValueSet = d.rotation === 0 || d.rotation;
           const labelRotation = hasRotationValueSet ? d.rotation : rotation;
           const attrs = {
-            alignmentBaseline: getAlignmentBaseline(labelAnchorY, aboveMiddle),
+            dominantBaseline: getDominantBaseline(labelAnchorY, aboveMiddle),
             className: 'rv-xy-plot__series--label-text',
             key: i,
             onClick: e => this._valueClickHandler(d, e),


### PR DESCRIPTION
This is a fix for https://github.com/uber/react-vis/issues/1033

AFAICT (and I'm by no means an SVG expert) alignment-baseline is only supposed to be meaningful relative to a textual parent like a tspan, though chrome accepts it; dominant baseline is the correct attribute to use in this case, as it renders irrespective of the parent.

Alignment Baseline: https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/alignment-baseline
Dominant Baseline: https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/dominant-baseline

Pre-firefox:

![image](https://user-images.githubusercontent.com/7430154/48215267-e47b2f80-e34f-11e8-89f1-5c258aa62f3a.png)

Pre-chrome:

![image](https://user-images.githubusercontent.com/7430154/48215288-f066f180-e34f-11e8-9030-9cbae039dc6c.png)

Post-firefox:

![image](https://user-images.githubusercontent.com/7430154/48215300-f5c43c00-e34f-11e8-95dd-7cd0ffbbf153.png)

Post-chrome:

![image](https://user-images.githubusercontent.com/7430154/48215310-fbba1d00-e34f-11e8-90a0-ab1acf5f1a31.png)
