### PR TITLE
Additional tests for crosshair with dates

### DIFF
--- a/showcase/axes/dynamic-crosshair.js
+++ b/showcase/axes/dynamic-crosshair.js
@@ -35,6 +35,11 @@ const DATA = [
   [{x: 1, y: 20}, {x: 2, y: 5}, {x: 3, y: 15}]
 ];
 
+const DATE_DATA = [
+  [{x: new Date(1), y: 10}, {x: new Date(2), y: 7}, {x: new Date(3), y: 15}],
+  [{x: new Date(1), y: 20}, {x: new Date(2), y: 5}, {x: new Date(3), y: 15}]
+];
+
 export default class DynamicCrosshair extends React.Component {
   constructor(props) {
     super(props);
@@ -65,14 +70,16 @@ export default class DynamicCrosshair extends React.Component {
   }
 
   render() {
+    const withDate = this.props.withDate
+    const xType = withDate ? 'time' : undefined
     return (
-      <XYPlot onMouseLeave={this._onMouseLeave} width={300} height={300}>
+      <XYPlot onMouseLeave={this._onMouseLeave} width={300} height={300} xType={xType}>
         <VerticalGridLines />
         <HorizontalGridLines />
         <XAxis />
         <YAxis />
-        <LineSeries onNearestX={this._onNearestX} data={DATA[0]} />
-        <LineSeries data={DATA[1]} />
+        <LineSeries onNearestX={this._onNearestX} data={withDate ? DATE_DATA[0] : DATA[0]} />
+        <LineSeries data={withDate ? DATE_DATA[1] : DATA[1]} />
         <Crosshair
           values={this.state.crosshairValues}
           className={'test-class-name'}

--- a/src/plot/crosshair.js
+++ b/src/plot/crosshair.js
@@ -22,6 +22,8 @@ import React, {PureComponent} from 'react';
 
 import PropTypes from 'prop-types';
 
+import {transformValueToString} from 'utils/data-utils';
+
 import {getAttributeFunctor} from 'utils/scales-utils';
 
 /**
@@ -34,7 +36,7 @@ function defaultTitleFormat(values) {
   if (value) {
     return {
       title: 'x',
-      value: Object.prototype.toString.call(value.x) === '[object Date]' ? value.x.toDateString() : value.x
+      value: transformValueToString(value.x)
     };
   }
 }

--- a/src/plot/crosshair.js
+++ b/src/plot/crosshair.js
@@ -34,7 +34,7 @@ function defaultTitleFormat(values) {
   if (value) {
     return {
       title: 'x',
-      value: value.x
+      value: Object.prototype.toString.call(value.x) === '[object Date]' ? value.x.toDateString() : value.x
     };
   }
 }

--- a/src/plot/hint.js
+++ b/src/plot/hint.js
@@ -22,6 +22,8 @@ import React, {PureComponent} from 'react';
 
 import PropTypes from 'prop-types';
 
+import {transformValueToString} from 'utils/data-utils';
+
 import {getAttributeFunctor} from 'utils/scales-utils';
 
 /*
@@ -70,7 +72,7 @@ const ORIENTATION = {
  */
 function defaultFormat(value) {
   return Object.keys(value).map(function getProp(key) {
-    return {title: key, value: value[key]};
+    return {title: key, value: transformValueToString(value[key])};
   });
 }
 

--- a/src/utils/data-utils.js
+++ b/src/utils/data-utils.js
@@ -45,3 +45,12 @@ export function addValueToArray(arr, value) {
   }
   return result;
 }
+
+/**
+ * Transforms a value ( number or date ) to a string.
+ * @param {Date | number} value The value as date or number.
+ * @returns {string | number} The value as string.
+ */
+export function transformValueToString(value) {
+  return Object.prototype.toString.call(value) === '[object Date]' ? value.toDateString() : value;
+}

--- a/tests/components/crosshair-tests.js
+++ b/tests/components/crosshair-tests.js
@@ -21,6 +21,23 @@ test('Crosshair: Dynamic Crosshair - Example', t => {
   }
 });
 
+test('Crosshair: Dynamic Crosshair - Date Example', t => {
+  const $ = mount(<DynamicCrosshair withDate={true}/>);
+  simulateMouseMove(100);
+  t.equal(
+    $.find('.rv-crosshair').hasClass('test-class-name'),
+    true,
+    'should find the class name passed as a prop'
+  );
+  t.end();
+
+  function simulateMouseMove(x) {
+    $.find('.rv-xy-plot__inner').simulate('mousemove', {
+      nativeEvent: {clientX: x, clientY: 150}
+    });
+  }
+});
+
 test('Crosshair: Dynamic Crosshair - Touch Example', t => {
   const $ = mount(<DynamicCrosshair />);
   simulateMouseMove(100);

--- a/tests/utils/data-utils-tests.js
+++ b/tests/utils/data-utils-tests.js
@@ -20,7 +20,7 @@
 
 import test from 'tape';
 
-import {getUniquePropertyValues, addValueToArray} from 'utils/data-utils';
+import {getUniquePropertyValues, addValueToArray, transformValueToString} from 'utils/data-utils';
 
 const arr = [{a: 1}, {b: 3, a: 2}, {a: 2}];
 
@@ -50,5 +50,13 @@ test('data-utils #addValueToArray', t => {
     [-1, 10],
     'Should add the value if the value is smaller'
   );
+  t.end();
+});
+
+test('data-utils #transformValueToString', t => {
+  t.deepEqual(transformValueToString(0), 0,
+    'Shouldn\'t transform the number value');
+  t.deepEqual(transformValueToString(new Date(0)), 'Thu Jan 01 1970',
+    'Should transform the date to string value');
   t.end();
 });


### PR DESCRIPTION
I added the possibility to show the dynamic cross hair component with dates and implemented a test to cover it. So that if the cross hair fails because the date x value is not parsed into a string, it will be caught.