### PR TITLE
Remove unnecessary columns in the documentation

### DIFF
--- a/docs/xy-plot.md
+++ b/docs/xy-plot.md
@@ -78,16 +78,16 @@ Not all properties can be visualized in each series. Here's a short comparison o
 
 |                      | `x` | `y` | `color` | `opacity` | `size` |
 |----------------------|-----|-----|---------|-----------|--------|
-| [LineSeries](line-series.md)  |  +  |  +  | +       |           |        |
-| [AreaSeries](area-series.md)         |  +  |  +  | +       |           |        |
-| [LineMarkSeries](line-mark-series.md)     |  +  |  +  | +       |     +     | +      |
-| [MarkSeries](mark-series.md)         |  +  |  +  | +       |     +     | +      |
-| [VerticalBarSeries](bar-series.md)  |  +  |  +  | +       |     +     |        |
-| [HorizontalBarSeries](bar-series.md)|  +  |  +  | +       |     +     |        |
-| [VerticalRectSeries](rect-series.md)  |  +  |  +  | +       |     +     |        |
-| [HorizontalRectSeries](rect-series.md)|  +  |  +  | +       |     +     |        |
-| [HeatmapSeries](heatmap-series.md)      |  +  |  +  | +       |     +     |        |      |
-| [HexbinSeries](hexbin-series.md)      |  +  |  +  | +       |     +     |        |      |
+| [LineSeries](line-series.md)  | + | + | + |  |  |
+| [AreaSeries](area-series.md)         | + | + | + |  |  |
+| [LineMarkSeries](line-mark-series.md)     | + | + | + | + | + |
+| [MarkSeries](mark-series.md)         | + | + | + | + | + |
+| [VerticalBarSeries](bar-series.md)  | + | + | + | + |  |
+| [HorizontalBarSeries](bar-series.md)| + | + | + | + |  |
+| [VerticalRectSeries](rect-series.md)  | + | + | + | + |  |
+| [HorizontalRectSeries](rect-series.md)| + | + | + | + |  |
+| [HeatmapSeries](heatmap-series.md)      | + | + | + | + |  |
+| [HexbinSeries](hexbin-series.md)      | + | + | + | + |  |
 
 
 ### A note on ordering


### PR DESCRIPTION
Remove unnecessary blanks and columns.

The last two rows contained two meaningless columns.

![captura de pantalla 2018-11-09 a la s 2 20 22 p m](https://user-images.githubusercontent.com/19965590/48280680-ad2d8100-e42a-11e8-81b9-cb3edf5d06cc.png)
