### PR TITLE
Avoid registering onWheel listener when not needed in XYPlot

### DIFF
--- a/src/plot/xy-plot.js
+++ b/src/plot/xy-plot.js
@@ -485,18 +485,6 @@ class XYPlot extends React.Component {
     });
   };
 
-  /**
-   * Trigger doule-click related callbacks if they are available.
-   * @param {React.SyntheticEvent} event Double-click event.
-   * @private
-   */
-  _wheelHandler = event => {
-    const {onWheel} = this.props;
-    if (onWheel) {
-      onWheel(event);
-    }
-  };
-
   renderCanvasComponents(components, props) {
     const componentsToRender = components.filter(
       c => c && !c.type.requiresSVG && c.type.isCanvas
@@ -530,7 +518,7 @@ class XYPlot extends React.Component {
   }
 
   render() {
-    const {className, dontCheckIfEmpty, style, width, height} = this.props;
+    const {className, dontCheckIfEmpty, style, width, height, onWheel} = this.props;
 
     if (!dontCheckIfEmpty && this._isPlotEmpty()) {
       return (
@@ -569,7 +557,7 @@ class XYPlot extends React.Component {
           onTouchMove={this._touchMoveHandler}
           onTouchEnd={this._touchEndHandler}
           onTouchCancel={this._touchCancelHandler}
-          onWheel={this._wheelHandler}
+          onWheel={onWheel}
         >
           {components.filter(c => c && c.type.requiresSVG)}
         </svg>

--- a/tests/components/xy-plot-tests.js
+++ b/tests/components/xy-plot-tests.js
@@ -298,3 +298,21 @@ test('XYPlot attach ref only to series components', t => {
   t.ok(statelessChild.ref === null, 'Ref not attached to stateless components');
   t.end();
 });
+
+test('XYPlot with wheel event callback', t => {
+  t.plan(1);
+
+  const onWheel = () => t.pass("onWheel is called correctly");
+
+  const $ = mount(
+    <XYPlot onWheel={onWheel} width={300} height={300}>
+      <VerticalBarSeries data={[{x: 1, y: 0}, {x: 2, y: 1}, {x: 3, y: 2}]} />
+    </XYPlot>
+  );
+
+  $.find('svg')
+    .at(0)
+    .simulate('wheel');
+
+  t.end();
+});


### PR DESCRIPTION
This pull request allows the onWheel handler to be undefined to avoid registering an active listener when not needed.

In the case that the XYPlot is used without an onWheel callback the code was registering a listener anyway. This would cause warnings in the chrome console about registering an active listener.

The warning will still be shown in the case that an onWheel callback is set, but this change prevents the listener from being registered when it is a no-op anyway.

