### PR TITLE
fix: Fix FlexiblePlot handling of container resize

### DIFF
--- a/src/make-vis-flexible.js
+++ b/src/make-vis-flexible.js
@@ -122,17 +122,17 @@ function makeFlexible(Component, isWidthFlexible, isHeightFlexible) {
     _onResize = () => {
       const containerElement = getDOMNode(this[CONTAINER_REF]);
       const {offsetHeight, offsetWidth} = containerElement;
+      const {height, width} = this.state;
 
-      const newHeight =
-        this.state.height === offsetHeight ? {} : {height: offsetHeight};
-
-      const newWidth =
-        this.state.width === offsetWidth ? {} : {width: offsetWidth};
-
-      this.setState({
-        ...newHeight,
-        ...newWidth
-      });
+      if (height !== offsetHeight || width !== offsetWidth){
+        // Only call setState if one dimension has changed.
+        // Otherwise, this will create an infinite loop because _onResize
+        // is called from componentDidUpdate.
+        this.setState({
+          height: offsetHeight,
+          width: offsetWidth
+        });
+      }
     };
 
     componentDidMount() {
@@ -140,7 +140,7 @@ function makeFlexible(Component, isWidthFlexible, isHeightFlexible) {
       this.cancelSubscription = subscribeToDebouncedResize(this._onResize);
     }
 
-    componentWillReceiveProps() {
+    componentDidUpdate() {
       this._onResize();
     }
 


### PR DESCRIPTION
## Tackled issue
A flexible plot is not properly resized when its parent container is resized

## Cause
The `_onResize` is called on the `componentWillReceiveProps` lifecycle event, which in addition to [being deprecated](https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops), is the wrong event: computing the parent dimensions will yield incorrect results (the DOM hasn't been updated yet)

## Solution
Use [`componentDidUpdate`] instead, and make sure `onResize` only calls `setState` if something did change.