### PR TITLE
No need to define enabled legend item colour.

### DIFF
--- a/src/styles/legends.scss
+++ b/src/styles/legends.scss
@@ -1,4 +1,3 @@
-$rv-legend-enabled-color: #3a3a48;
 $rv-legend-disabled-color: #b8b8b8;
 
 .rv-discrete-color-legend {
@@ -12,7 +11,6 @@ $rv-legend-disabled-color: #b8b8b8;
 }
 
 .rv-discrete-color-legend-item {
-  color: $rv-legend-enabled-color;
   border-radius: 1px;
   padding: 9px 10px;
 


### PR DESCRIPTION
This is a minor contribution. Thinking in term of "themes" I think it is not necessary to define enabled items colour.