### PR TITLE
Reference react-vis properly from showcase.

### DIFF
--- a/packages/react-vis/package.json
+++ b/packages/react-vis/package.json
@@ -106,7 +106,8 @@
             "src"
           ],
           "alias": {
-            "react-vis/*": "src/*"
+            "react-vis/*": "src/*",
+            "react-vis": "src"
           }
         }
       ]

--- a/packages/react-vis/package.json
+++ b/packages/react-vis/package.json
@@ -104,7 +104,10 @@
         {
           "root": [
             "src"
-          ]
+          ],
+          "alias": {
+            "react-vis/*": "src/*"
+          }
         }
       ]
     ],

--- a/packages/react-vis/package.json
+++ b/packages/react-vis/package.json
@@ -104,11 +104,7 @@
         {
           "root": [
             "src"
-          ],
-          "alias": {
-            "react-vis/*": "src/*",
-            "react-vis": "src"
-          }
+          ]
         }
       ]
     ],

--- a/packages/react-vis/tests/components/xy-plot-tests.js
+++ b/packages/react-vis/tests/components/xy-plot-tests.js
@@ -24,6 +24,7 @@ import {mount, shallow} from 'enzyme';
 
 import AbstractSeries from 'plot/series/abstract-series';
 import VerticalBarSeries from 'plot/series/vertical-bar-series';
+import BarSeries from 'plot/series/bar-series';
 import LineSeries from 'plot/series/line-series';
 import XAxis from 'plot/axis/x-axis';
 import XYPlot from 'plot/xy-plot';
@@ -161,8 +162,8 @@ test('testing flexible charts', t => {
 test('Render two stacked bar series with a non-stacked line series chart', t => {
   const $ = mount(<MixedStackedChart />);
 
-  const renderedBarsWrapper = $.find('BarSeries');
-  const renderedLineWrapper = $.find('LineSeries');
+  const renderedBarsWrapper = $.find(BarSeries);
+  const renderedLineWrapper = $.find(LineSeries);
   t.deepEqual(
     renderedBarsWrapper.at(0).prop('data'),
     [

--- a/packages/react-vis/tests/components/xy-plot-tests.js
+++ b/packages/react-vis/tests/components/xy-plot-tests.js
@@ -24,7 +24,6 @@ import {mount, shallow} from 'enzyme';
 
 import AbstractSeries from 'plot/series/abstract-series';
 import VerticalBarSeries from 'plot/series/vertical-bar-series';
-import BarSeries from 'plot/series/bar-series';
 import LineSeries from 'plot/series/line-series';
 import XAxis from 'plot/axis/x-axis';
 import XYPlot from 'plot/xy-plot';

--- a/packages/react-vis/tests/components/xy-plot-tests.js
+++ b/packages/react-vis/tests/components/xy-plot-tests.js
@@ -162,9 +162,8 @@ test('testing flexible charts', t => {
 test('Render two stacked bar series with a non-stacked line series chart', t => {
   const $ = mount(<MixedStackedChart />);
 
-  const renderedBarsWrapper = $.find(BarSeries);
-  const renderedLineWrapper = $.find(LineSeries);
-
+  const renderedBarsWrapper = $.find('BarSeries');
+  const renderedLineWrapper = $.find('LineSeries');
   t.deepEqual(
     renderedBarsWrapper.at(0).prop('data'),
     [

--- a/packages/showcase/axes/axis-on-0.js
+++ b/packages/showcase/axes/axis-on-0.js
@@ -27,7 +27,7 @@ import {
   VerticalGridLines,
   HorizontalGridLines,
   LineSeries
-} from 'index';
+}from 'react-vis';
 
 export default function AxisOn0({
   xDomain = [-1, 3],

--- a/packages/showcase/axes/custom-axes-orientation.js
+++ b/packages/showcase/axes/custom-axes-orientation.js
@@ -27,7 +27,7 @@ import {
   HorizontalGridLines,
   VerticalGridLines,
   LineSeries
-} from 'index';
+}from 'react-vis';
 
 export default function Example(props) {
   return (

--- a/packages/showcase/axes/custom-axes.js
+++ b/packages/showcase/axes/custom-axes.js
@@ -20,7 +20,7 @@
 
 import React from 'react';
 
-import {XYPlot, XAxis, YAxis, MarkSeries} from 'index';
+import {XYPlot, XAxis, YAxis, MarkSeries}from 'react-vis';
 
 const MARGIN = {
   left: 10,

--- a/packages/showcase/axes/custom-axis-tick-element.js
+++ b/packages/showcase/axes/custom-axis-tick-element.js
@@ -27,7 +27,7 @@ import {
   VerticalGridLines,
   HorizontalGridLines,
   LineSeries
-} from 'index';
+}from 'react-vis';
 
 export default class Example extends React.Component {
   state = {

--- a/packages/showcase/axes/custom-axis-tick-format.js
+++ b/packages/showcase/axes/custom-axis-tick-format.js
@@ -27,7 +27,7 @@ import {
   VerticalGridLines,
   HorizontalGridLines,
   LineSeries
-} from 'index';
+}from 'react-vis';
 
 export default class Example extends React.Component {
   static _xTickFormatValue(v, i, scale, tickTotal) {

--- a/packages/showcase/axes/custom-axis.js
+++ b/packages/showcase/axes/custom-axis.js
@@ -27,7 +27,7 @@ import {
   VerticalGridLines,
   HorizontalGridLines,
   LineSeries
-} from 'index';
+}from 'react-vis';
 
 export default function Example(props) {
   const axisStyle = {

--- a/packages/showcase/axes/decorative-axes-criss-cross.js
+++ b/packages/showcase/axes/decorative-axes-criss-cross.js
@@ -20,7 +20,7 @@
 
 import React from 'react';
 
-import {XYPlot, DecorativeAxis} from 'index';
+import {XYPlot, DecorativeAxis}from 'react-vis';
 
 const MARGIN = {
   left: 30,

--- a/packages/showcase/axes/dynamic-complex-edge-hints.js
+++ b/packages/showcase/axes/dynamic-complex-edge-hints.js
@@ -29,7 +29,7 @@ import {
   LineSeries,
   MarkSeries,
   Hint
-} from 'index';
+}from 'react-vis';
 
 const {LEFT, TOP, BOTTOM_EDGE, LEFT_EDGE, RIGHT_EDGE, TOP_EDGE} = Hint.ALIGN;
 

--- a/packages/showcase/axes/dynamic-crosshair-scatterplot.js
+++ b/packages/showcase/axes/dynamic-crosshair-scatterplot.js
@@ -30,7 +30,7 @@ import {
   XYPlot,
   YAxis,
   Voronoi
-} from 'index';
+}from 'react-vis';
 
 const DATA = [
   {x: 1, y: 4, size: 9},

--- a/packages/showcase/axes/dynamic-crosshair.js
+++ b/packages/showcase/axes/dynamic-crosshair.js
@@ -28,7 +28,7 @@ import {
   HorizontalGridLines,
   LineSeries,
   Crosshair
-} from 'index';
+}from 'react-vis';
 
 const DATA = [
   [{x: 1, y: 10}, {x: 2, y: 7}, {x: 3, y: 15}],

--- a/packages/showcase/axes/dynamic-hints.js
+++ b/packages/showcase/axes/dynamic-hints.js
@@ -28,7 +28,7 @@ import {
   HorizontalGridLines,
   MarkSeries,
   Hint
-} from 'index';
+}from 'react-vis';
 
 export default class Example extends React.Component {
   constructor(props) {

--- a/packages/showcase/axes/dynamic-programmatic-rightedge-hints.js
+++ b/packages/showcase/axes/dynamic-programmatic-rightedge-hints.js
@@ -29,7 +29,7 @@ import {
   LineSeries,
   MarkSeries,
   Hint
-} from 'index';
+}from 'react-vis';
 
 const CHART_MARGINS = {left: 50, right: 10, top: 10, bottom: 25};
 const DATA = [{x: 1, y: 5}, {x: 2, y: 12}, {x: 3, y: 8}, {x: 4, y: 15}];

--- a/packages/showcase/axes/dynamic-simple-edge-hints.js
+++ b/packages/showcase/axes/dynamic-simple-edge-hints.js
@@ -28,7 +28,7 @@ import {
   HorizontalGridLines,
   MarkSeries,
   Hint
-} from 'index';
+}from 'react-vis';
 
 const {LEFT, RIGHT, TOP, BOTTOM_EDGE, RIGHT_EDGE, TOP_EDGE} = Hint.ALIGN;
 const CHART_MARGINS = {left: 50, right: 10, top: 10, bottom: 25};

--- a/packages/showcase/axes/dynamic-simple-topedge-hints.js
+++ b/packages/showcase/axes/dynamic-simple-topedge-hints.js
@@ -29,7 +29,7 @@ import {
   LineSeries,
   MarkSeries,
   Hint
-} from 'index';
+}from 'react-vis';
 
 const CHART_MARGINS = {left: 50, right: 10, top: 10, bottom: 25};
 const DATA = [{x: 1, y: 5}, {x: 2, y: 10}, {x: 3, y: 10}, {x: 4, y: 15}];

--- a/packages/showcase/axes/empty-chart.js
+++ b/packages/showcase/axes/empty-chart.js
@@ -26,7 +26,7 @@ import {
   YAxis,
   VerticalGridLines,
   HorizontalGridLines
-} from 'index';
+}from 'react-vis';
 
 export default function EmptyChart() {
   return (

--- a/packages/showcase/axes/padded-axis.js
+++ b/packages/showcase/axes/padded-axis.js
@@ -27,7 +27,7 @@ import {
   HorizontalGridLines,
   VerticalGridLines,
   LineSeries
-} from 'index';
+}from 'react-vis';
 
 export default class Example extends React.Component {
   getRandomData() {

--- a/packages/showcase/axes/parallel-coordinates-example.js
+++ b/packages/showcase/axes/parallel-coordinates-example.js
@@ -23,7 +23,7 @@ import {scaleLinear} from 'd3-scale';
 
 import CarData from '../datasets/car-data.json';
 
-import {XYPlot, DecorativeAxis, LineSeries} from 'index';
+import {XYPlot, DecorativeAxis, LineSeries}from 'react-vis';
 
 const DEFAULT_DOMAIN = {min: Infinity, max: -Infinity};
 // begin by figuring out the domain of each of the columns

--- a/packages/showcase/axes/static-crosshair.js
+++ b/packages/showcase/axes/static-crosshair.js
@@ -28,7 +28,7 @@ import {
   HorizontalGridLines,
   LineSeries,
   Crosshair
-} from 'index';
+}from 'react-vis';
 
 export default function Example(props) {
   return (

--- a/packages/showcase/axes/static-hints.js
+++ b/packages/showcase/axes/static-hints.js
@@ -28,7 +28,7 @@ import {
   HorizontalGridLines,
   LineSeries,
   Hint
-} from 'index';
+}from 'react-vis';
 
 export default function Example(props) {
   return (

--- a/packages/showcase/color/line-chart-many-colors.js
+++ b/packages/showcase/color/line-chart-many-colors.js
@@ -27,7 +27,7 @@ import {
   HorizontalGridLines,
   VerticalGridLines,
   LineSeries
-} from 'index';
+}from 'react-vis';
 
 const data = [];
 

--- a/packages/showcase/color/mini-color-examples.js
+++ b/packages/showcase/color/mini-color-examples.js
@@ -26,7 +26,7 @@ import {
   LineSeries,
   MarkSeries,
   VerticalBarSeries
-} from 'index';
+}from 'react-vis';
 
 import {
   DISCRETE_COLOR_RANGE,

--- a/packages/showcase/data/mini-data-examples.js
+++ b/packages/showcase/data/mini-data-examples.js
@@ -20,7 +20,7 @@
 
 import React from 'react';
 
-import {XYPlot, LineSeries, MarkSeries, VerticalBarSeries} from 'index';
+import {XYPlot, LineSeries, MarkSeries, VerticalBarSeries}from 'react-vis';
 
 const data = [
   {x: 0, y: 8},

--- a/packages/showcase/examples/candlestick/candlestick-example.js
+++ b/packages/showcase/examples/candlestick/candlestick-example.js
@@ -19,7 +19,7 @@
 // THE SOFTWARE.
 
 import React from 'react';
-import {XAxis, YAxis, LineSeries, FlexibleWidthXYPlot} from 'index';
+import {XAxis, YAxis, LineSeries, FlexibleWidthXYPlot}from 'react-vis';
 import Candlestick from './candlestick';
 
 import './candlestick.scss';

--- a/packages/showcase/examples/candlestick/candlestick.js
+++ b/packages/showcase/examples/candlestick/candlestick.js
@@ -20,7 +20,7 @@
 
 import React from 'react';
 
-import {AbstractSeries} from 'index';
+import {AbstractSeries}from 'react-vis';
 
 const predefinedClassName =
   'rv-xy-plot__series rv-xy-plot__series--candlestick';

--- a/packages/showcase/examples/force-directed-graph/force-directed-graph.js
+++ b/packages/showcase/examples/force-directed-graph/force-directed-graph.js
@@ -22,7 +22,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {forceSimulation, forceLink, forceManyBody, forceCenter} from 'd3-force';
 
-import {XYPlot, MarkSeriesCanvas, LineSeriesCanvas} from 'index';
+import {XYPlot, MarkSeriesCanvas, LineSeriesCanvas}from 'react-vis';
 
 const colors = [
   '#19CDD7',

--- a/packages/showcase/examples/iris-dashboard/iris-dashboard.js
+++ b/packages/showcase/examples/iris-dashboard/iris-dashboard.js
@@ -26,7 +26,7 @@ import {
   MarkSeriesCanvas,
   Borders,
   Highlight
-} from 'index';
+}from 'react-vis';
 
 import Iris from '../../datasets/iris.json';
 

--- a/packages/showcase/examples/responsive-vis/responsive-bar-chart.js
+++ b/packages/showcase/examples/responsive-vis/responsive-bar-chart.js
@@ -19,7 +19,7 @@
 // THE SOFTWARE.
 
 import React from 'react';
-import {AreaSeries, HorizontalBarSeries, XAxis, XYPlot, YAxis}from 'react-vis';
+import {AreaSeries, HorizontalBarSeries, XAxis, XYPlot, YAxis} from 'react-vis';
 
 import {filterFeatures, getPPP} from './responsive-vis-utils';
 

--- a/packages/showcase/examples/responsive-vis/responsive-bar-chart.js
+++ b/packages/showcase/examples/responsive-vis/responsive-bar-chart.js
@@ -19,7 +19,7 @@
 // THE SOFTWARE.
 
 import React from 'react';
-import {AreaSeries, HorizontalBarSeries, XAxis, XYPlot, YAxis} from 'index';
+import {AreaSeries, HorizontalBarSeries, XAxis, XYPlot, YAxis}from 'react-vis';
 
 import {filterFeatures, getPPP} from './responsive-vis-utils';
 

--- a/packages/showcase/examples/responsive-vis/responsive-scatterplot.js
+++ b/packages/showcase/examples/responsive-vis/responsive-scatterplot.js
@@ -27,7 +27,7 @@ import {
   YAxis,
   Hint,
   LabelSeries
-} from 'index';
+}from 'react-vis';
 
 import {
   filterFeatures,

--- a/packages/showcase/examples/streamgraph/streamgraph-example.js
+++ b/packages/showcase/examples/streamgraph/streamgraph-example.js
@@ -23,7 +23,7 @@ import PropTypes from 'prop-types';
 import {stack as d3Stack, stackOffsetWiggle} from 'd3-shape';
 import {range, transpose} from 'd3-array';
 
-import {FlexibleWidthXYPlot, AreaSeries} from 'index';
+import {FlexibleWidthXYPlot, AreaSeries}from 'react-vis';
 
 import './streamgraph-example.scss';
 

--- a/packages/showcase/flexible/flexible-examples.js
+++ b/packages/showcase/flexible/flexible-examples.js
@@ -25,7 +25,7 @@ import {
   FlexibleWidthXYPlot,
   FlexibleHeightXYPlot,
   FlexibleXYPlot
-} from 'index';
+}from 'react-vis';
 
 const data = [
   {x: 0, y: 8},

--- a/packages/showcase/interaction/interaction-examples.js
+++ b/packages/showcase/interaction/interaction-examples.js
@@ -20,7 +20,7 @@
 
 import React, {Component} from 'react';
 
-import {XYPlot, LineSeries, MarkSeries} from 'index';
+import {XYPlot, LineSeries, MarkSeries}from 'react-vis';
 
 const scatterPlotData = [...Array(30).keys()].map(() => ({
   x: Math.random() * 10,

--- a/packages/showcase/legends/continuous-color.js
+++ b/packages/showcase/legends/continuous-color.js
@@ -20,7 +20,7 @@
 
 import React from 'react';
 
-import ContinuousColorLegend from 'legends/continuous-color-legend';
+import ContinuousColorLegend from 'react-vis/legends/continuous-color-legend';
 
 export default class Example extends React.Component {
   constructor(props) {

--- a/packages/showcase/legends/continuous-size.js
+++ b/packages/showcase/legends/continuous-size.js
@@ -20,7 +20,7 @@
 
 import React from 'react';
 
-import ContinuousSizeLegend from 'legends/continuous-size-legend';
+import ContinuousSizeLegend from 'react-vis/legends/continuous-size-legend';
 
 export default class Example extends React.Component {
   constructor(props) {

--- a/packages/showcase/legends/horizontal-discrete-color.js
+++ b/packages/showcase/legends/horizontal-discrete-color.js
@@ -20,8 +20,8 @@
 
 import React from 'react';
 
-import DiscreteColorLegend from 'legends/discrete-color-legend';
-import GradientDefs from 'plot/gradient-defs';
+import DiscreteColorLegend from 'react-vis/legends/discrete-color-legend';
+import GradientDefs from 'react-vis/plot/gradient-defs';
 
 const ITEMS = [
   {title: 'Dashed', color: "#45aeb1", strokeStyle: "dashed"},

--- a/packages/showcase/legends/horizontal-discrete-custom-palette.js
+++ b/packages/showcase/legends/horizontal-discrete-custom-palette.js
@@ -20,7 +20,7 @@
 
 import React, {Component} from 'react';
 
-import DiscreteColorLegend from 'legends/discrete-color-legend';
+import DiscreteColorLegend from 'react-vis/legends/discrete-color-legend';
 
 const ITEMS = [
   'Options',

--- a/packages/showcase/legends/searchable-discrete-color-hover.js
+++ b/packages/showcase/legends/searchable-discrete-color-hover.js
@@ -20,7 +20,7 @@
 
 import React, {Component} from 'react';
 
-import SearchableDiscreteColorLegend from 'legends/searchable-discrete-color-legend';
+import SearchableDiscreteColorLegend from 'react-vis/legends/searchable-discrete-color-legend';
 
 export default class SearchableDiscreteColorLegendHoverExample extends Component {
   constructor(props) {

--- a/packages/showcase/legends/searchable-discrete-color.js
+++ b/packages/showcase/legends/searchable-discrete-color.js
@@ -20,7 +20,7 @@
 
 import React from 'react';
 
-import SearchableDiscreteColorLegend from 'legends/searchable-discrete-color-legend';
+import SearchableDiscreteColorLegend from 'react-vis/legends/searchable-discrete-color-legend';
 
 export default class Example extends React.Component {
   constructor(props) {

--- a/packages/showcase/legends/vertical-discrete-color.js
+++ b/packages/showcase/legends/vertical-discrete-color.js
@@ -20,7 +20,7 @@
 
 import React from 'react';
 
-import DiscreteColorLegend from 'legends/discrete-color-legend';
+import DiscreteColorLegend from 'react-vis/legends/discrete-color-legend';
 
 const ITEMS = [
   'Options',

--- a/packages/showcase/misc/2d-dragable-plot.js
+++ b/packages/showcase/misc/2d-dragable-plot.js
@@ -29,7 +29,7 @@ import {
   MarkSeries,
   Highlight,
   Hint
-} from 'index';
+}from 'react-vis';
 
 import {generateSeededRandom} from '../showcase-utils';
 const seededRandom = generateSeededRandom(3);

--- a/packages/showcase/misc/animation-example.js
+++ b/packages/showcase/misc/animation-example.js
@@ -28,7 +28,7 @@ import {
   VerticalGridLines,
   HorizontalGridLines,
   MarkSeries
-} from 'index';
+}from 'react-vis';
 
 function generateData() {
   return [...new Array(10)].map(row => ({

--- a/packages/showcase/misc/dragable-chart-example.js
+++ b/packages/showcase/misc/dragable-chart-example.js
@@ -20,7 +20,7 @@
 
 import React from 'react';
 
-import {XYPlot, XAxis, YAxis, VerticalRectSeries, Highlight} from 'index';
+import {XYPlot, XAxis, YAxis, VerticalRectSeries, Highlight}from 'react-vis';
 
 const DATA = [
   {x0: 0, x: 1, y: 1},

--- a/packages/showcase/misc/gradient-example.js
+++ b/packages/showcase/misc/gradient-example.js
@@ -29,7 +29,7 @@ import {
   AreaSeries,
   GradientDefs,
   Borders
-} from 'index';
+}from 'react-vis';
 
 export default function GradientExample(props) {
   return (

--- a/packages/showcase/misc/label-series-example.js
+++ b/packages/showcase/misc/label-series-example.js
@@ -21,7 +21,7 @@
 import React from 'react';
 
 import ShowcaseButton from '../showcase-components/showcase-button';
-import {XYPlot, XAxis, YAxis, MarkSeries, LabelSeries} from 'index';
+import {XYPlot, XAxis, YAxis, MarkSeries, LabelSeries}from 'react-vis';
 
 function generateData() {
   return [

--- a/packages/showcase/misc/null-data-example.js
+++ b/packages/showcase/misc/null-data-example.js
@@ -29,7 +29,7 @@ import {
   HorizontalGridLines,
   VerticalGridLines,
   LineMarkSeries
-} from 'index';
+}from 'react-vis';
 
 const DATA = [
   [{x: 1, y: 10}, {x: 2, y: 10}, {x: 3, y: 13}, {x: 4, y: 7}, {x: 5, y: null}],

--- a/packages/showcase/misc/selection-plot-example.js
+++ b/packages/showcase/misc/selection-plot-example.js
@@ -28,7 +28,7 @@ import {
   HorizontalGridLines,
   MarkSeries,
   Highlight
-} from 'index';
+}from 'react-vis';
 
 import {generateSeededRandom} from '../showcase-utils';
 const seededRandom = generateSeededRandom(36);

--- a/packages/showcase/misc/synced-charts.js
+++ b/packages/showcase/misc/synced-charts.js
@@ -27,7 +27,7 @@ import {
   VerticalGridLines,
   HorizontalGridLines,
   LineSeries
-} from 'index';
+}from 'react-vis';
 
 export default class Example extends React.Component {
   constructor(props) {

--- a/packages/showcase/misc/time-chart.js
+++ b/packages/showcase/misc/time-chart.js
@@ -27,7 +27,7 @@ import {
   HorizontalGridLines,
   VerticalGridLines,
   LineSeries
-} from 'index';
+}from 'react-vis';
 
 const MSEC_DAILY = 86400000;
 

--- a/packages/showcase/misc/triangle-example.js
+++ b/packages/showcase/misc/triangle-example.js
@@ -20,7 +20,7 @@
 
 import React from 'react';
 
-import {XYPlot, PolygonSeries, XAxis, YAxis, GradientDefs} from 'index';
+import {XYPlot, PolygonSeries, XAxis, YAxis, GradientDefs}from 'react-vis';
 
 function buildTriangle(sideWidth, lowerLeftCoord) {
   const {x, y} = lowerLeftCoord;

--- a/packages/showcase/misc/voronoi-line-chart.js
+++ b/packages/showcase/misc/voronoi-line-chart.js
@@ -29,7 +29,7 @@ import {
   LineSeries,
   MarkSeries,
   Voronoi
-} from 'index';
+}from 'react-vis';
 
 const lines = [
   [{x: 1, y: 3}, {x: 2, y: 5}, {x: 3, y: 15}, {x: 4, y: 12}],

--- a/packages/showcase/misc/zoomable-chart-example.js
+++ b/packages/showcase/misc/zoomable-chart-example.js
@@ -27,7 +27,7 @@ import {
   XYPlot,
   LineSeries,
   Highlight
-} from 'index';
+}from 'react-vis';
 import {generateSeededRandom} from '../showcase-utils';
 
 const seededRandom = generateSeededRandom(9);

--- a/packages/showcase/package.json
+++ b/packages/showcase/package.json
@@ -33,6 +33,11 @@
     "yarn": "1.22.4"
   },
   "babel": {
+    "presets": [
+      "es2015",
+      "stage-0",
+      "react"
+    ],
     "plugins": [
       [
         "module-resolver",

--- a/packages/showcase/package.json
+++ b/packages/showcase/package.json
@@ -31,5 +31,21 @@
   "volta": {
     "node": "10.20.1",
     "yarn": "1.22.4"
+  },
+  "babel": {
+    "plugins": [
+      [
+        "module-resolver",
+        {
+          "root": [
+            "."
+          ],
+          "alias": {
+            "react-vis/*": "../react-vis/src/*",
+            "react-vis": "../react-vis/src"
+          }
+        }
+      ]
+    ]
   }
 }

--- a/packages/showcase/parallel-coordinates/animated-parallel-coordinates.js
+++ b/packages/showcase/parallel-coordinates/animated-parallel-coordinates.js
@@ -21,7 +21,7 @@
 import React, {Component} from 'react';
 
 import ShowcaseButton from '../showcase-components/showcase-button';
-import {ParallelCoordinates} from 'index';
+import {ParallelCoordinates}from 'react-vis';
 
 const DATA = [
   {

--- a/packages/showcase/parallel-coordinates/basic-parallel-coordinates.js
+++ b/packages/showcase/parallel-coordinates/basic-parallel-coordinates.js
@@ -21,7 +21,7 @@
 import React from 'react';
 import {format} from 'd3-format';
 
-import {ParallelCoordinates} from 'index';
+import {ParallelCoordinates}from 'react-vis';
 
 const DATA = [
   {

--- a/packages/showcase/parallel-coordinates/brushed-parallel-coordinates.js
+++ b/packages/showcase/parallel-coordinates/brushed-parallel-coordinates.js
@@ -20,7 +20,7 @@
 
 import React from 'react';
 
-import {ParallelCoordinates} from 'index';
+import {ParallelCoordinates}from 'react-vis';
 import IrisData from '../datasets/iris.json';
 
 // {"sepal length": 5.1, "sepal width": 3.5, "petal length": 1.4, "petal width": 0.2, "species": "setosa"},

--- a/packages/showcase/plot/area-chart-elevated.js
+++ b/packages/showcase/plot/area-chart-elevated.js
@@ -28,7 +28,7 @@ import {
   HorizontalGridLines,
   LineMarkSeries,
   AreaSeries
-} from 'index';
+}from 'react-vis';
 
 export default function AreaChartElevated(props) {
   return (

--- a/packages/showcase/plot/area-chart.js
+++ b/packages/showcase/plot/area-chart.js
@@ -27,7 +27,7 @@ import {
   VerticalGridLines,
   HorizontalGridLines,
   AreaSeries
-} from 'index';
+}from 'react-vis';
 
 export default function Example(props) {
   return (

--- a/packages/showcase/plot/axis-with-turned-labels.js
+++ b/packages/showcase/plot/axis-with-turned-labels.js
@@ -27,7 +27,7 @@ import {
   VerticalGridLines,
   HorizontalGridLines,
   VerticalBarSeries
-} from 'index';
+}from 'react-vis';
 
 export default function Example(props) {
   return (

--- a/packages/showcase/plot/bar-chart.js
+++ b/packages/showcase/plot/bar-chart.js
@@ -29,7 +29,7 @@ import {
   VerticalBarSeries,
   VerticalBarSeriesCanvas,
   LabelSeries
-} from 'index';
+}from 'react-vis';
 
 const greenData = [{x: 'A', y: 10}, {x: 'B', y: 5}, {x: 'C', y: 15}];
 

--- a/packages/showcase/plot/big-base-bar-chart.js
+++ b/packages/showcase/plot/big-base-bar-chart.js
@@ -26,7 +26,7 @@ import {
   YAxis,
   VerticalBarSeries,
   VerticalBarSeriesCanvas
-} from 'index';
+}from 'react-vis';
 
 const myDATA = [
   {id: '00036', y: 200400, x: 1504121437},

--- a/packages/showcase/plot/clustered-stacked-bar-chart.js
+++ b/packages/showcase/plot/clustered-stacked-bar-chart.js
@@ -30,7 +30,7 @@ import {
   VerticalBarSeries,
   VerticalBarSeriesCanvas,
   DiscreteColorLegend
-} from 'index';
+}from 'react-vis';
 
 export default class Example extends React.Component {
   state = {

--- a/packages/showcase/plot/complex-chart.js
+++ b/packages/showcase/plot/complex-chart.js
@@ -29,7 +29,7 @@ import {
   VerticalRectSeries,
   DiscreteColorLegend,
   Crosshair
-} from 'index';
+}from 'react-vis';
 
 /**
  * Get the array of x and y pairs.

--- a/packages/showcase/plot/contour-series-example.js
+++ b/packages/showcase/plot/contour-series-example.js
@@ -29,7 +29,7 @@ import {
   ContourSeries,
   MarkSeriesCanvas,
   Borders
-} from 'index';
+}from 'react-vis';
 
 import DATA from '../datasets/old-faithful.json';
 

--- a/packages/showcase/plot/custom-scales.js
+++ b/packages/showcase/plot/custom-scales.js
@@ -27,7 +27,7 @@ import {
   HorizontalGridLines,
   VerticalGridLines,
   LineSeries
-} from 'index';
+}from 'react-vis';
 
 export default function Example(props) {
   return (

--- a/packages/showcase/plot/custom-svg-all-the-marks.js
+++ b/packages/showcase/plot/custom-svg-all-the-marks.js
@@ -28,7 +28,7 @@ import {
   HorizontalGridLines,
   CustomSVGSeries,
   Hint
-} from 'index';
+}from 'react-vis';
 
 import ShowcaseButton from '../showcase-components/showcase-button';
 

--- a/packages/showcase/plot/custom-svg-example.js
+++ b/packages/showcase/plot/custom-svg-example.js
@@ -27,7 +27,7 @@ import {
   VerticalGridLines,
   HorizontalGridLines,
   CustomSVGSeries
-} from 'index';
+}from 'react-vis';
 
 export default function Example(props) {
   return (

--- a/packages/showcase/plot/custom-svg-root-level.js
+++ b/packages/showcase/plot/custom-svg-root-level.js
@@ -27,7 +27,7 @@ import {
   VerticalGridLines,
   HorizontalGridLines,
   CustomSVGSeries
-} from 'index';
+}from 'react-vis';
 
 export default function CustomSVGRootLevelComponent(props) {
   return (

--- a/packages/showcase/plot/difference-chart.js
+++ b/packages/showcase/plot/difference-chart.js
@@ -26,7 +26,7 @@ import {
   YAxis,
   VerticalBarSeries,
   VerticalBarSeriesCanvas
-} from 'index';
+}from 'react-vis';
 
 // When making a difference chart you are specifying in coordinates
 // where you want your bars to start and stop

--- a/packages/showcase/plot/faux-radial-scatterplot.js
+++ b/packages/showcase/plot/faux-radial-scatterplot.js
@@ -20,7 +20,7 @@
 
 import React from 'react';
 
-import {XYPlot, XAxis, YAxis, MarkSeries, CircularGridLines} from 'index';
+import {XYPlot, XAxis, YAxis, MarkSeries, CircularGridLines}from 'react-vis';
 
 const data = [
   {r: 1, theta: Math.PI / 3, size: 30},

--- a/packages/showcase/plot/grid.js
+++ b/packages/showcase/plot/grid.js
@@ -20,7 +20,7 @@
 
 import React from 'react';
 
-import {XYPlot, XAxis, YAxis, VerticalGridLines, LineSeries} from 'index';
+import {XYPlot, XAxis, YAxis, VerticalGridLines, LineSeries}from 'react-vis';
 
 export default function Example(props) {
   return (

--- a/packages/showcase/plot/heatmap-chart.js
+++ b/packages/showcase/plot/heatmap-chart.js
@@ -20,7 +20,7 @@
 
 import React, {Component} from 'react';
 
-import {XYPlot, XAxis, YAxis, HeatmapSeries, Hint} from 'index';
+import {XYPlot, XAxis, YAxis, HeatmapSeries, Hint}from 'react-vis';
 
 export default class HeatmapChart extends Component {
   state = {

--- a/packages/showcase/plot/hex-heatmap.js
+++ b/packages/showcase/plot/hex-heatmap.js
@@ -22,7 +22,7 @@ import React, {Component} from 'react';
 
 import ShowcaseButton from '../showcase-components/showcase-button';
 
-import {XYPlot, XAxis, YAxis, HexbinSeries, Borders, Hint} from 'index';
+import {XYPlot, XAxis, YAxis, HexbinSeries, Borders, Hint}from 'react-vis';
 
 import DATA from '../datasets/old-faithful.json';
 

--- a/packages/showcase/plot/hexbin-size-example.js
+++ b/packages/showcase/plot/hexbin-size-example.js
@@ -22,7 +22,7 @@ import React, {Component} from 'react';
 
 import ShowcaseButton from '../showcase-components/showcase-button';
 
-import {XYPlot, XAxis, YAxis, HexbinSeries, ChartLabel} from 'index';
+import {XYPlot, XAxis, YAxis, HexbinSeries, ChartLabel}from 'react-vis';
 
 import DATA from '../datasets/car-data.json';
 
@@ -100,7 +100,7 @@ export default class HexbinSizeExample extends Component {
           />
           <XAxis />
           <YAxis />
-          <ChartLabel 
+          <ChartLabel
             text={DIMENSIONS[xAxis]}
             className="alt-x-label"
             xPercent={0.9}
@@ -111,7 +111,7 @@ export default class HexbinSizeExample extends Component {
             }}
             />
 
-          <ChartLabel 
+          <ChartLabel
             text={DIMENSIONS[yAxis]}
             className="alt-y-label"
             xPercent={0.1}

--- a/packages/showcase/plot/histogram.js
+++ b/packages/showcase/plot/histogram.js
@@ -26,7 +26,7 @@ import {
   VerticalGridLines,
   HorizontalGridLines,
   VerticalRectSeries
-} from 'index';
+}from 'react-vis';
 
 const timestamp = new Date('May 23 2017').getTime();
 const ONE_DAY = 86400000;

--- a/packages/showcase/plot/labeled-heatmap.js
+++ b/packages/showcase/plot/labeled-heatmap.js
@@ -21,7 +21,7 @@
 import React, {Component} from 'react';
 import {scaleLinear} from 'd3-scale';
 
-import {XYPlot, XAxis, YAxis, HeatmapSeries, LabelSeries, Hint} from 'index';
+import {XYPlot, XAxis, YAxis, HeatmapSeries, LabelSeries, Hint}from 'react-vis';
 
 const alphabet = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J'];
 const data = alphabet.reduce((acc, letter1, idx) => {

--- a/packages/showcase/plot/labeled-stacked-vertical-bar-chart.js
+++ b/packages/showcase/plot/labeled-stacked-vertical-bar-chart.js
@@ -29,7 +29,7 @@ import {
   VerticalBarSeries,
   VerticalBarSeriesCanvas,
   LabelSeries
-} from 'index';
+}from 'react-vis';
 
 export default class Example extends React.Component {
   state = {
@@ -46,7 +46,7 @@ export default class Example extends React.Component {
 
     const bars = data.map((value, index) => <BarSeries data={value} key={index} />)
     const labels = labelsData.map((value, index) => <LabelSeries data={value} key={index} labelAnchorY='hanging' style={{fill: '#ff8c00'}}/>)
-    
+
     return (
       <div>
         <ShowcaseButton

--- a/packages/showcase/plot/line-chart-canvas.js
+++ b/packages/showcase/plot/line-chart-canvas.js
@@ -32,7 +32,7 @@ import {
   LineSeriesCanvas,
   LineSeries,
   Crosshair
-} from 'index';
+}from 'react-vis';
 
 function getRandomData() {
   return new Array(1000).fill(0).map((row, i) => ({

--- a/packages/showcase/plot/line-chart-with-style.js
+++ b/packages/showcase/plot/line-chart-with-style.js
@@ -28,7 +28,7 @@ import {
   HorizontalGridLines,
   VerticalGridLines,
   LineSeries
-} from 'index';
+}from 'react-vis';
 
 export default function Example(props) {
   return (

--- a/packages/showcase/plot/line-chart.js
+++ b/packages/showcase/plot/line-chart.js
@@ -31,7 +31,7 @@ import {
   VerticalGridLines,
   LineSeries,
   LineSeriesCanvas
-} from 'index';
+}from 'react-vis';
 
 export default class Example extends React.Component {
   state = {
@@ -53,7 +53,7 @@ export default class Example extends React.Component {
           <VerticalGridLines />
           <XAxis />
           <YAxis />
-          <ChartLabel 
+          <ChartLabel
             text="X Axis"
             className="alt-x-label"
             includeMargin={false}
@@ -61,7 +61,7 @@ export default class Example extends React.Component {
             yPercent={1.01}
             />
 
-          <ChartLabel 
+          <ChartLabel
             text="Y Axis"
             className="alt-y-label"
             includeMargin={false}

--- a/packages/showcase/plot/line-series-canvas-nearest-xy-example.js
+++ b/packages/showcase/plot/line-series-canvas-nearest-xy-example.js
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 import React from 'react';
-import {XYPlot, LineSeriesCanvas, MarkSeriesCanvas} from 'index';
+import {XYPlot, LineSeriesCanvas, MarkSeriesCanvas}from 'react-vis';
 const k = 100;
 const data = Array(k)
   .fill(0)

--- a/packages/showcase/plot/linemark-chart.js
+++ b/packages/showcase/plot/linemark-chart.js
@@ -27,7 +27,7 @@ import {
   VerticalGridLines,
   HorizontalGridLines,
   LineMarkSeries
-} from 'index';
+}from 'react-vis';
 
 export default function Example(props) {
   return (

--- a/packages/showcase/plot/mixed-stacked-chart.js
+++ b/packages/showcase/plot/mixed-stacked-chart.js
@@ -29,7 +29,7 @@ import {
   VerticalBarSeries,
   VerticalBarSeriesCanvas,
   LineSeries
-} from 'index';
+}from 'react-vis';
 
 export default class Example extends React.Component {
   state = {

--- a/packages/showcase/plot/scatterplot-canvas.js
+++ b/packages/showcase/plot/scatterplot-canvas.js
@@ -30,7 +30,7 @@ import {
   MarkSeries,
   MarkSeriesCanvas,
   Hint
-} from 'index';
+}from 'react-vis';
 
 function getRandomData() {
   return new Array(100).fill(0).map(row => ({

--- a/packages/showcase/plot/scatterplot.js
+++ b/packages/showcase/plot/scatterplot.js
@@ -27,7 +27,7 @@ import {
   VerticalGridLines,
   HorizontalGridLines,
   MarkSeries
-} from 'index';
+}from 'react-vis';
 
 export default function Example(props) {
   return (

--- a/packages/showcase/plot/stacked-histogram.js
+++ b/packages/showcase/plot/stacked-histogram.js
@@ -28,7 +28,7 @@ import {
   HorizontalGridLines,
   VerticalRectSeries,
   VerticalRectSeriesCanvas
-} from 'index';
+}from 'react-vis';
 
 export default class Example extends React.Component {
   state = {

--- a/packages/showcase/plot/stacked-horizontal-bar-chart.js
+++ b/packages/showcase/plot/stacked-horizontal-bar-chart.js
@@ -28,7 +28,7 @@ import {
   HorizontalGridLines,
   HorizontalBarSeries,
   HorizontalBarSeriesCanvas
-} from 'index';
+}from 'react-vis';
 
 export default class Example extends React.Component {
   state = {

--- a/packages/showcase/plot/stacked-vertical-bar-chart.js
+++ b/packages/showcase/plot/stacked-vertical-bar-chart.js
@@ -28,7 +28,7 @@ import {
   HorizontalGridLines,
   VerticalBarSeries,
   VerticalBarSeriesCanvas
-} from 'index';
+}from 'react-vis';
 
 export default class Example extends React.Component {
   state = {

--- a/packages/showcase/plot/whisker-chart.js
+++ b/packages/showcase/plot/whisker-chart.js
@@ -27,7 +27,7 @@ import {
   VerticalGridLines,
   HorizontalGridLines,
   WhiskerSeries
-} from 'index';
+}from 'react-vis';
 
 export default function Example(props) {
   return (

--- a/packages/showcase/plot/width-height-margin.js
+++ b/packages/showcase/plot/width-height-margin.js
@@ -20,7 +20,7 @@
 
 import React from 'react';
 
-import {XYPlot, XAxis, YAxis, VerticalGridLines, LineSeries} from 'index';
+import {XYPlot, XAxis, YAxis, VerticalGridLines, LineSeries}from 'react-vis';
 
 export default function Example(props) {
   return (

--- a/packages/showcase/radar-chart/animated-radar-chart.js
+++ b/packages/showcase/radar-chart/animated-radar-chart.js
@@ -21,8 +21,8 @@
 import React, {Component} from 'react';
 
 import ShowcaseButton from '../showcase-components/showcase-button';
-import RadarChart from 'radar-chart';
-import CircularGridLines from 'plot/circular-grid-lines';
+import RadarChart from 'react-vis/radar-chart';
+import CircularGridLines from 'react-vis/plot/circular-grid-lines';
 
 const DATA = [
   {

--- a/packages/showcase/radar-chart/basic-radar-chart.js
+++ b/packages/showcase/radar-chart/basic-radar-chart.js
@@ -21,7 +21,7 @@
 import React from 'react';
 import {format} from 'd3-format';
 
-import RadarChart from 'radar-chart';
+import RadarChart from 'react-vis/radar-chart';
 
 const DATA = [
   {

--- a/packages/showcase/radar-chart/four-quadrant-radar-chart.js
+++ b/packages/showcase/radar-chart/four-quadrant-radar-chart.js
@@ -20,7 +20,7 @@
 
 import React from 'react';
 
-import RadarChart from 'radar-chart';
+import RadarChart from 'react-vis/radar-chart';
 
 const RADAR_PROPS = {
   data: [

--- a/packages/showcase/radar-chart/radar-chart-series-tooltips.js
+++ b/packages/showcase/radar-chart/radar-chart-series-tooltips.js
@@ -21,7 +21,7 @@
 import React, {Component} from 'react';
 import {format} from 'd3-format';
 
-import RadarChart from 'radar-chart';
+import RadarChart from 'react-vis/radar-chart';
 import {Hint}from 'react-vis';
 
 

--- a/packages/showcase/radar-chart/radar-chart-series-tooltips.js
+++ b/packages/showcase/radar-chart/radar-chart-series-tooltips.js
@@ -22,7 +22,7 @@ import React, {Component} from 'react';
 import {format} from 'd3-format';
 
 import RadarChart from 'radar-chart';
-import {Hint} from 'index';
+import {Hint}from 'react-vis';
 
 
 const DATA = [

--- a/packages/showcase/radar-chart/radar-chart-with-tooltips.js
+++ b/packages/showcase/radar-chart/radar-chart-with-tooltips.js
@@ -20,7 +20,7 @@
 
 import React, {Component} from 'react';
 import RadarChart from 'radar-chart';
-import {Hint} from 'index';
+import {Hint}from 'react-vis';
 
 // The first 6 data elements here are to simulate a 'spider' type of radar chart -
 // similar to CircularGridLines, but straight edges instead.

--- a/packages/showcase/radar-chart/radar-chart-with-tooltips.js
+++ b/packages/showcase/radar-chart/radar-chart-with-tooltips.js
@@ -19,7 +19,7 @@
 // THE SOFTWARE.
 
 import React, {Component} from 'react';
-import RadarChart from 'radar-chart';
+import RadarChart from 'react-vis/radar-chart';
 import {Hint}from 'react-vis';
 
 // The first 6 data elements here are to simulate a 'spider' type of radar chart -

--- a/packages/showcase/radial-chart/arc-series-example.js
+++ b/packages/showcase/radial-chart/arc-series-example.js
@@ -23,7 +23,7 @@ import React from 'react';
 import ShowcaseButton from '../showcase-components/showcase-button';
 import {XYPlot, ArcSeries, XAxis, YAxis}from 'react-vis';
 
-import {EXTENDED_DISCRETE_COLOR_RANGE as COLORS} from 'theme';
+import {EXTENDED_DISCRETE_COLOR_RANGE as COLORS} from 'react-vis/theme';
 
 const PI = Math.PI;
 

--- a/packages/showcase/radial-chart/arc-series-example.js
+++ b/packages/showcase/radial-chart/arc-series-example.js
@@ -21,7 +21,7 @@
 import React from 'react';
 
 import ShowcaseButton from '../showcase-components/showcase-button';
-import {XYPlot, ArcSeries, XAxis, YAxis} from 'index';
+import {XYPlot, ArcSeries, XAxis, YAxis}from 'react-vis';
 
 import {EXTENDED_DISCRETE_COLOR_RANGE as COLORS} from 'theme';
 

--- a/packages/showcase/radial-chart/custom-radius-radial-chart.js
+++ b/packages/showcase/radial-chart/custom-radius-radial-chart.js
@@ -20,7 +20,7 @@
 
 import React, {Component} from 'react';
 
-import {CircularGridLines, RadialChart} from 'index';
+import {CircularGridLines, RadialChart}from 'react-vis';
 
 const DATA = [
   {

--- a/packages/showcase/radial-chart/donut-chart.js
+++ b/packages/showcase/radial-chart/donut-chart.js
@@ -20,7 +20,7 @@
 
 import React, {Component} from 'react';
 
-import {RadialChart, Hint} from 'index';
+import {RadialChart, Hint}from 'react-vis';
 
 export default class SimpleRadialChart extends Component {
   state = {

--- a/packages/showcase/radial-chart/gradient-pie.js
+++ b/packages/showcase/radial-chart/gradient-pie.js
@@ -20,7 +20,7 @@
 
 import React from 'react';
 
-import {GradientDefs, RadialChart} from 'index';
+import {GradientDefs, RadialChart}from 'react-vis';
 
 export default function GradientPie(props) {
   return (

--- a/packages/showcase/radial-chart/simple-radial-chart.js
+++ b/packages/showcase/radial-chart/simple-radial-chart.js
@@ -20,7 +20,7 @@
 
 import React from 'react';
 
-import RadialChart from 'radial-chart';
+import RadialChart from 'react-vis/radial-chart';
 
 export default function SimpleRadialChart(props) {
   return (

--- a/packages/showcase/sankey/basic.js
+++ b/packages/showcase/sankey/basic.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import Sankey from 'sankey';
+import Sankey from 'react-vis/sankey';
 
 const nodes = [{name: 'a', rotation: 0}, {name: 'b'}, {name: 'c'}];
 const links = [

--- a/packages/showcase/sankey/energy-sankey.js
+++ b/packages/showcase/sankey/energy-sankey.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import Sankey from 'sankey';
+import Sankey from 'react-vis/sankey';
 
 import Energy from '../datasets/energy.json';
 import ShowcaseButton from '../showcase-components/showcase-button';

--- a/packages/showcase/sankey/link-event.js
+++ b/packages/showcase/sankey/link-event.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import Sankey from 'sankey';
+import Sankey from 'react-vis/sankey';
 
 const BLURRED_LINK_OPACITY = 0.3;
 const FOCUSED_LINK_OPACITY = 0.6;

--- a/packages/showcase/sankey/link-hint.js
+++ b/packages/showcase/sankey/link-hint.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import Sankey from 'sankey';
-import Hint from 'plot/hint';
+import Sankey from 'react-vis/sankey';
+import Hint from 'react-vis/plot/hint';
 
 const BLURRED_LINK_OPACITY = 0.3;
 const FOCUSED_LINK_OPACITY = 0.6;

--- a/packages/showcase/sankey/voronoi.js
+++ b/packages/showcase/sankey/voronoi.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import Sankey from 'sankey';
+import Sankey from 'react-vis/sankey';
 
 const BLURRED_NODE_OPACITY = 0.8;
 const FOCUSED_NODE_OPACITY = 1;

--- a/packages/showcase/sunbursts/animated-sunburst.js
+++ b/packages/showcase/sunbursts/animated-sunburst.js
@@ -20,7 +20,7 @@
 
 import React from 'react';
 
-import {Sunburst} from 'index';
+import {Sunburst}from 'react-vis';
 import ShowcaseButton from '../showcase-components/showcase-button';
 
 function randomLeaf() {

--- a/packages/showcase/sunbursts/basic-sunburst.js
+++ b/packages/showcase/sunbursts/basic-sunburst.js
@@ -22,7 +22,7 @@ import React from 'react';
 
 import Sunburst from 'sunburst';
 import {EXTENDED_DISCRETE_COLOR_RANGE} from 'theme';
-import {LabelSeries} from 'index';
+import {LabelSeries}from 'react-vis';
 
 import D3FlareData from '../datasets/d3-flare-example.json';
 

--- a/packages/showcase/sunbursts/basic-sunburst.js
+++ b/packages/showcase/sunbursts/basic-sunburst.js
@@ -20,8 +20,8 @@
 
 import React from 'react';
 
-import Sunburst from 'sunburst';
-import {EXTENDED_DISCRETE_COLOR_RANGE} from 'theme';
+import Sunburst from 'react-vis/sunburst';
+import {EXTENDED_DISCRETE_COLOR_RANGE} from 'react-vis/theme';
 import {LabelSeries}from 'react-vis';
 
 import D3FlareData from '../datasets/d3-flare-example.json';

--- a/packages/showcase/sunbursts/clock-example.js
+++ b/packages/showcase/sunbursts/clock-example.js
@@ -22,7 +22,7 @@ import React from 'react';
 
 import {XYPlot, ArcSeries}from 'react-vis';
 
-import {EXTENDED_DISCRETE_COLOR_RANGE} from 'theme';
+import {EXTENDED_DISCRETE_COLOR_RANGE} from 'react-vis/theme';
 
 const PI = Math.PI;
 

--- a/packages/showcase/sunbursts/clock-example.js
+++ b/packages/showcase/sunbursts/clock-example.js
@@ -20,7 +20,7 @@
 
 import React from 'react';
 
-import {XYPlot, ArcSeries} from 'index';
+import {XYPlot, ArcSeries}from 'react-vis';
 
 import {EXTENDED_DISCRETE_COLOR_RANGE} from 'theme';
 

--- a/packages/showcase/sunbursts/sunburst-with-tooltips.js
+++ b/packages/showcase/sunbursts/sunburst-with-tooltips.js
@@ -22,7 +22,7 @@ import React from 'react';
 
 import {Hint, Sunburst}from 'react-vis';
 
-import {EXTENDED_DISCRETE_COLOR_RANGE as COLORS} from 'theme';
+import {EXTENDED_DISCRETE_COLOR_RANGE as COLORS} from 'react-vis/theme';
 
 const DATA = {
   children: [

--- a/packages/showcase/sunbursts/sunburst-with-tooltips.js
+++ b/packages/showcase/sunbursts/sunburst-with-tooltips.js
@@ -20,7 +20,7 @@
 
 import React from 'react';
 
-import {Hint, Sunburst} from 'index';
+import {Hint, Sunburst}from 'react-vis';
 
 import {EXTENDED_DISCRETE_COLOR_RANGE as COLORS} from 'theme';
 

--- a/packages/showcase/treemap/dynamic-treemap.js
+++ b/packages/showcase/treemap/dynamic-treemap.js
@@ -20,7 +20,7 @@
 
 import React from 'react';
 
-import Treemap from 'treemap';
+import Treemap from 'react-vis/treemap';
 import ShowcaseButton from '../showcase-components/showcase-button';
 
 function _getRandomData(total) {

--- a/packages/showcase/treemap/simple-treemap.js
+++ b/packages/showcase/treemap/simple-treemap.js
@@ -20,7 +20,7 @@
 
 import React from 'react';
 
-import Treemap from 'treemap';
+import Treemap from 'react-vis/treemap';
 
 import D3FlareData from '../datasets/d3-flare-example.json';
 import ShowcaseButton from '../showcase-components/showcase-button';


### PR DESCRIPTION
Showcase was using 'index' when importing 'react-vis';
This causes issues when trying to migrate to babel 7.