### PR TITLE
remove unused dependency hoek

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4891,11 +4891,6 @@
         "minimalistic-crypto-utils": "1.0.1"
       }
     },
-    "hoek": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
-    },
     "home-or-tmp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "d3-voronoi": "^1.1.2",
     "deep-equal": "^1.0.1",
     "global": "^4.3.1",
-    "hoek": "4.2.1",
     "prop-types": "^15.5.8",
     "react-motion": "^0.5.2"
   },


### PR DESCRIPTION
fix #1128 

It also removes a `npm` warning
```
npm WARN deprecated hoek@4.2.1: This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).
```