### PR TITLE
Update CustomSVGSeries to use getX / getY

### DIFF
--- a/src/plot/series/custom-svg-series.js
+++ b/src/plot/series/custom-svg-series.js
@@ -140,8 +140,8 @@ class CustomSVGSeries extends AbstractSeries {
     const y = this._getAttributeFunctor('y');
     const contents = data.map((seriesComponent, index) => {
       const positionInPixels = {
-        x: x({x: seriesComponent.x}),
-        y: y({y: seriesComponent.y})
+        x: x(seriesComponent),
+        y: y(seriesComponent)
       };
       const innerComponent = getInnerComponent({
         customComponent: seriesComponent,


### PR DESCRIPTION
I ran into this problem when I refactored my graphs to use getX / getY rather than previously data.map to conform to x and y keys, and in doing so made my icons disappear as they had NaN as their x and y.

This has been successful in fixing them.