### PR TITLE
add fontSize property to label-series

### DIFF
--- a/src/plot/series/label-series.js
+++ b/src/plot/series/label-series.js
@@ -79,7 +79,7 @@ class LabelSeries extends AbstractSeries {
         style={style}
       >
         {data.reduce((res, d, i) => {
-          const {style: markStyle, xOffset, yOffset} = d;
+          const {style: markStyle, xOffset, yOffset, fontSize} = d;
           if (!getLabel(d)) {
             return res;
           }
@@ -109,6 +109,7 @@ class LabelSeries extends AbstractSeries {
             x,
             y,
             transform: `rotate(${labelRotation},${x},${y})`,
+            fontSize,
             ...markStyle
           };
           const textContent = getLabel(_data ? _data[i] : d);


### PR DESCRIPTION
Thank you for amazing library. It very useful in our production. 

I want to add some functional to our label-series
I have to some customize fontSize property for labels and suggest this feature.

I had this small PR as fist step. I would be glad to continue commit

Example:
```
<LabelSeries
          animation={animation}
          className={className}
          rotation={labelRotation}
          labelAnchorY="text-before-edge"
          data={nodesCopy.map((node, i) => {
            return {
              x: node.x0 + (node.x0 < width / 2 ? nWidth + 10 : -10),
              y: (node.y0 + node.y1) / 2 - marginTop,
              label: node.name,
              style: {
                textAnchor: node.x0 < width / 2 ? 'start' : 'end',
                dy: '-.5em',
                fontSize: node.fontSize || 'inherit', // add fontSize
                ...style.labels
              },
              // unfortunately this can not be ...node as the version
              // found in nodesCopy is modified by the sankey process
              ...nodes[i]
            };
          })}
        />
```

