### PR TITLE
Loosen `tickValues` propTypes to support `Date`s in time series

### DIFF
--- a/docs/scales-and-data.md
+++ b/docs/scales-and-data.md
@@ -116,7 +116,7 @@ To redefine a scale, you must pass a prop to the series that uses that scale. Th
     * `'category'`  
     Categorical scale, each new value gets the next value from the range. Similar to d3.scale.category\[Number\], but works with other values besides colors.
     * `'time'`  
-    Time scale. Similar to [d3.scaleTime](https://github.com/d3/d3-scale/blob/master/README.md#time-scales).
+    Time scale. Similar to [d3.scaleTime](https://github.com/d3/d3-scale/blob/master/README.md#time-scales). Times can be provided as JavaScript `Date` objects or as Unix epoch numbers.
     * `'time-utc'`  
     Time UTC scale. Similar to [d3.scaleUtc](https://github.com/d3/d3-scale/blob/master/README.md#scaleUtc)
     * `'log'`  

--- a/src/plot/axis/axis.js
+++ b/src/plot/axis/axis.js
@@ -73,7 +73,8 @@ const propTypes = {
   tickValues: PropTypes.arrayOf(
     PropTypes.oneOfType([
       PropTypes.number,
-      PropTypes.string
+      PropTypes.string,
+      PropTypes.object,
     ])
   ),
   tickFormat: PropTypes.func,

--- a/src/plot/circular-grid-lines.js
+++ b/src/plot/circular-grid-lines.js
@@ -112,7 +112,13 @@ CircularGridLines.propTypes = {
 
   style: PropTypes.object,
 
-  tickValues: PropTypes.arrayOf(PropTypes.number),
+  tickValues: PropTypes.arrayOf(
+    PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.string,
+      PropTypes.object,
+    ])
+  ),
   tickTotal: PropTypes.number,
 
   animation: AnimationPropType,

--- a/src/plot/grid-lines.js
+++ b/src/plot/grid-lines.js
@@ -46,7 +46,8 @@ const propTypes = {
   tickValues: PropTypes.arrayOf(
     PropTypes.oneOfType([
       PropTypes.number,
-      PropTypes.string
+      PropTypes.string,
+      PropTypes.object,
     ])
   ),
   tickTotal: PropTypes.number,


### PR DESCRIPTION
A time series can have JS `Date` objects (or epoch numbers) as
values. (See issue #1083)