### PR TITLE
feat(treemap): Extend tree map API.

### DIFF
--- a/docs/treemap.md
+++ b/docs/treemap.md
@@ -100,6 +100,12 @@ Type: `number`
 
 The padding between cells the cells of the heatmap in pixels.
 
+#### margin
+
+Type: `number`
+
+The margin of cells in pixels.
+
 #### data
 
 Type: `Object`
@@ -202,3 +208,44 @@ Pass in a function that will be used to sort the nodes, for more information see
 
 Scale properties for the `color` scale. If `color` property is not passed in the data object, each new section of the chart gets the next color (e. g. the `'category'` scale is applied).
 Please refer to [Scales and Data](scales-and-data.md) for more information about scales.
+
+#### getSize
+
+Type: `function`
+
+- Should accept arguments (leaf)
+
+Pass in a function that will be used for get size.
+
+#### getColor
+
+Type: `function`
+
+- Should accept arguments (leaf)
+
+Pass in a function that will be used for get color.
+
+#### getLabel
+
+Type: `function`
+
+- Should accept arguments (leaf)
+
+Pass in a function that will be used for get label.
+
+#### getContent
+
+Type: `function`
+
+- Should accept arguments (leaf)
+
+Pass in a function that will be used for get inner content of leaf.
+Can return a string or react component (JSX)
+
+#### getChildren
+
+Type: `function`
+
+- Should accept arguments (leaf)
+
+Pass in a function that will be used for get children

--- a/src/treemap/index.js
+++ b/src/treemap/index.js
@@ -157,7 +157,7 @@ class Treemap extends React.Component {
       .tile(tileFn)
       .size([innerWidth, innerHeight])
       .padding(padding);
-    const structuredInput = hierarchy(data)
+    const structuredInput = hierarchy(data, this.props.getChildren)
       .sum(getSize)
       .sort((a, b) => sortFunction(a, b, getSize));
     return treemapingFunction(structuredInput).descendants();
@@ -191,7 +191,10 @@ Treemap.propTypes = {
   sortFunction: PropTypes.func,
   width: PropTypes.number.isRequired,
   getSize: PropTypes.func,
-  getColor: PropTypes.func
+  getColor: PropTypes.func,
+  getLabel: PropTypes.func,
+  getContent: PropTypes.func,
+  getChildren: PropTypes.func
 };
 
 Treemap.defaultProps = {
@@ -218,6 +221,8 @@ Treemap.defaultProps = {
   },
   getSize: d => d.size,
   getColor: d => d.color,
-  getLabel: d => d.title
+  getLabel: d => d.title,
+  getContent: () => {},
+  getChildren: d => d.children
 };
 export default Treemap;

--- a/src/treemap/treemap-leaf.js
+++ b/src/treemap/treemap-leaf.js
@@ -43,6 +43,7 @@ function TreemapLeaf(props) {
   const {
     animation,
     getLabel,
+    getContent,
     mode,
     node,
     onLeafClick,
@@ -92,7 +93,8 @@ function TreemapLeaf(props) {
       onClick={event => onLeafClick(node, event)}
       style={leafStyle}
     >
-      <div className="rv-treemap__leaf__content">{title}</div>
+      { title && <div className="rv-treemap__leaf__content">{ title }</div> }
+      { getContent(node) }
     </div>
   );
 }
@@ -105,6 +107,7 @@ TreemapLeaf.propTypes = {
   onLeafClick: PropTypes.func,
   onLeafMouseOver: PropTypes.func,
   onLeafMouseOut: PropTypes.func,
+  getContent: PropTypes.func,
   scales: PropTypes.object.isRequired,
   width: PropTypes.number.isRequired,
   r: PropTypes.number.isRequired,


### PR DESCRIPTION
Motivation: For creating complex tree map [example](https://codepen.io/nardecky/details/ZeRPde) we need more control over rendering. 
Adding these props allows you to create, for example, nested treemaps.
![Example](https://i.imgur.com/zIWGZz8.png)