### PR TITLE
Fix build travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: node_js
 node_js:
   - '6'
   - '7'
-before_script:
-  - export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start
+  - '8'
+  - '9'
 script:
   - npm run lint
   - npm run cover


### PR DESCRIPTION
Removes a before script from the travis build which was causing it to crash. I don't really know what it does, googling shows this https://docs.travis-ci.com/user/gui-and-headless-browsers/ but we don't really use a headless browser to test things? I also added testing for node 8/9 with the intention of turning off 6/7 because they are not longer under long term support (https://nodejs.org/en/about/releases/).