### PR TITLE
Add barRadiusX and barRadiusY props to BarSeries

### DIFF
--- a/src/plot/series/bar-series.js
+++ b/src/plot/series/bar-series.js
@@ -38,13 +38,17 @@ class BarSeries extends AbstractSeries {
       lineSizeAttr: PropTypes.string,
       valueSizeAttr: PropTypes.string,
       cluster: PropTypes.string,
-      barWidth: PropTypes.number
+      barWidth: PropTypes.number,
+      barRadiusX: PropTypes.number,
+      barRadiusY: PropTypes.number
     };
   }
 
   static get defaultProps() {
     return {
-      barWidth: 0.85
+      barWidth: 0.85,
+      barRadiusX: 0,
+      barRadiusY: 0
     };
   }
 
@@ -60,7 +64,9 @@ class BarSeries extends AbstractSeries {
       style,
       valuePosAttr,
       valueSizeAttr,
-      barWidth
+      barWidth,
+      barRadiusX,
+      barRadiusY
     } = this.props;
 
     if (!data) {
@@ -120,6 +126,8 @@ class BarSeries extends AbstractSeries {
             [lineSizeAttr]: spacePerBar,
             [valuePosAttr]: Math.min(value0Functor(d), valueFunctor(d)),
             [valueSizeAttr]: Math.abs(-value0Functor(d) + valueFunctor(d)),
+            rx: barRadiusX,
+            ry: barRadiusY,
             onClick: e => this._valueClickHandler(d, e),
             onContextMenu: e => this._valueRightClickHandler(d, e),
             onMouseOver: e => this._valueMouseOverHandler(d, e),


### PR DESCRIPTION
Hi,

I've needed rounded corners on `BarSeries` and wanted to make it available upstream so others can benefit, too.

Actually, setting `rx` and `ry` should be settable by CSS, according to [the mozilla docs](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/rx#rect). However, even if it works on Chrome (74.0.3729.169), it doesn't on Firefox (67.0) and Edge (44.17763.1.0).

I can also add relevant documentation but wanted to get a go first.