### PR TITLE
Migrate tests to jest runner

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -25,7 +25,8 @@
   },
   "env": {
     "es6": true,
-    "browser": true
+    "browser": true,
+    "jest": true
   },
   "rules": {
     "consistent-return": 0,

--- a/packages/react-vis/jest.config.js
+++ b/packages/react-vis/jest.config.js
@@ -1,0 +1,10 @@
+/*eslint-env node*/
+const path = require('path');
+
+module.exports = {
+  testMatch: ['**/?(*-)+(test|tests).[tj]s?(x)'],
+  transform: {
+    '^.+\\.js$': path.resolve(__dirname, './jestBabelTransform.js')
+  },
+  setupFilesAfterEnv: ['./jest.setup.js']
+};

--- a/packages/react-vis/jest.setup.js
+++ b/packages/react-vis/jest.setup.js
@@ -1,0 +1,18 @@
+/*eslint-env node*/
+import jsdom from 'jsdom';
+import Enzyme from 'enzyme';
+
+import Adapter from 'enzyme-adapter-react-16';
+Enzyme.configure({adapter: new Adapter()});
+
+global.document = jsdom.jsdom('<body></body>');
+global.window = document.defaultView;
+Object.keys(document.defaultView).forEach(function mapProperties(property) {
+  if (typeof global[property] === 'undefined') {
+    global[property] = document.defaultView[property];
+  }
+});
+
+global.navigator = {
+  userAgent: 'node.js'
+};

--- a/packages/react-vis/jestBabelTransform.js
+++ b/packages/react-vis/jestBabelTransform.js
@@ -1,0 +1,7 @@
+/*eslint-env node*/
+const babelJest = require('babel-jest');
+
+// see https://github.com/facebook/jest/issues/7359#issuecomment-471509996
+module.exports = babelJest.createTransformer({
+  rootMode: 'upward'
+});

--- a/packages/react-vis/package.json
+++ b/packages/react-vis/package.json
@@ -27,9 +27,9 @@
     "build": "yarn run clean && babel --root-mode upward src -d dist --copy-files && BABEL_ENV=es babel --root-mode upward src -d es --copy-files && node-sass src/main.scss dist/style.css --output-style compressed && yarn run build:browser",
     "lint-styles": "stylelint src/styles/*.scss --syntax scss",
     "test:windows": "babel-node --inspect ./tests/index.js",
-    "test": "node --inspect ./node_modules/.bin/babel-node --root-mode upward ./tests/index.js --only='../showcase/**/*.js,src,tests'",
+    "test": "NODE_ENV=development jest",
     "full-test": "npm run lint && npm run cover",
-    "cover": "nyc --reporter=text --reporter=html --reporter=lcov npm test",
+    "cover": "NODE_ENV=development jest --coverage",
     "prettier": "prettier --write $(git ls-files | grep '.js$')"
   },
   "dependencies": {
@@ -63,15 +63,16 @@
     "@babel/preset-react": "^7.0.0",
     "@babel/register": "^7.0.0",
     "babel-eslint": "^10.1.0",
+    "babel-jest":"^25.5.1",
     "babel-plugin-module-resolver": "^4.0.0",
     "babelify": "^10.0.0",
     "browserify": "^14.3.0",
     "canvas-prebuilt": "^1.6.11",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.2",
+    "jest":"^25.5.4",
     "jsdom": "^9.9.1",
     "node-sass": "^4.9.3",
-    "nyc": "^13.0.1",
     "prettier": "^1.14.2",
     "react": "^16.0.0",
     "react-addons-test-utils": ">=15.4.2",
@@ -80,7 +81,6 @@
     "react-vis-showcase": "^0.1.0",
     "stylelint": "^7.7.1",
     "stylelint-config-standard": "^15.0.1",
-    "tape": "^4.6.3",
     "uglify-js": "^2.8.22"
   },
   "peerDependencies": {

--- a/packages/react-vis/tests/components/animation-tests.js
+++ b/packages/react-vis/tests/components/animation-tests.js
@@ -18,7 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import test from 'tape';
 import React from 'react';
 import {mount} from 'enzyme';
 
@@ -28,7 +27,7 @@ import AxisTicks from 'plot/axis/axis-ticks';
 import VerticalBarSeries from 'plot/series/vertical-bar-series';
 import XYPlot from 'plot/xy-plot';
 
-test('Animation interpolates xDomain when specified', t => {
+test('Animation interpolates xDomain when specified', () => {
   const wrapper = mount(
     <XYPlot width={300} height={300}>
       <VerticalBarSeries data={[{x: 1, y: 0}]} />
@@ -42,11 +41,7 @@ test('Animation interpolates xDomain when specified', t => {
 
   const renderedAnimationWrapper = wrapper.find(Animation);
 
-  t.deepEqual(
-    renderedAnimationWrapper.find(AxisTicks).prop('xDomain'),
-    ['Black'],
-    'Axis interpolates props and passes to Animation'
-  );
-
-  t.end();
+  expect(renderedAnimationWrapper.find(AxisTicks).prop('xDomain')).toEqual([
+    'Black'
+  ]);
 });

--- a/packages/react-vis/tests/components/arc-series-tests.js
+++ b/packages/react-vis/tests/components/arc-series-tests.js
@@ -1,4 +1,3 @@
-import test from 'tape';
 import React from 'react';
 import {mount} from 'enzyme';
 import ArcSeries from 'plot/series/arc-series';
@@ -7,24 +6,10 @@ import ArcSeriesExample from '../../../showcase/radial-chart/arc-series-example'
 
 testRenderWithProps(ArcSeries, GENERIC_XYPLOT_SERIES_PROPS);
 
-test('ArcSeries: Showcase Example - ArcSeriesExample', t => {
+test('ArcSeries: Showcase Example - ArcSeriesExample', () => {
   const $ = mount(<ArcSeriesExample />);
-  t.equal(
-    $.text(),
-    'UPDATE-4-2024-4-2024',
-    'should find the right text content'
-  );
+  expect($.text()).toBe('UPDATE-4-2024-4-2024');
   // multiplied by two to account for shadow listeners
-  t.equal(
-    $.find('.rv-xy-plot__series--arc').length,
-    4,
-    'should find the right number of series'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series--arc path').length,
-    2 * 8,
-    'with the right number of arc in them'
-  );
-
-  t.end();
+  expect($.find('.rv-xy-plot__series--arc').length).toBe(4);
+  expect($.find('.rv-xy-plot__series--arc path').length).toBe(2 * 8);
 });

--- a/packages/react-vis/tests/components/area-series-tests.js
+++ b/packages/react-vis/tests/components/area-series-tests.js
@@ -1,4 +1,3 @@
-import test from 'tape';
 import React from 'react';
 import {mount} from 'enzyme';
 
@@ -20,88 +19,33 @@ const AREA_PROPS = {
   ]
 };
 
-test('AreaSeries: basic rendering', t => {
+test('AreaSeries: basic rendering', () => {
   const $ = mount(
     <XYPlot width={300} height={300}>
       <AreaSeries {...AREA_PROPS} />
     </XYPlot>
   );
-  t.equal(
-    $.find('.rv-xy-plot__series').length,
-    1,
-    'should find the right number of series'
-  );
-  t.equal(
-    $.find('path.rv-xy-plot__series').length,
-    1,
-    'should find the right number of series'
-  );
-  t.equal(
-    $.find('path.area-chart-example').length,
-    1,
-    'should find the right number of custom named series'
-  );
+  expect($.find('.rv-xy-plot__series').length).toBe(1);
+  expect($.find('path.rv-xy-plot__series').length).toBe(1);
+  expect($.find('path.area-chart-example').length).toBe(1);
 
   $.setProps({children: <AreaSeries {...{...AREA_PROPS, data: null}} />});
-  t.equal(
-    $.find('.rv-xy-plot__series').length,
-    0,
-    'should find the right number of series'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series path').length,
-    0,
-    'should find the right number of series'
-  );
-  t.equal(
-    $.find('.area-chart-example').length,
-    0,
-    'should find the right number of custom named series'
-  );
-  t.end();
+  expect($.find('.rv-xy-plot__series').length).toBe(0);
+  expect($.find('.rv-xy-plot__series path').length).toBe(0);
+  expect($.find('.area-chart-example').length).toBe(0);
 });
 
-test('AreaSeries: Showcase Example - AreaChart', t => {
+test('AreaSeries: Showcase Example - AreaChart', () => {
   const $ = mount(<AreaChart />);
-  t.equal(
-    $.find('.rv-xy-plot__series').length,
-    1,
-    'should find the right number of series'
-  );
-  t.equal(
-    $.find('path.rv-xy-plot__series').length,
-    1,
-    'should find the right number of series'
-  );
-  t.equal(
-    $.find('path.area-series-example').length,
-    1,
-    'should find the right number of custom named series'
-  );
-  t.end();
+  expect($.find('.rv-xy-plot__series').length).toBe(1);
+  expect($.find('path.rv-xy-plot__series').length).toBe(1);
+  expect($.find('path.area-series-example').length).toBe(1);
 });
 
-test('AreaSeries: Showcase Example - AreaChartElevated', t => {
+test('AreaSeries: Showcase Example - AreaChartElevated', () => {
   const $ = mount(<AreaChartElevated />);
-  t.equal(
-    $.find('.rv-xy-plot__series').length,
-    5,
-    'should find the right number of series'
-  );
-  t.equal(
-    $.find('path.rv-xy-plot__series').length,
-    3,
-    'should find the right number of pathes'
-  );
-  t.equal(
-    $.find('path.area-elevated-series-1').length,
-    1,
-    'should find the first custom component correctly'
-  );
-  t.equal(
-    $.find('path.area-elevated-series-2').length,
-    1,
-    'should find the second custom component correctly'
-  );
-  t.end();
+  expect($.find('.rv-xy-plot__series').length).toBe(5);
+  expect($.find('path.rv-xy-plot__series').length).toBe(3);
+  expect($.find('path.area-elevated-series-1').length).toBe(1);
+  expect($.find('path.area-elevated-series-2').length).toBe(1);
 });

--- a/packages/react-vis/tests/components/axes-tests.js
+++ b/packages/react-vis/tests/components/axes-tests.js
@@ -1,4 +1,3 @@
-import test from 'tape';
 import React from 'react';
 import {mount} from 'enzyme';
 
@@ -9,91 +8,45 @@ import CustomAxesOrientation from '../../../showcase/axes/custom-axes-orientatio
 import AxisWithTurnedLabels from '../../../showcase/plot/axis-with-turned-labels';
 import AxisOn0 from '../../../showcase/axes/axis-on-0';
 
-test('Axis: Showcase Example - CustomAxesOrientation', t => {
+test('Axis: Showcase Example - CustomAxesOrientation', () => {
   const $ = mount(<CustomAxesOrientation />);
-  t.equal(
-    $.text(),
-    '1.01.52.02.53.03.54.0X Axis246810Y Axis',
-    'should find appropriate text'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series--line').length,
-    2,
-    'should find the right number of lines'
-  );
-  t.equal(
-    $.find('line').length,
-    26,
-    'should find the right number of grid lines'
-  );
-  t.end();
+  expect($.text()).toBe('1.01.52.02.53.03.54.0X Axis246810Y Axis');
+  expect($.find('.rv-xy-plot__series--line').length).toBe(2);
+  expect($.find('line').length).toBe(26);
 });
 
-test('Axis: Showcase Example - Custom axis', t => {
+test('Axis: Showcase Example - Custom axis', () => {
   const $ = mount(<CustomAxis />);
-  t.equal($.text(), '1.01.52.03.0X', 'should find appropriate text');
-  t.equal(
-    $.find('.rv-xy-plot__series--line').length,
-    1,
-    'should find the right number of lines'
-  );
-  t.equal(
-    $.find('line').length,
-    15,
-    'should find the right number of grid lines'
-  );
+  expect($.text()).toBe('1.01.52.03.0X');
+  expect($.find('.rv-xy-plot__series--line').length).toBe(1);
+  expect($.find('line').length).toBe(15);
 
   const titleStyle = $.find('.rv-xy-plot__axis__title text').prop('style');
-  t.equal(titleStyle.fontSize, '16px', 'Styling: should honor title fontSize');
-  t.end();
+  expect(titleStyle.fontSize).toBe('16px');
 });
 
-test('Axis: Showcase Example - Even more Custom axes', t => {
+test('Axis: Showcase Example - Even more Custom axes', () => {
   const $ = mount(<CustomAxes />);
-  t.equal(
-    $.text(),
-    '01345XValue is 0Value is 1Value is 2Value is 3Value is 4Value is 501491625cooldogskateboardwowsuchMultilinedogs',
-    'should find appropriate text'
+  expect($.text()).toBe(
+    '01345XValue is 0Value is 1Value is 2Value is 3Value is 4Value is 501491625cooldogskateboardwowsuchMultilinedogs'
   );
-  t.equal(
-    $.find('line').length,
-    26,
-    'should find the right number of grid lines'
-  );
-  t.end();
+  expect($.find('line').length).toBe(26);
 });
 
-test('Axis: Showcase Example - AxisWithTurnedLabels', t => {
+test('Axis: Showcase Example - AxisWithTurnedLabels', () => {
   const $ = mount(<AxisWithTurnedLabels />);
-  t.equal(
-    $.text(),
-    'ApplesBananasCranberries02468101214',
-    'should find appropriate text'
-  );
-  t.equal($.find('rect').length, 6, 'should find the right number of lines');
-  t.equal(
-    $.find('line').length,
-    24,
-    'should find the right number of grid lines'
-  );
-  t.end();
+  expect($.text()).toBe('ApplesBananasCranberries02468101214');
+  expect($.find('rect').length).toBe(6);
+  expect($.find('line').length).toBe(24);
 });
 
-test('Axis: Showcase Example - Padded', t => {
+test('Axis: Showcase Example - Padded', () => {
   const $ = mount(<PaddedAxis />);
-  t.equal(
-    $.find('.rv-xy-plot__series--line').length,
-    4,
-    'should find the right number of lines'
-  );
-  t.ok(
-    $.find('line').length > 30,
-    'should find the right number of grid lines'
-  );
-  t.end();
+  expect($.find('.rv-xy-plot__series--line').length).toBe(4);
+  expect($.find('line').length > 30).toBeTruthy();
 });
 
-test('Axis: axis crosses on 0', t => {
+test('Axis: axis crosses on 0', () => {
   // vertical axes
   const $0 = mount(
     <AxisOn0
@@ -108,11 +61,7 @@ test('Axis: axis crosses on 0', t => {
     $0.find('.rv-xy-plot__axis.rv-xy-plot__axis--vertical')[0].attribs.transform
   )[0];
 
-  t.equal(
-    xOfGridlines0,
-    xOfAxisSetOn0,
-    'vertical axis set on 0 overlaps gridline.'
-  );
+  expect(xOfGridlines0).toBe(xOfAxisSetOn0);
 
   const $1 = mount(
     <AxisOn0
@@ -127,10 +76,7 @@ test('Axis: axis crosses on 0', t => {
     .attribs.transform.replace('translate(', '')
     .split(',')[0];
 
-  t.ok(
-    xOfGridlines0 !== xOfAxisNotSetOn0,
-    "vertical axis not set on 0 won't overlap gridline."
-  );
+  expect(xOfGridlines0 !== xOfAxisNotSetOn0).toBeTruthy();
 
   // horizontal axes
   const $2 = mount(
@@ -151,11 +97,7 @@ test('Axis: axis crosses on 0', t => {
       .transform
   )[1];
 
-  t.equal(
-    yOfAxisSetOn0,
-    yOfGridlines0,
-    'horizontal axis set on 0 overlaps gridline.'
-  );
+  expect(yOfAxisSetOn0).toBe(yOfGridlines0);
 
   const $3 = mount(
     <AxisOn0
@@ -169,12 +111,7 @@ test('Axis: axis crosses on 0', t => {
     $3.find('.rv-xy-plot__axis.rv-xy-plot__axis--horizontal')[0].attribs
       .transform
   )[1];
-  t.ok(
-    yOfAxisNotSetOn0 !== yOfGridlines0,
-    "horizontal axis not set on 0 doesn't overlap gridline."
-  );
-
-  t.end();
+  expect(yOfAxisNotSetOn0 !== yOfGridlines0).toBeTruthy();
 });
 
 function translateToXY(translate) {

--- a/packages/react-vis/tests/components/axis-tick-format-tests.js
+++ b/packages/react-vis/tests/components/axis-tick-format-tests.js
@@ -1,59 +1,48 @@
-import test from 'tape';
 import React from 'react';
 import {mount} from 'enzyme';
 
 import CustomAxisTickElement from '../../../showcase/axes/custom-axis-tick-element';
 
-test('Axis Format: correctly renders return values from tickFormat', t => {
+test('Axis Format: correctly renders return values from tickFormat', () => {
   const element = mount(<CustomAxisTickElement />);
   const ticks = element.find(
     '.rv-xy-plot__axis--horizontal .rv-xy-plot__axis__tick'
   );
-  t.deepEqual(
-    ticks.map(tick => tick.find('text').length),
-    [0, 0, 1, 0, 1],
-    'renders custom element without text node'
-  );
-  t.equal(
+  expect(ticks.map(tick => tick.find('text').length)).toEqual([0, 0, 1, 0, 1]);
+  expect(
     ticks
       .at(2)
       .find('text')
-      .find('tspan').length,
-    1,
-    'renders tspan inside text node'
-  );
-  t.equal(
+      .find('tspan').length
+  ).toBe(1);
+  expect(
     ticks
       .at(4)
       .find('text')
-      .text(),
-    'Label',
-    'renders text inside text node'
-  );
-  t.end();
+      .text()
+  ).toBe('Label');
 });
 
-test('Axis Format: passes props to custom element', t => {
+test('Axis Format: passes props to custom element', () => {
   const CustomLabel = props => {
-    t.deepEqual(
-      Object.keys(props).sort(),
-      ['containerWidth', 'dy', 'textAnchor', 'tickCount', 'transform'],
-      'custom element received correct props'
-    );
+    expect(Object.keys(props).sort()).toEqual([
+      'containerWidth',
+      'dy',
+      'textAnchor',
+      'tickCount',
+      'transform'
+    ]);
     return <text>Custom Label</text>;
   };
   const element = mount(<CustomAxisTickElement />);
   element.setState({
     data: [...element.state().data, {x: 5, y: 600, label: <CustomLabel />}]
   });
-  t.equal(
+  expect(
     element
       .find('.rv-xy-plot__axis--horizontal .rv-xy-plot__axis__tick')
       .at(5)
       .find('text')
-      .text(),
-    'Custom Label',
-    'renders custom label contents'
-  );
-  t.end();
+      .text()
+  ).toBe('Custom Label');
 });

--- a/packages/react-vis/tests/components/axis-title-tests.js
+++ b/packages/react-vis/tests/components/axis-title-tests.js
@@ -1,4 +1,3 @@
-import test from 'tape';
 import React from 'react';
 import {mount} from 'enzyme';
 import AxisTitle from 'plot/axis/axis-title';
@@ -12,76 +11,44 @@ const baseProps = {
   title: 'Title'
 };
 
-test('AxisTitle: horizontal bottom axis title', t => {
+test('AxisTitle: horizontal bottom axis title', () => {
   const props = Object.assign({}, baseProps, {
     orientation: BOTTOM
   });
   const $ = mount(<AxisTitle {...props} />);
   const innerGroupHtml = $.find('g > g').html();
-  t.ok(
-    innerGroupHtml.includes('text-anchor: end'),
-    'should have text-anchor: end'
-  );
-  t.equal(
-    $.find('text').text(),
-    baseProps.title,
-    'should render the correct title'
-  );
-  t.end();
+  expect(innerGroupHtml.includes('text-anchor: end')).toBeTruthy();
+  expect($.find('text').text()).toBe(baseProps.title);
 });
 
-test('AxisTitle: horizontal top axis title', t => {
+test('AxisTitle: horizontal top axis title', () => {
   const props = Object.assign({}, baseProps, {
     orientation: TOP,
     position: 'start'
   });
   const $ = mount(<AxisTitle {...props} />);
   const innerGroupHtml = $.find('g > g').html();
-  t.ok(
-    innerGroupHtml.includes('text-anchor: start'),
-    'should have text-anchor: start'
-  );
-  t.equal(
-    $.find('text').text(),
-    baseProps.title,
-    'should render the correct title'
-  );
-  t.end();
+  expect(innerGroupHtml.includes('text-anchor: start')).toBeTruthy();
+  expect($.find('text').text()).toBe(baseProps.title);
 });
 
-test('AxisTitle: vertical left title', t => {
+test('AxisTitle: vertical left title', () => {
   const props = Object.assign({}, baseProps, {
     orientation: LEFT
   });
   const $ = mount(<AxisTitle {...props} />);
   const innerGroupHtml = $.find('g > g').html();
-  t.ok(
-    innerGroupHtml.includes('text-anchor: end'),
-    'should have text-anchor: end'
-  );
-  t.equal(
-    $.find('text').text(),
-    baseProps.title,
-    'should render the correct title'
-  );
-  t.end();
+  expect(innerGroupHtml.includes('text-anchor: end')).toBeTruthy();
+  expect($.find('text').text()).toBe(baseProps.title);
 });
 
-test('AxisTitle: vertical right title', t => {
+test('AxisTitle: vertical right title', () => {
   const props = Object.assign({}, baseProps, {
     orientation: RIGHT,
     position: 'start'
   });
   const $ = mount(<AxisTitle {...props} />);
   const innerGroupHtml = $.find('g > g').html();
-  t.ok(
-    innerGroupHtml.includes('text-anchor: start'),
-    'should have text-anchor: start'
-  );
-  t.equal(
-    $.find('text').text(),
-    baseProps.title,
-    'should render the correct title'
-  );
-  t.end();
+  expect(innerGroupHtml.includes('text-anchor: start')).toBeTruthy();
+  expect($.find('text').text()).toBe(baseProps.title);
 });

--- a/packages/react-vis/tests/components/bar-series-tests.js
+++ b/packages/react-vis/tests/components/bar-series-tests.js
@@ -1,4 +1,3 @@
-import test from 'tape';
 import React from 'react';
 import {mount} from 'enzyme';
 import XYPlot from 'plot/xy-plot';
@@ -15,48 +14,18 @@ import DifferenceChart from '../../../showcase/plot/difference-chart';
 testRenderWithProps(HorizontalBarSeries, GENERIC_XYPLOT_SERIES_PROPS);
 testRenderWithProps(VerticalBarSeries, GENERIC_XYPLOT_SERIES_PROPS);
 
-test('BarSeries: Showcase Example - BarChart', t => {
+test('BarSeries: Showcase Example - BarChart', () => {
   const $ = mount(<BarChart />);
-  t.equal(
-    $.text(),
-    'TOGGLE TO CANVASABC02468101214ABC',
-    'should fine the right text content'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series--bar rect').length,
-    6,
-    'should find the right number of bars'
-  );
-  t.equal(
-    $.find('g.vertical-bar-series-example').length,
-    1,
-    'should find the right number of custom named series'
-  );
+  expect($.text()).toBe('TOGGLE TO CANVASABC02468101214ABC');
+  expect($.find('.rv-xy-plot__series--bar rect').length).toBe(6);
+  expect($.find('g.vertical-bar-series-example').length).toBe(1);
 
   $.find('.showcase-button').simulate('click');
-  t.equal(
-    $.find('rect.rv-xy-plot__series--bar').length,
-    0,
-    'should now find no rects'
-  );
-  t.equal(
-    $.find('.rv-xy-canvas canvas').length,
-    1,
-    'should now find one canvas'
-  );
-
-  // TODO CONFIGURE BETTER TESTING SYSTEM FOR CANVAS
-  // const canvas = $.find('.rv-xy-canvas canvas');
-  // t.equal(
-  //   canvas && canvas.node.toDataURL(),
-  //   'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAPoAAAD6CAYAAACI7Fo9AAAABmJLR0QA/wD/AP+gvaeTAAAEa0lEQVR4nO3cwYpWZQDH4fd8jjppTeJCpExoU0HrFOoS2rePoCBw0a5uwNoLgQTRTbTpBgy8i1JoVYsIQ3PeNk1CzJQYfcfp9zzbd/Pf/M55N+csA46R8zdufjnG8u7aOx6Zd3+89sGltVf8k83aA4D/ntAhQOgQIHQIEDoECB0ChA4BQocAoUOA0CFA6BAgdAgQOgQIHQKEDgFChwChQ4DQIUDoECB0CBA6BAgdAoQOAUKHAKFDgNAhQOgQIHQIEDoECB0ChA4BQocAoUOA0CFA6BAgdAgQOgQIHQKEDgFChwChQ4DQIUDoECB0CBA6BAgdAoQOAUKHgJ21BzyOj7/97sPNXC6sveNPm+X29auXvl57BjyuYxH6MjefzDEvrb3jwNwfX40xhM6x4eoOAUKHAKFDgNAhQOgQIHQIEDoECB0ChA4BQocAoUOA0CFA6BAgdAgQOgQci+/R4Wn0/Okz4+1Xrl587tad79fe8off5v7+O5+9dfn2Xw+EDk9os9mM3ZMnN+Op+SnK8vPYLGcPO3F1h39hzrn2hEeW+fCoI6FDgNAhQOgQIHQIEDoECB0ChA4BQocAoUOA0CFA6BAgdAgQOgQc+pnqCzdvnvn1wfLytsccZX8+PLlZPJPgSR0a+v37mytzzG+WMe5te9Bh7j24v3f21O7aM+DYOvLHE8tYfhljntvmmKPMMeYYY1l7BxxX7sMQIHQIEDoECB0ChA4BQocAoUOA0CFA6BAgdAgQOgQIHQKEDgFChwChQ4DQIUDoECB0CBA6BAgdAoQOAUKHAKFDgNAhQOgQIHQIEDoECB0ChA4BQocAoUOA0CFA6BAgdAgQOgQIHQKEDgFChwChQ4DQIUDoECB0CBA6BAgdAoQOAUKHAKFDgNAhQOgQIHQIEDoECB0ChA4BQocAoUOA0CFA6BAgdAgQOgQIHQKEDgFChwChQ4DQIUDoECB0CBA6BAgdAoQOAUKHAKFDgNAhQOgQIHQIEDoECB0ChA4BQocAoUOA0CFA6BCws/aAgvM3vrg9xry49o4Dc4xPf7r2/udr72B7hL4Fy5ivzTGeXXvHgWXMC2tvYLtc3SFA6BAgdAgQOgQIHQKEDgFChwChQ4DQIUDoECB0CBA6BAgdAoQOAUKHAKFDgNAhQOgQIHQIEDoECB0ChA4BQocAoUOA0CFA6BAgdAgQOgQIHQKEDgFChwChQ4DQIUDoECB0CBA6BAgdAoQOAUKHAKFDgNAhQOgQIHQIEDoECB0ChA4BQocAoUPAztoD2K7XL1weV1589aNTt+68t/aWMcZY5vzh+psvvbH2jv87occ8s3N6nDqxszfG3Ft7yxhjjGWcW3tCgas7BAgdAoQOAUKHAKFDgNAhQOgQIHQIEDoECB0ChA4BQocAoUOA0CFA6BAgdAgQOgQIHQKEDgFChwChQ4DQIUDoECB0CBA6BAgdAoQOAUKHAKFDgNAhQOgQcGToy5i72xzyd5ZlWXsCHOrE5il6V85xZLO/A/PwTf3wSEVKAAAAAElFTkSuQmCC',
-  //   'should get the correct serialized image'
-  // );
-
-  t.end();
+  expect($.find('rect.rv-xy-plot__series--bar').length).toBe(0);
+  expect($.find('.rv-xy-canvas canvas').length).toBe(1);
 });
 
-test('BarSeries: Showcase Example - StackedHorizontalBarChart & StackedVerticalBarChart', t => {
+test('BarSeries: Showcase Example - StackedHorizontalBarChart & StackedVerticalBarChart', () => {
   [StackedHorizontalBarChart, StackedVerticalBarChart].forEach(
     (Component, i) => {
       const $ = mount(<Component />);
@@ -65,29 +34,16 @@ test('BarSeries: Showcase Example - StackedHorizontalBarChart & StackedVerticalB
         ? textContent.reverse()
         : textContent
       ).join('')}`;
-      t.equal($.text(), expectedContent, 'should fine the right text content');
-      t.equal(
-        $.find('.rv-xy-plot__series--bar rect').length,
-        6,
-        'should find the right number of bars'
-      );
+      expect($.text()).toBe(expectedContent);
+      expect($.find('.rv-xy-plot__series--bar rect').length).toBe(6);
       $.find('.showcase-button').simulate('click');
-      t.equal(
-        $.find('.rv-xy-plot__series--bar rect').length,
-        0,
-        'should now find no rects'
-      );
-      t.equal(
-        $.find('.rv-xy-canvas canvas').length,
-        1,
-        'should now find one canvas'
-      );
+      expect($.find('.rv-xy-plot__series--bar rect').length).toBe(0);
+      expect($.find('.rv-xy-canvas canvas').length).toBe(1);
     }
   );
-  t.end();
 });
 
-test('BarSeries: Ordinal Y-Axis HorizontalBarSeries', t => {
+test('BarSeries: Ordinal Y-Axis HorizontalBarSeries', () => {
   const $ = mount(
     <XYPlot width={300} height={300} yType="ordinal">
       <HorizontalBarSeries
@@ -99,127 +55,54 @@ test('BarSeries: Ordinal Y-Axis HorizontalBarSeries', t => {
       />
     </XYPlot>
   );
-  t.equal(
-    $.find('.rv-xy-plot__series--bar rect').length,
-    3,
-    'should find the right number of bars'
-  );
-  t.equal(
+  expect($.find('.rv-xy-plot__series--bar rect').length).toBe(3);
+  expect(
     $.find('.rv-xy-plot__series--bar rect')
       .at(0)
-      .prop('height') > 0,
-    true,
-    'should not have negative bar height'
-  );
-  t.end();
+      .prop('height') > 0
+  ).toBe(true);
 });
 
-test('BarSeries: No data', t => {
+test('BarSeries: No data', () => {
   const $ = mount(
     <XYPlot width={300} height={300} yType="ordinal">
       <HorizontalBarSeries data={null} />
     </XYPlot>
   );
-  t.equal(
-    $.find('.rv-xy-plot__series--bar rect').length,
-    0,
-    'should find the right number of bars'
-  );
-  t.end();
+  expect($.find('.rv-xy-plot__series--bar rect').length).toBe(0);
 });
 
-test('BarSeries: Showcase Example - ClusteredStackedVerticalBarChart', t => {
+test('BarSeries: Showcase Example - ClusteredStackedVerticalBarChart', () => {
   const $ = mount(<ClusteredStackedVerticalBarChart />);
-  t.equal(
-    $.text(),
-    'TOGGLE TO CANVASQ1Q2Q3Q40102030ApplesOranges',
-    'should fine the right text content'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series--bar rect').length,
-    16,
-    'should find the right number of bars'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series').length,
-    4,
-    'should find the right number of series'
-  );
+  expect($.text()).toBe('TOGGLE TO CANVASQ1Q2Q3Q40102030ApplesOranges');
+  expect($.find('.rv-xy-plot__series--bar rect').length).toBe(16);
+  expect($.find('.rv-xy-plot__series').length).toBe(4);
 
   $.find('.showcase-button').simulate('click');
-  t.equal(
-    $.find('.rv-xy-plot__series--bar rect').length,
-    0,
-    'should now find no rects'
-  );
-  t.equal(
-    $.find('.rv-xy-canvas canvas').length,
-    1,
-    'should now find one canvas'
-  );
-  t.end();
+  expect($.find('.rv-xy-plot__series--bar rect').length).toBe(0);
+  expect($.find('.rv-xy-canvas canvas').length).toBe(1);
 });
 
-test('BarSeries: Showcase Example - BigBaseBarChart', t => {
+test('BarSeries: Showcase Example - BigBaseBarChart', () => {
   const $ = mount(<BigBaseBarChart />);
-  t.equal(
-    $.text(),
-    'TOGGLE TO CANVAS:38:39:40:41199,800199,900200,000200,100200,200200,300200,400',
-    'should fine the right text content'
+  expect($.text()).toBe(
+    'TOGGLE TO CANVAS:38:39:40:41199,800199,900200,000200,100200,200200,300200,400'
   );
-  t.equal(
-    $.find('.rv-xy-plot__series--bar rect').length,
-    15,
-    'should find the right number of bars'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series').length,
-    1,
-    'should find the right number of series'
-  );
+  expect($.find('.rv-xy-plot__series--bar rect').length).toBe(15);
+  expect($.find('.rv-xy-plot__series').length).toBe(1);
 
   $.find('.showcase-button').simulate('click');
-  t.equal(
-    $.find('.rv-xy-plot__series--bar rect').length,
-    0,
-    'should now find no rects'
-  );
-  t.equal(
-    $.find('.rv-xy-canvas canvas').length,
-    1,
-    'should now find one canvas'
-  );
-  t.end();
+  expect($.find('.rv-xy-plot__series--bar rect').length).toBe(0);
+  expect($.find('.rv-xy-canvas canvas').length).toBe(1);
 });
 
-test('BarSeries: Showcase Example - DifferenceChart', t => {
+test('BarSeries: Showcase Example - DifferenceChart', () => {
   const $ = mount(<DifferenceChart />);
-  t.equal(
-    $.text(),
-    'TOGGLE TO CANVAS02468101214-4-20246810',
-    'should fine the right text content'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series--bar rect').length,
-    15,
-    'should find the right number of bars'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series').length,
-    1,
-    'should find the right number of series'
-  );
+  expect($.text()).toBe('TOGGLE TO CANVAS02468101214-4-20246810');
+  expect($.find('.rv-xy-plot__series--bar rect').length).toBe(15);
+  expect($.find('.rv-xy-plot__series').length).toBe(1);
 
   $.find('.showcase-button').simulate('click');
-  t.equal(
-    $.find('.rv-xy-plot__series--bar rect').length,
-    0,
-    'should now find no rects'
-  );
-  t.equal(
-    $.find('.rv-xy-canvas canvas').length,
-    1,
-    'should now find one canvas'
-  );
-  t.end();
+  expect($.find('.rv-xy-plot__series--bar rect').length).toBe(0);
+  expect($.find('.rv-xy-canvas canvas').length).toBe(1);
 });

--- a/packages/react-vis/tests/components/borders-tests.js
+++ b/packages/react-vis/tests/components/borders-tests.js
@@ -1,4 +1,3 @@
-import test from 'tape';
 import React from 'react';
 import {mount} from 'enzyme';
 import Borders from 'plot/borders';
@@ -7,17 +6,8 @@ import GradientExample from '../../../showcase/misc/gradient-example';
 
 testRenderWithProps(Borders, GENERIC_XYPLOT_SERIES_PROPS);
 
-test('Borders: GradientExample', t => {
+test('Borders: GradientExample', () => {
   const $ = mount(<GradientExample />);
-  t.equal(
-    $.find('.rv-xy-plot__borders').length,
-    1,
-    'should find the right number of borders containers'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__borders rect').length,
-    4,
-    'should find the right number of borders'
-  );
-  t.end();
+  expect($.find('.rv-xy-plot__borders').length).toBe(1);
+  expect($.find('.rv-xy-plot__borders rect').length).toBe(4);
 });

--- a/packages/react-vis/tests/components/circular-grid-lines-tests.js
+++ b/packages/react-vis/tests/components/circular-grid-lines-tests.js
@@ -1,4 +1,3 @@
-import test from 'tape';
 import React from 'react';
 import {mount} from 'enzyme';
 import CircularGridLines from 'plot/circular-grid-lines';
@@ -7,17 +6,8 @@ import FauxRadialScatterplot from '../../../showcase/plot/faux-radial-scatterplo
 
 testRenderWithProps(CircularGridLines, GENERIC_XYPLOT_SERIES_PROPS);
 
-test('CircularGridLines: Showcase Example - FauxRadialScatterplot', t => {
+test('CircularGridLines: Showcase Example - FauxRadialScatterplot', () => {
   const $ = mount(<FauxRadialScatterplot />);
-  t.equal(
-    $.text(),
-    '-3-2-10123-3-2-10123',
-    'should find the right text content'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__circular-grid-lines__line').length,
-    7,
-    'should find the right number of circles'
-  );
-  t.end();
+  expect($.text()).toBe('-3-2-10123-3-2-10123');
+  expect($.find('.rv-xy-plot__circular-grid-lines__line').length).toBe(7);
 });

--- a/packages/react-vis/tests/components/color-article-tests.js
+++ b/packages/react-vis/tests/components/color-article-tests.js
@@ -1,4 +1,3 @@
-import test from 'tape';
 import React from 'react';
 import {mount} from 'enzyme';
 
@@ -23,7 +22,7 @@ import {
   CustomPalette
 } from '../../../showcase/color/mini-color-examples';
 
-test('Color Article Test: #generateCharts', t => {
+test('Color Article Test: #generateCharts', () => {
   [
     {name: 'SensibleDefaults', Item: SensibleDefaults},
     {name: 'ColorInXYPlot', Item: ColorInXYPlot},
@@ -46,87 +45,34 @@ test('Color Article Test: #generateCharts', t => {
     },
     {name: 'LinearColorAtMarkLevel', Item: LinearColorAtMarkLevel}
   ].forEach(obj => {
-    const {name, Item} = obj;
+    const {Item} = obj;
     const $ = mount(<Item />);
-    t.equal(
-      $.find('.rv-xy-plot').length,
-      3,
-      `${name} should find the right number of xy-plots`
-    );
-    t.equal(
-      $.find('.rv-xy-plot__series--bar rect').length,
-      30,
-      `${name} should find the right number of rects`
-    );
-    t.equal(
-      $.find('path.rv-xy-plot__series--line').length,
-      3,
-      `${name} should find the right number of paths`
-    );
-    t.equal(
-      $.find('.rv-xy-plot__series--mark circle').length,
-      30,
-      `${name} should find the right number of circles`
-    );
+    expect($.find('.rv-xy-plot').length).toBe(3);
+    expect($.find('.rv-xy-plot__series--bar rect').length).toBe(30);
+    expect($.find('path.rv-xy-plot__series--line').length).toBe(3);
+    expect($.find('.rv-xy-plot__series--mark circle').length).toBe(30);
   });
-  t.end();
 });
 
-test('Color Article Test: GradientCharts', t => {
+test('Color Article Test: GradientCharts', () => {
   const $ = mount(<GradientCharts />);
 
-  t.equal(
-    $.find('.rv-xy-plot').length,
-    3,
-    'should find the right number of xy-plots'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series--bar rect').length,
-    10,
-    'should find the right number of rects'
-  );
-  t.equal(
-    $.find('path.rv-xy-plot__series--line').length,
-    1,
-    'should find the right number of paths'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series--mark circle').length,
-    10,
-    'should find the right number of circles'
-  );
-
-  t.end();
+  expect($.find('.rv-xy-plot').length).toBe(3);
+  expect($.find('.rv-xy-plot__series--bar rect').length).toBe(10);
+  expect($.find('path.rv-xy-plot__series--line').length).toBe(1);
+  expect($.find('.rv-xy-plot__series--mark circle').length).toBe(10);
 });
 
-test('Color Article Test: ColorSpecificity', t => {
+test('Color Article Test: ColorSpecificity', () => {
   const $ = mount(<ColorSpecificity />);
 
-  t.equal(
-    $.find('.rv-xy-plot').length,
-    3,
-    'should find the right number of xy-plots'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series--bar rect').length,
-    10,
-    'should find the right number of rects'
-  );
-  t.equal(
-    $.find('path.rv-xy-plot__series--line').length,
-    3,
-    'should find the right number of paths'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series--mark circle').length,
-    30,
-    'should find the right number of circles'
-  );
-
-  t.end();
+  expect($.find('.rv-xy-plot').length).toBe(3);
+  expect($.find('.rv-xy-plot__series--bar rect').length).toBe(10);
+  expect($.find('path.rv-xy-plot__series--line').length).toBe(3);
+  expect($.find('.rv-xy-plot__series--mark circle').length).toBe(30);
 });
 
-test('Color Article Test: generatePalette', t => {
+test('Color Article Test: generatePalette', () => {
   [
     {
       name: 'ReactVis5',
@@ -155,35 +101,15 @@ test('Color Article Test: generatePalette', t => {
       numberOfBoxes: 20
     }
   ].forEach(obj => {
-    const {Item, expectedText, numberOfBoxes, name} = obj;
+    const {Item, expectedText, numberOfBoxes} = obj;
     const $ = mount(<Item />);
-    t.equal(
-      $.find('.color-box').length,
-      numberOfBoxes,
-      `${name} color scale: should find boxes being rendered`
-    );
-    t.equal(
-      $.text(),
-      expectedText,
-      `${name} color scale: should find the right text`
-    );
+    expect($.find('.color-box').length).toBe(numberOfBoxes);
+    expect($.text()).toBe(expectedText);
   });
-
-  t.end();
 });
 
-test('Color Article Test: LineSeriesMarkSeries', t => {
+test('Color Article Test: LineSeriesMarkSeries', () => {
   const $ = mount(<LineSeriesMarkSeries />);
-  t.equal(
-    $.find('path.rv-xy-plot__series--line').length,
-    3,
-    'should find the right number of paths'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series--mark circle').length,
-    30,
-    'should find the right number of circles'
-  );
-
-  t.end();
+  expect($.find('path.rv-xy-plot__series--line').length).toBe(3);
+  expect($.find('.rv-xy-plot__series--mark circle').length).toBe(30);
 });

--- a/packages/react-vis/tests/components/contour-series-tests.js
+++ b/packages/react-vis/tests/components/contour-series-tests.js
@@ -1,4 +1,3 @@
-import test from 'tape';
 import React from 'react';
 import {mount} from 'enzyme';
 import ContourSeries from 'plot/series/contour-series';
@@ -7,22 +6,9 @@ import ContourSeriesExample from '../../../showcase/plot/contour-series-example'
 
 testRenderWithProps(ContourSeries, GENERIC_XYPLOT_SERIES_PROPS);
 
-test('ContourSeries: Showcase Example - ContourSeriesExample', t => {
+test('ContourSeries: Showcase Example - ContourSeriesExample', () => {
   const $ = mount(<ContourSeriesExample />);
-  t.equal(
-    $.text(),
-    '4045505560657075808590951002345678UPDATE',
-    'should find the right text content'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series--contour').length,
-    1,
-    'should find the right number of contour groups'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series--contour-line').length,
-    28,
-    'with the right number of contour lines'
-  );
-  t.end();
+  expect($.text()).toBe('4045505560657075808590951002345678UPDATE');
+  expect($.find('.rv-xy-plot__series--contour').length).toBe(1);
+  expect($.find('.rv-xy-plot__series--contour-line').length).toBe(28);
 });

--- a/packages/react-vis/tests/components/crosshair-tests.js
+++ b/packages/react-vis/tests/components/crosshair-tests.js
@@ -1,18 +1,12 @@
-import test from 'tape';
 import React from 'react';
 import {mount} from 'enzyme';
 
 import DynamicCrosshair from '../../../showcase/axes/dynamic-crosshair';
 
-test('Crosshair: Dynamic Crosshair - Example', t => {
+test('Crosshair: Dynamic Crosshair - Example', () => {
   const $ = mount(<DynamicCrosshair />);
   simulateMouseMove(100);
-  t.equal(
-    $.find('.rv-crosshair').hasClass('test-class-name'),
-    true,
-    'should find the class name passed as a prop'
-  );
-  t.end();
+  expect($.find('.rv-crosshair').hasClass('test-class-name')).toBe(true);
 
   function simulateMouseMove(x) {
     $.find('.rv-xy-plot__inner').simulate('mousemove', {
@@ -21,15 +15,10 @@ test('Crosshair: Dynamic Crosshair - Example', t => {
   }
 });
 
-test('Crosshair: Dynamic Crosshair - Touch Example', t => {
+test('Crosshair: Dynamic Crosshair - Touch Example', () => {
   const $ = mount(<DynamicCrosshair />);
   simulateMouseMove(100);
-  t.equal(
-    $.find('.rv-crosshair').hasClass('test-class-name'),
-    true,
-    'should find the class name passed as a prop'
-  );
-  t.end();
+  expect($.find('.rv-crosshair').hasClass('test-class-name')).toBe(true);
 
   function simulateMouseMove(x) {
     $.find('.rv-xy-plot__inner').simulate('touchmove', {

--- a/packages/react-vis/tests/components/custom-svg-series-tests.js
+++ b/packages/react-vis/tests/components/custom-svg-series-tests.js
@@ -1,4 +1,3 @@
-import test from 'tape';
 import React from 'react';
 import {mount} from 'enzyme';
 import CustomSVGSeries from 'plot/series/custom-svg-series';
@@ -9,104 +8,39 @@ import CustomSVGRootLevelComponent from '../../../showcase/plot/custom-svg-root-
 
 testRenderWithProps(CustomSVGSeries, GENERIC_XYPLOT_SERIES_PROPS);
 
-test('CustomSVGSeries: Showcase Example - CustomSVGExample', t => {
+test('CustomSVGSeries: Showcase Example - CustomSVGExample', () => {
   const $ = mount(<CustomSVGExample />);
-  t.equal(
-    $.text(),
-    '1.01.52.02.53.068101214x: 187.5y: 200',
-    'should fine the right text content'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series--custom-svg').length,
-    5,
-    'should find the right number of gs'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series--custom-svg polygon').length,
-    0,
-    'should find the right number of polygons'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series--custom-svg circle').length,
-    2,
-    'should find the right number of circle'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series--custom-svg rect').length,
-    3,
-    'should find the right number of rects'
-  );
-  t.end();
+  expect($.text()).toBe('1.01.52.02.53.068101214x: 187.5y: 200');
+  expect($.find('.rv-xy-plot__series--custom-svg').length).toBe(5);
+  expect($.find('.rv-xy-plot__series--custom-svg polygon').length).toBe(0);
+  expect($.find('.rv-xy-plot__series--custom-svg circle').length).toBe(2);
+  expect($.find('.rv-xy-plot__series--custom-svg rect').length).toBe(3);
 });
 
-test('CustomSVGSeries: Showcase Example - CustomSVGRootLevelComponent', t => {
+test('CustomSVGSeries: Showcase Example - CustomSVGRootLevelComponent', () => {
   const $ = mount(<CustomSVGRootLevelComponent />);
-  t.equal(
-    $.text(),
-    '1.01.52.02.53.068101214x: 0y: 125x: 87.5y: 75.00000000000001x: 125y: 250x: 250y: 0x: 187.5y: 200',
-    'should fine the right text content'
+  expect($.text()).toBe(
+    '1.01.52.02.53.068101214x: 0y: 125x: 87.5y: 75.00000000000001x: 125y: 250x: 250y: 0x: 187.5y: 200'
   );
-  t.equal(
-    $.find('.rv-xy-plot__series--custom-svg').length,
-    5,
-    'should find the right number of gs'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series--custom-svg polygon').length,
-    0,
-    'should find the right number of polygons'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series--custom-svg circle').length,
-    5,
-    'should find the right number of circle'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series--custom-svg rect').length,
-    0,
-    'should find the right number of rects'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series--custom-svg text').length,
-    5,
-    'should find the right number of texts'
-  );
-  t.end();
+  expect($.find('.rv-xy-plot__series--custom-svg').length).toBe(5);
+  expect($.find('.rv-xy-plot__series--custom-svg polygon').length).toBe(0);
+  expect($.find('.rv-xy-plot__series--custom-svg circle').length).toBe(5);
+  expect($.find('.rv-xy-plot__series--custom-svg rect').length).toBe(0);
+  expect($.find('.rv-xy-plot__series--custom-svg text').length).toBe(5);
 });
 
-test('CustomSVGSeries: Showcase Example - CustomSVGAllTheMarks', t => {
+test('CustomSVGSeries: Showcase Example - CustomSVGAllTheMarks', () => {
   const textContent = 'REVERSE0123402468101214';
   const hoverText = 'star';
 
   const $ = mount(<CustomSVGAllTheMarks />);
-  t.equal($.text(), textContent, 'should fine the right text content');
+  expect($.text()).toBe(textContent);
   $.find('.rv-xy-plot__series--custom-svg')
     .at(0)
     .simulate('mouseEnter');
-  t.equal(
-    $.text(),
-    `${textContent}${hoverText}`,
-    'should fine the right text content on hover'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series--custom-svg').length,
-    20,
-    'should find the right number of gs'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series--custom-svg polygon').length,
-    10,
-    'should find the right number of polygons'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series--custom-svg circle').length,
-    5,
-    'should find the right number of circle'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series--custom-svg rect').length,
-    5,
-    'should find the right number of rects'
-  );
-  t.end();
+  expect($.text()).toBe(`${textContent}${hoverText}`);
+  expect($.find('.rv-xy-plot__series--custom-svg').length).toBe(20);
+  expect($.find('.rv-xy-plot__series--custom-svg polygon').length).toBe(10);
+  expect($.find('.rv-xy-plot__series--custom-svg circle').length).toBe(5);
+  expect($.find('.rv-xy-plot__series--custom-svg rect').length).toBe(5);
 });

--- a/packages/react-vis/tests/components/data-article-tests.js
+++ b/packages/react-vis/tests/components/data-article-tests.js
@@ -1,11 +1,9 @@
-import test from 'tape';
 import React from 'react';
 import {mount} from 'enzyme';
 
 import {MiniCharts} from '../../../showcase/data/mini-data-examples';
 
-test('Scales and data examples: MiniCharts', t => {
+test('Scales and data examples: MiniCharts', () => {
   const $ = mount(<MiniCharts />);
-  t.equal($.find('.rv-xy-plot').length, 3, '3 XYPlot in this example');
-  t.end();
+  expect($.find('.rv-xy-plot').length).toBe(3);
 });

--- a/packages/react-vis/tests/components/decorative-axis-tests.js
+++ b/packages/react-vis/tests/components/decorative-axis-tests.js
@@ -1,4 +1,3 @@
-import test from 'tape';
 import React from 'react';
 import {mount} from 'enzyme';
 import DecorativeAxis from 'plot/axis/decorative-axis';
@@ -13,52 +12,22 @@ testRenderWithProps(DecorativeAxis, {
   axisDomain: [0, 1]
 });
 
-test('DecorativeAxis: Showcase Example - DecorativeAxisCrissCross', t => {
+test('DecorativeAxis: Showcase Example - DecorativeAxisCrissCross', () => {
   const $ = mount(<DecorativeAxisCrissCross />);
-  t.equal(
-    $.text(),
-    '-101.01223344556677889100¡1000!¡990!¡980!¡970!¡960!¡950!¡940!¡930!¡920!¡910!¡900!',
-    'should find the right text content'
+  expect($.text()).toBe(
+    '-101.01223344556677889100¡1000!¡990!¡980!¡970!¡960!¡950!¡940!¡930!¡920!¡910!¡900!'
   );
-  t.equal(
-    $.find('.rv-xy-manipulable-axis').length,
-    2,
-    'should find the number of axes'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__axis__tick__line').length,
-    22,
-    'should find the number of axis ticks'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__axis__tick__text').length,
-    22,
-    'should find the number of axis tick texts'
-  );
-  t.end();
+  expect($.find('.rv-xy-manipulable-axis').length).toBe(2);
+  expect($.find('.rv-xy-plot__axis__tick__line').length).toBe(22);
+  expect($.find('.rv-xy-plot__axis__tick__text').length).toBe(22);
 });
 
-test('DecorativeAxis: Showcase Example - ParallelCoordinatesExample', t => {
+test('DecorativeAxis: Showcase Example - ParallelCoordinatesExample', () => {
   const $ = mount(<ParallelCoordinatesExample />);
-  t.equal(
-    $.text(),
-    '0.04.79.314192328333742473.03.54.04.55.05.56.06.57.07.58.0681101501802202603003403804204600.023466992120140160180210230160020002300270030003400370041004400480051008.09.71113151618202123257071727475767778808182',
-    'should find the right text content'
+  expect($.text()).toBe(
+    '0.04.79.314192328333742473.03.54.04.55.05.56.06.57.07.58.0681101501802202603003403804204600.023466992120140160180210230160020002300270030003400370041004400480051008.09.71113151618202123257071727475767778808182'
   );
-  t.equal(
-    $.find('.rv-xy-manipulable-axis').length,
-    7,
-    'should find the number of axes'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__axis__tick__line').length,
-    77,
-    'should find the number of axis ticks'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__axis__tick__text').length,
-    77,
-    'should find the number of axis tick texts'
-  );
-  t.end();
+  expect($.find('.rv-xy-manipulable-axis').length).toBe(7);
+  expect($.find('.rv-xy-plot__axis__tick__line').length).toBe(77);
+  expect($.find('.rv-xy-plot__axis__tick__text').length).toBe(77);
 });

--- a/packages/react-vis/tests/components/gradient-tests.js
+++ b/packages/react-vis/tests/components/gradient-tests.js
@@ -1,4 +1,3 @@
-import test from 'tape';
 import React from 'react';
 import {mount} from 'enzyme';
 import GradientDefs from 'plot/gradient-defs';
@@ -8,42 +7,16 @@ import GradientExample from '../../../showcase/misc/gradient-example';
 
 testRenderWithProps(GradientDefs, GENERIC_XYPLOT_SERIES_PROPS);
 
-test('GradientDefs: TriangleExample', t => {
+test('GradientDefs: TriangleExample', () => {
   const $ = mount(<TriangleExample />);
-  t.equal(
-    $.find('.rv-xy-plot__series--polygon').length,
-    121,
-    'should find the right number of polygons'
-  );
-  t.equal(
-    $.find('.rv-gradient-defs').length,
-    1,
-    'should find the right number of gradient defs'
-  );
-  t.equal(
-    $.find('#grad1').length,
-    1,
-    'should find the right number of gradients'
-  );
-  t.end();
+  expect($.find('.rv-xy-plot__series--polygon').length).toBe(121);
+  expect($.find('.rv-gradient-defs').length).toBe(1);
+  expect($.find('#grad1').length).toBe(1);
 });
 
-test('GradientDefs: GradientExample', t => {
+test('GradientDefs: GradientExample', () => {
   const $ = mount(<GradientExample />);
-  t.equal(
-    $.find('.rv-xy-plot__series--line').length,
-    2,
-    'should find the right number of polygons'
-  );
-  t.equal(
-    $.find('.rv-gradient-defs').length,
-    1,
-    'should find the right number of gradient defs'
-  );
-  t.equal(
-    $.find('#CoolGradient').length,
-    1,
-    'should find the right number of gradients'
-  );
-  t.end();
+  expect($.find('.rv-xy-plot__series--line').length).toBe(2);
+  expect($.find('.rv-gradient-defs').length).toBe(1);
+  expect($.find('#CoolGradient').length).toBe(1);
 });

--- a/packages/react-vis/tests/components/grid-lines-tests.js
+++ b/packages/react-vis/tests/components/grid-lines-tests.js
@@ -1,4 +1,3 @@
-import test from 'tape';
 import React from 'react';
 import {shallow} from 'enzyme';
 import XYPlot from 'plot/xy-plot';
@@ -6,7 +5,7 @@ import LineSeries from 'plot/series/line-series';
 import HorizontalGridLines from 'plot/horizontal-grid-lines';
 import VerticalGridLines from 'plot/vertical-grid-lines';
 
-test('GridLines: HorizontalGridLines', t => {
+test('GridLines: HorizontalGridLines', () => {
   const wrapper = shallow(
     <XYPlot width={300} height={300} stackBy="y">
       <HorizontalGridLines className="test-class-name" />
@@ -14,18 +13,15 @@ test('GridLines: HorizontalGridLines', t => {
     </XYPlot>
   );
 
-  t.equal(
+  expect(
     wrapper
       .find(HorizontalGridLines)
       .at(0)
-      .hasClass('test-class-name'),
-    true,
-    'should find className passed as prop'
-  );
-  t.end();
+      .hasClass('test-class-name')
+  ).toBe(true);
 });
 
-test('GridLines: VerticalGridLines', t => {
+test('GridLines: VerticalGridLines', () => {
   const wrapper = shallow(
     <XYPlot width={300} height={300} stackBy="y">
       <VerticalGridLines className="test-class-name" />
@@ -33,13 +29,10 @@ test('GridLines: VerticalGridLines', t => {
     </XYPlot>
   );
 
-  t.equal(
+  expect(
     wrapper
       .find(VerticalGridLines)
       .at(0)
-      .hasClass('test-class-name'),
-    true,
-    'should find className passed as prop'
-  );
-  t.end();
+      .hasClass('test-class-name')
+  ).toBe(true);
 });

--- a/packages/react-vis/tests/components/heatmap-tests.js
+++ b/packages/react-vis/tests/components/heatmap-tests.js
@@ -1,4 +1,3 @@
-import test from 'tape';
 import React from 'react';
 import {mount} from 'enzyme';
 import XYPlot from 'plot/xy-plot';
@@ -27,98 +26,37 @@ const HEATMAP_PROPS = {
 
 testRenderWithProps(HeatmapSeries, GENERIC_XYPLOT_SERIES_PROPS);
 
-test('Heatmap: basic rendering', t => {
+test('Heatmap: basic rendering', () => {
   const $ = mount(
     <XYPlot width={300} height={300}>
       <HeatmapSeries {...HEATMAP_PROPS} />
     </XYPlot>
   );
-  t.equal(
-    $.find('.rv-xy-plot__series--heatmap').length,
-    1,
-    'should find the right number of series'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series--heatmap rect').length,
-    12,
-    'should find the right number of series'
-  );
-  t.equal(
-    $.find('g.heatmap-series-example').length,
-    1,
-    'should find the correct custom class name'
-  );
+  expect($.find('.rv-xy-plot__series--heatmap').length).toBe(1);
+  expect($.find('.rv-xy-plot__series--heatmap rect').length).toBe(12);
+  expect($.find('g.heatmap-series-example').length).toBe(1);
 
   $.setProps({children: <HeatmapSeries {...{...HEATMAP_PROPS, data: null}} />});
-  t.equal(
-    $.find('.rv-xy-plot__series--heatmap').length,
-    0,
-    'should find no series'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series--heatmap rect').length,
-    0,
-    'should find no rects'
-  );
-  t.equal(
-    $.find('.heatmap-series-example').length,
-    0,
-    'should not find the custom name'
-  );
-  t.end();
+  expect($.find('.rv-xy-plot__series--heatmap').length).toBe(0);
+  expect($.find('.rv-xy-plot__series--heatmap rect').length).toBe(0);
+  expect($.find('.heatmap-series-example').length).toBe(0);
 });
 
-test('Heatmap: Showcase Example - HeatmapChart', t => {
+test('Heatmap: Showcase Example - HeatmapChart', () => {
   const $ = mount(<HeatmapChart />);
-  t.equal(
-    $.find('.rv-xy-plot__series--heatmap').length,
-    1,
-    'should find the right number of series'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series--heatmap rect').length,
-    12,
-    'should find the right number of series'
-  );
-  t.equal(
-    $.find('g.heatmap-series-example').length,
-    1,
-    'should find the correct custom class name'
-  );
-  t.equal(
-    $.text(),
-    '0.51.01.52.02.53.03.5051015',
-    'should find the correct text'
-  );
-  t.end();
+  expect($.find('.rv-xy-plot__series--heatmap').length).toBe(1);
+  expect($.find('.rv-xy-plot__series--heatmap rect').length).toBe(12);
+  expect($.find('g.heatmap-series-example').length).toBe(1);
+  expect($.text()).toBe('0.51.01.52.02.53.03.5051015');
 });
 
-test('Heatmap: Showcase Example - LabeledHeatmap', t => {
+test('Heatmap: Showcase Example - LabeledHeatmap', () => {
   const $ = mount(<LabeledHeatmap />);
-  t.equal(
-    $.find('.rv-xy-plot__series--heatmap').length,
-    1,
-    'should find the right number of series'
+  expect($.find('.rv-xy-plot__series--heatmap').length).toBe(1);
+  expect($.find('.rv-xy-plot__series--label').length).toBe(1);
+  expect($.find('.rv-xy-plot__series--heatmap rect').length).toBe(100);
+  expect($.find('g.heatmap-series-example').length).toBe(1);
+  expect($.text()).toBe(
+    'A1B1C1D1E1F1G1H1I1J1J2I2H2G2F2E2D2C2B2A20123456789111111111122222122233333331313444444444155555555556666666666777777777788888888889999999999'
   );
-  t.equal(
-    $.find('.rv-xy-plot__series--label').length,
-    1,
-    'should find the right number of series'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series--heatmap rect').length,
-    100,
-    'should find the right number of series'
-  );
-  t.equal(
-    $.find('g.heatmap-series-example').length,
-    1,
-    'should find the correct custom class name'
-  );
-  t.equal(
-    $.text(),
-    'A1B1C1D1E1F1G1H1I1J1J2I2H2G2F2E2D2C2B2A20123456789111111111122222122233333331313444444444155555555556666666666777777777788888888889999999999',
-    'should find the correct text'
-  );
-  t.end();
 });

--- a/packages/react-vis/tests/components/hexbin-series-tests.js
+++ b/packages/react-vis/tests/components/hexbin-series-tests.js
@@ -1,4 +1,3 @@
-import test from 'tape';
 import React from 'react';
 import {mount} from 'enzyme';
 import HexbinSeries from 'plot/series/hexbin-series';
@@ -8,53 +7,27 @@ import HexbinSizeExample from '../../../showcase/plot/hexbin-size-example';
 
 testRenderWithProps(HexbinSeries, GENERIC_XYPLOT_SERIES_PROPS);
 
-test('HexbinSeries: Showcase Example - HexHeatmap', t => {
+test('HexbinSeries: Showcase Example - HexHeatmap', () => {
   const $ = mount(<HexHeatmap />);
-  t.equal(
-    $.find('.rv-xy-plot__series--hexbin').length,
-    1,
-    'should find the right number of series'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series--hexbin path').length,
-    53,
-    'should find the right number of hexes'
-  );
-  t.equal(
-    $.find('g.hexbin-example').length,
-    1,
-    'should find the correct custom class name'
-  );
-  t.equal(
-    $.text(),
-    '4050607080901002345678UPDATE DATAUPDATE RADIUSUPDATE OFFSET',
-    'should find the correct text'
+  expect($.find('.rv-xy-plot__series--hexbin').length).toBe(1);
+  expect($.find('.rv-xy-plot__series--hexbin path').length).toBe(53);
+  expect($.find('g.hexbin-example').length).toBe(1);
+  expect($.text()).toBe(
+    '4050607080901002345678UPDATE DATAUPDATE RADIUSUPDATE OFFSET'
   );
 
   $.find('.rv-xy-plot__series--hexbin path')
     .at(2)
     .simulate('mouseOver');
-  t.equal(
-    $.text(),
-    '4050607080901002345678x: 138.56406460551017y: 180value: 1UPDATE DATAUPDATE RADIUSUPDATE OFFSET',
-    'should find the correct text'
+  expect($.text()).toBe(
+    '4050607080901002345678x: 138.56406460551017y: 180value: 1UPDATE DATAUPDATE RADIUSUPDATE OFFSET'
   );
-
-  t.end();
 });
 
-test('HexbinSeries: Showcase Example - HexbinSizeExample', t => {
+test('HexbinSeries: Showcase Example - HexbinSizeExample', () => {
   const $ = mount(<HexbinSizeExample />);
-  t.equal(
-    $.find('g.alt-x-label').length,
-    1,
-    'should find custom x class on chart label correctly'
-  );
-  t.equal(
-    $.find('g.alt-y-label').length,
-    1,
-    'should find custom y class on chart label correctly'
-  );
+  expect($.find('g.alt-x-label').length).toBe(1);
+  expect($.find('g.alt-y-label').length).toBe(1);
   [
     {
       numHexes: 56,
@@ -92,23 +65,9 @@ test('HexbinSeries: Showcase Example - HexbinSizeExample', t => {
         .at(buttonToPress)
         .simulate('click');
     }
-    t.equal(
-      $.find('.rv-xy-plot__series--hexbin').length,
-      1,
-      'should find the right number of series'
-    );
-    t.equal(
-      $.find('.rv-xy-plot__series--hexbin path').length,
-      numHexes,
-      'should find the right number of hexes'
-    );
-    t.equal(
-      $.find('g.hexbin-size-example').length,
-      1,
-      'should find the correct custom class name'
-    );
-    t.equal($.text(), text, 'should find the correct text');
+    expect($.find('.rv-xy-plot__series--hexbin').length).toBe(1);
+    expect($.find('.rv-xy-plot__series--hexbin path').length).toBe(numHexes);
+    expect($.find('g.hexbin-size-example').length).toBe(1);
+    expect($.text()).toBe(text);
   });
-
-  t.end();
 });

--- a/packages/react-vis/tests/components/highlight-tests.js
+++ b/packages/react-vis/tests/components/highlight-tests.js
@@ -1,4 +1,3 @@
-import test from 'tape';
 import React from 'react';
 import {mount} from 'enzyme';
 import Highlight from 'plot/highlight';
@@ -11,11 +10,11 @@ import {testRenderWithProps, GENERIC_XYPLOT_SERIES_PROPS} from '../test-utils';
 
 testRenderWithProps(Highlight, GENERIC_XYPLOT_SERIES_PROPS);
 
-test('Highlight: DragableExample', t => {
+test('Highlight: DragableExample', () => {
   const $ = mount(<DragableExample />);
   const initialText =
     '0.00.51.01.52.02.53.03.54.04.55.05.56.06.57.00246810selectionStart: 0,selectionEnd: 0,';
-  t.equal($.text(), initialText, 'should find the correct text initially');
+  expect($.text()).toBe(initialText);
 
   $.find('.rv-mouse-target').simulate('mouseDown', {
     nativeEvent: {offsetX: 100, offsetY: 100}
@@ -25,14 +24,12 @@ test('Highlight: DragableExample', t => {
       nativeEvent: {offsetX: 100 + i, offsetY: 100}
     });
   }
-  t.equal($.text(), initialText, 'should find the right text after brushing');
+  expect($.text()).toBe(initialText);
   $.find('.rv-mouse-target').simulate('mouseUp', {
     nativeEvent: {offsetX: 200, offsetY: 100}
   });
-  t.equal(
-    $.text(),
-    '0.00.51.01.52.02.53.03.54.04.55.05.56.06.57.00246810selectionStart: 0.93,selectionEnd: 2.47,',
-    'should find the right text after brushing'
+  expect($.text()).toBe(
+    '0.00.51.01.52.02.53.03.54.04.55.05.56.06.57.00246810selectionStart: 0.93,selectionEnd: 2.47,'
   );
 
   // click to clear
@@ -42,20 +39,14 @@ test('Highlight: DragableExample', t => {
   $.find('.rv-mouse-target').simulate('mouseUp', {
     nativeEvent: {offsetX: 0, offsetY: 0}
   });
-  t.equal(
-    $.text(),
-    initialText,
-    'should find no points selected after click to clear'
-  );
-
-  t.end();
+  expect($.text()).toBe(initialText);
 });
 
-test('Highlight: ZoomableChartExample', t => {
+test('Highlight: ZoomableChartExample', () => {
   const $ = mount(<ZoomableChartExample />);
   const initialText =
     '-5051015200102030405060708090Reset ZoomLast Draw AreaN/A';
-  t.equal($.text(), initialText, 'should find the correct text initially');
+  expect($.text()).toBe(initialText);
 
   // brush in a drag area
   $.find('.rv-mouse-target').simulate('mouseDown', {
@@ -66,30 +57,22 @@ test('Highlight: ZoomableChartExample', t => {
       nativeEvent: {offsetX: 100 + i, offsetY: 100 + i}
     });
   }
-  t.equal($.text(), initialText, 'should find the right text after brushing');
+  expect($.text()).toBe(initialText);
 
   $.find('.rv-mouse-target').simulate('mouseUp', {
     nativeEvent: {offsetX: 200, offsetY: 200}
   });
-  t.equal(
-    $.text(),
-    '-5051015200102030405060708090Reset ZoomLast Draw AreaTop: 11.083578425950623Right: 34.98Bottom: -0.5863163548405383Left: 13.2',
-    'should find the right text after brush finishes'
+  expect($.text()).toBe(
+    '-5051015200102030405060708090Reset ZoomLast Draw AreaTop: 11.083578425950623Right: 34.98Bottom: -0.5863163548405383Left: 13.2'
   );
-
-  t.end();
 });
 
-test('Highlight: SelectionPlotExample', t => {
+test('Highlight: SelectionPlotExample', () => {
   const $ = mount(<SelectionPlotExample />);
 
   const initialText = '0.51.01.52.02.5681012There are 0 selected points';
-  t.equal(
-    $.find('g.selection-example').length,
-    1,
-    'should find the custom class is passed through correctly'
-  );
-  t.equal($.text(), initialText, 'should find the correct text initially');
+  expect($.find('g.selection-example').length).toBe(1);
+  expect($.text()).toBe(initialText);
 
   $.find('.rv-mouse-target').simulate('mouseDown', {
     nativeEvent: {offsetX: 100, offsetY: 100}
@@ -99,19 +82,11 @@ test('Highlight: SelectionPlotExample', t => {
       nativeEvent: {offsetX: 100, offsetY: 100 + i}
     });
   }
-  t.equal(
-    $.text(),
-    '0.51.01.52.02.5681012There are 4 selected points',
-    'should find the right text after brushing'
-  );
+  expect($.text()).toBe('0.51.01.52.02.5681012There are 4 selected points');
   $.find('.rv-mouse-target').simulate('mouseUp', {
     nativeEvent: {offsetX: 100, offsetY: 200}
   });
-  t.equal(
-    $.text(),
-    '0.51.01.52.02.5681012There are 4 selected points',
-    'should find the right text after brushing'
-  );
+  expect($.text()).toBe('0.51.01.52.02.5681012There are 4 selected points');
 
   // click to clear
   $.find('.rv-mouse-target').simulate('mouseDown', {
@@ -120,23 +95,14 @@ test('Highlight: SelectionPlotExample', t => {
   $.find('.rv-mouse-target').simulate('mouseUp', {
     nativeEvent: {offsetX: 0, offsetY: 0}
   });
-  t.equal(
-    $.text(),
-    initialText,
-    'should find no points selected after click to clear'
-  );
-  t.end();
+  expect($.text()).toBe(initialText);
 });
 
-test('Highlight: BidirectionDragChart', t => {
+test('Highlight: BidirectionDragChart', () => {
   const $ = mount(<BidirectionDragChart />);
 
   // brush in a drag area
-  t.equal(
-    $.text(),
-    '12342468There are 0 selected points',
-    'should find the correct text initially'
-  );
+  expect($.text()).toBe('12342468There are 0 selected points');
 
   $.find('.rv-mouse-target').simulate('mouseDown', {
     nativeEvent: {offsetX: 100, offsetY: 100}
@@ -146,20 +112,12 @@ test('Highlight: BidirectionDragChart', t => {
       nativeEvent: {offsetX: 100 + i, offsetY: 100 + i}
     });
   }
-  t.equal(
-    $.text(),
-    '12342468There are 5 selected points',
-    'should find the right text after brushing'
-  );
+  expect($.text()).toBe('12342468There are 5 selected points');
 
   $.find('.rv-mouse-target').simulate('mouseUp', {
     nativeEvent: {offsetX: 200, offsetY: 200}
   });
-  t.equal(
-    $.text(),
-    '12342468There are 5 selected points',
-    'should find the right text after brush finishes'
-  );
+  expect($.text()).toBe('12342468There are 5 selected points');
 
   // execute dragging
   $.find('.rv-mouse-target').simulate('mouseDown', {
@@ -170,19 +128,11 @@ test('Highlight: BidirectionDragChart', t => {
       nativeEvent: {offsetX: 150 + i, offsetY: 150 + i}
     });
   }
-  t.equal(
-    $.text(),
-    '12342468There are 6 selected points',
-    'should find the right text after dragging'
-  );
+  expect($.text()).toBe('12342468There are 6 selected points');
   $.find('.rv-mouse-target').simulate('mouseUp', {
     nativeEvent: {offsetX: 200, offsetY: 200}
   });
-  t.equal(
-    $.text(),
-    '12342468There are 6 selected points',
-    'should find the right text after drag finishes'
-  );
+  expect($.text()).toBe('12342468There are 6 selected points');
 
   // click to clear
   $.find('.rv-mouse-target').simulate('mouseDown', {
@@ -191,11 +141,5 @@ test('Highlight: BidirectionDragChart', t => {
   $.find('.rv-mouse-target').simulate('mouseUp', {
     nativeEvent: {offsetX: 75, offsetY: 75}
   });
-  t.equal(
-    $.text(),
-    '12342468There are 0 selected points',
-    'should find no points selected after click to clear'
-  );
-
-  t.end();
+  expect($.text()).toBe('12342468There are 0 selected points');
 });

--- a/packages/react-vis/tests/components/hints-tests.js
+++ b/packages/react-vis/tests/components/hints-tests.js
@@ -1,28 +1,17 @@
-import test from 'tape';
 import React from 'react';
 import {shallow} from 'enzyme';
 import Hint from 'plot/hint';
 
-test('Hint: Appends user-input class name to the class signatures list', t => {
+test('Hint: Appends user-input class name to the class signatures list', () => {
   const wrapper = shallow(
     <Hint x={0} y={0} value={{test: 123}} className="test-class-name" />
   );
 
-  t.equal(
-    wrapper.hasClass('test-class-name'),
-    true,
-    'should find className passed as prop'
-  );
-  t.end();
+  expect(wrapper.hasClass('test-class-name')).toBe(true);
 });
 
-test('Hint: Assigns only default class names when no custom class specified', t => {
+test('Hint: Assigns only default class names when no custom class specified', () => {
   const wrapper = shallow(<Hint x={0} y={0} value={{test: 123}} />);
 
-  t.equal(
-    wrapper.hasClass('undefined'),
-    false,
-    'should not add any class names when no specified in prop'
-  );
-  t.end();
+  expect(wrapper.hasClass('undefined')).toBe(false);
 });

--- a/packages/react-vis/tests/components/interaction-article-tests.js
+++ b/packages/react-vis/tests/components/interaction-article-tests.js
@@ -1,4 +1,3 @@
-import test from 'tape';
 import React from 'react';
 import {mount} from 'enzyme';
 
@@ -9,26 +8,22 @@ import {
   ScatterPlotOnNearestXY
 } from '../../../showcase/interaction/interaction-examples';
 
-test('Interaction examples: LinkedCharts', t => {
+test('Interaction examples: LinkedCharts', () => {
   const $ = mount(<LinkedCharts />);
-  t.equal($.find('.rv-xy-plot').length, 3, '3 XYPlot in this example');
-  t.end();
+  expect($.find('.rv-xy-plot').length).toBe(3);
 });
 
-test('Interaction examples: LineChartMouseOverXY', t => {
+test('Interaction examples: LineChartMouseOverXY', () => {
   const $ = mount(<LineChartMouseOverXY />);
-  t.equal($.find('.rv-xy-plot').length, 1, '1 XYPlot in this example');
-  t.end();
+  expect($.find('.rv-xy-plot').length).toBe(1);
 });
 
-test('Interaction examples: LineChartMouseOverSeries', t => {
+test('Interaction examples: LineChartMouseOverSeries', () => {
   const $ = mount(<LineChartMouseOverSeries />);
-  t.equal($.find('.rv-xy-plot').length, 1, '1 XYPlot in this example');
-  t.end();
+  expect($.find('.rv-xy-plot').length).toBe(1);
 });
 
-test('Interaction examples: ScatterPlotOnNearestXY', t => {
+test('Interaction examples: ScatterPlotOnNearestXY', () => {
   const $ = mount(<ScatterPlotOnNearestXY />);
-  t.equal($.find('.rv-xy-plot').length, 1, '1 XYPlot in this example');
-  t.end();
+  expect($.find('.rv-xy-plot').length).toBe(1);
 });

--- a/packages/react-vis/tests/components/label-series-tests.js
+++ b/packages/react-vis/tests/components/label-series-tests.js
@@ -1,4 +1,3 @@
-import test from 'tape';
 import React from 'react';
 import {mount} from 'enzyme';
 import LabelSeries from 'plot/series/label-series';
@@ -8,40 +7,24 @@ import LabeledStackedVerticalBarChart from '../../../showcase/plot/labeled-stack
 
 testRenderWithProps(LabelSeries, GENERIC_XYPLOT_SERIES_PROPS);
 
-test('LabelSeries: Showcase Example - LabelSeriesExample', t => {
+test('LabelSeries: Showcase Example - LabelSeriesExample', () => {
   const $ = mount(<LabelSeriesExample />);
-  t.equal(
-    $.text(),
-    'UPDATE-101234505101520WigglytuffPsyduckGeodudeDittoSnorlax',
-    'should find the right text content'
+  expect($.text()).toBe(
+    'UPDATE-101234505101520WigglytuffPsyduckGeodudeDittoSnorlax'
   );
-  t.equal(
-    $.find('.rv-xy-plot__series--label text').length,
-    5,
-    'should find the right number of text boxes'
-  );
+  expect($.find('.rv-xy-plot__series--label text').length).toBe(5);
 
   $.find('.showcase-button').simulate('click');
-  t.equal(
-    $.text(),
-    'UPDATE-101234505101520WigglytuffPsyduckGeoduderedblue',
-    'should find the right text content'
+  expect($.text()).toBe(
+    'UPDATE-101234505101520WigglytuffPsyduckGeoduderedblue'
   );
   $.find('.showcase-button').simulate('click');
-  t.equal(
-    $.text(),
-    'UPDATE-101234505101520WigglytuffPsyduckGeoduderedblue',
-    'should find the right text content'
+  expect($.text()).toBe(
+    'UPDATE-101234505101520WigglytuffPsyduckGeoduderedblue'
   );
-  t.end();
 });
 
-test('BarSeries: Showcase Example - LabeledStackedVerticalBarChart', t => {
+test('BarSeries: Showcase Example - LabeledStackedVerticalBarChart', () => {
   const $ = mount(<LabeledStackedVerticalBarChart />);
-  t.equal(
-    $.find('.rv-xy-plot__series--label text').length,
-    9,
-    'should find the right number of labels'
-  );
-  t.end();
+  expect($.find('.rv-xy-plot__series--label text').length).toBe(9);
 });

--- a/packages/react-vis/tests/components/legends-tests.js
+++ b/packages/react-vis/tests/components/legends-tests.js
@@ -1,4 +1,3 @@
-import test from 'tape';
 import React from 'react';
 import {mount} from 'enzyme';
 import ContinuousSizeLegend from '../../../showcase/legends/continuous-size';
@@ -11,160 +10,105 @@ import SearchableDiscreteColorLegendHoverExample from '../../../showcase/legends
 import HorizontalDiscreteCustomPalette from '../../../showcase/legends/horizontal-discrete-custom-palette';
 import ClusteredStackedVerticalBarChart from '../../../showcase/plot/clustered-stacked-bar-chart';
 
-test('Discrete Legend has no clickable className while onItemClick is not passing', t => {
+test('Discrete Legend has no clickable className while onItemClick is not passing', () => {
   const withOnClick$ = mount(<VerticalDiscreteLegend />);
   const withoutOnClick$ = mount(<SearchableDiscreteLegend />);
 
-  t.equal(
+  expect(
     withOnClick$
       .find('.rv-discrete-color-legend-item.vertical')
       .first()
-      .props().onClick,
-    null,
-    'should not have onClick prop'
-  );
-  t.notEqual(
+      .props().onClick
+  ).toBe(null);
+  expect(
     withoutOnClick$
       .find('.rv-discrete-color-legend-item.vertical.clickable')
       .first()
-      .props().onClick,
-    Function,
-    'should have onClick prop'
-  );
-
-  t.end();
+      .props().onClick
+  ).not.toBe(Function);
 });
 
-test('Continuous Size Legend', t => {
+test('Continuous Size Legend', () => {
   const $ = mount(<ContinuousSizeLegend />);
-  t.equal($.text(), '          100200', 'should find the correct text content');
-  t.equal(
-    $.find('.rv-bubble').length,
-    10,
-    'should find the right number of bubbles'
-  );
-
-  t.end();
+  expect($.text()).toBe('          100200');
+  expect($.find('.rv-bubble').length).toBe(10);
 });
 
-test('Continuous Color Legend', t => {
+test('Continuous Color Legend', () => {
   const $ = mount(<ContinuousColorLegend />);
-  t.equal($.text(), '100200150', 'should find the correct text content');
+  expect($.text()).toBe('100200150');
   const expectedStyle = {
     background: 'linear-gradient(to right, #EF5D28,#FF9833)'
   };
-  t.deepEqual(
-    $.find('.rv-gradient').props().style,
-    expectedStyle,
-    'should find the correct styling'
-  );
-  t.end();
+  expect($.find('.rv-gradient').props().style).toEqual(expectedStyle);
 });
 
-test('Discrete Legends', t => {
+test('Discrete Legends', () => {
   const verticalLegend = mount(<VerticalDiscreteLegend />);
-  t.equal(
-    verticalLegend.text(),
-    'OptionsButtonsSelect boxesDate inputsPassword inputsFormsOther',
-    'should find the correct text content'
+  expect(verticalLegend.text()).toBe(
+    'OptionsButtonsSelect boxesDate inputsPassword inputsFormsOther'
   );
-  t.equal(
-    verticalLegend.find('.rv-discrete-color-legend-item__color').length,
-    7,
-    'should find the right number of elements'
-  );
+  expect(
+    verticalLegend.find('.rv-discrete-color-legend-item__color').length
+  ).toBe(7);
 
-  t.deepEqual(
+  expect(
     verticalLegend
       .find('.rv-discrete-color-legend-item__color__path')
       .first()
-      .props().style,
-    {stroke: '#12939A'},
-    'normal discrete legend uses default palette'
-  );
+      .props().style
+  ).toEqual({stroke: '#12939A'});
 
-  t.deepEqual(
+  expect(
     mount(<HorizontalDiscreteCustomPalette />)
       .find('.rv-discrete-color-legend-item__color__path')
       .first()
-      .props().style,
-    {stroke: '#6588cd'},
-    'custom discrete legend uses custom palette'
-  );
+      .props().style
+  ).toEqual({stroke: '#6588cd'});
 
   const $ = mount(<SearchableDiscreteLegend />);
-  t.equal(
-    $.text(),
-    'ApplesBananasBlueberriesCarrotsEggplantsLimesPotatoes',
-    'should find the correct text content for the searchable legend'
+  expect($.text()).toBe(
+    'ApplesBananasBlueberriesCarrotsEggplantsLimesPotatoes'
   );
-  t.equal(
-    $.find('.rv-discrete-color-legend-item__color').length,
-    7,
-    'should find the right number of element for the searchable legends'
-  );
-  t.deepEqual(
+  expect($.find('.rv-discrete-color-legend-item__color').length).toBe(7);
+  expect(
     mount(<HorizontalDiscreteLegend />)
       .find('.rv-discrete-color-legend-item__color__path')
       .first()
-      .props().style,
-    {strokeDasharray: '6, 2', stroke: '#45aeb1'},
-    'should find the default dashed dasharray style'
-  );
-  t.deepEqual(
+      .props().style
+  ).toEqual({strokeDasharray: '6, 2', stroke: '#45aeb1'});
+  expect(
     mount(<HorizontalDiscreteLegend />)
       .find('.rv-discrete-color-legend-item__color__path')
       .at(4)
-      .props().style,
-    {strokeWidth: 13, stroke: 'url(#stripes)'},
-    'should find the specified stroke width'
-  );
+      .props().style
+  ).toEqual({strokeWidth: 13, stroke: 'url(#stripes)'});
   $.find('.rv-search-wrapper__form__input').simulate('change', {
     target: {value: 'egg'}
   });
-  t.equal(
-    $.text(),
-    'Eggplants',
-    'should find the correct text content after search'
-  );
+  expect($.text()).toBe('Eggplants');
   const itemsFound = $.find('.rv-discrete-color-legend-item__color').length;
-  t.equal(
-    itemsFound,
-    1,
-    'should find the right number of elements for the searchable legend after searched'
-  );
+  expect(itemsFound).toBe(1);
 
-  t.equal(
-    $.find('.disabled').length,
-    0,
-    'before clicking, should find no items disabled'
-  );
+  expect($.find('.disabled').length).toBe(0);
   $.find('.clickable').simulate('click');
-  t.equal(
-    $.find('.disabled').length,
-    1,
-    'before clicking, should find no items disabled'
-  );
+  expect($.find('.disabled').length).toBe(1);
 
-  t.deepEqual(
+  expect(
     mount(<ClusteredStackedVerticalBarChart />)
       .find('.rv-discrete-color-legend')
       .first()
-      .props().style,
-    {
-      width: undefined,
-      height: undefined,
-      position: 'absolute',
-      left: '50px',
-      top: '10px'
-    },
-    'discrete legend retains passed styles'
-  );
-
-  t.end();
+      .props().style
+  ).toEqual({
+    width: undefined,
+    height: undefined,
+    position: 'absolute',
+    left: '50px',
+    top: '10px'
+  });
 });
 
-test('Discrete Legends Showcase: HorizontalDiscreteCustomPalette', t => {
+test('Discrete Legends Showcase: HorizontalDiscreteCustomPalette', () => {
   const $ = mount(<HorizontalDiscreteCustomPalette />);
   const colors = $.find('.rv-discrete-color-legend-item__color__path')
     .map(colorBrick => {
@@ -172,39 +116,27 @@ test('Discrete Legends Showcase: HorizontalDiscreteCustomPalette', t => {
     })
     .join(' ');
 
-  t.equal(
-    colors,
-    '#6588cd #66b046 #a361c7 #ad953f #c75a87 #55a47b #cb6141',
-    'should find all correct values for the colors'
+  expect(colors).toBe(
+    '#6588cd #66b046 #a361c7 #ad953f #c75a87 #55a47b #cb6141'
   );
-  t.equal(
-    $.text(),
-    'OptionsButtonsSelect boxesDate inputsPassword inputsFormsOther',
-    'should find the right text'
+  expect($.text()).toBe(
+    'OptionsButtonsSelect boxesDate inputsPassword inputsFormsOther'
   );
 
   $.find('.rv-discrete-color-legend-item')
     .first()
     .simulate('mouseEnter');
-  t.equal(
-    $.text(),
-    'OptionsSELECTEDButtonsSelect boxesDate inputsPassword inputsFormsOther',
-    'should find the right text, with the first element selected'
+  expect($.text()).toBe(
+    'OptionsSELECTEDButtonsSelect boxesDate inputsPassword inputsFormsOther'
   );
-
-  t.end();
 });
 
-test('Discrete Legends Showcase: SearchableDiscreteLegendHover', t => {
+test('Discrete Legends Showcase: SearchableDiscreteLegendHover', () => {
   const $ = mount(<SearchableDiscreteColorLegendHoverExample />);
   $.find('.rv-discrete-color-legend-item')
     .first()
     .simulate('mouseEnter');
-  t.equal(
-    $.text(),
-    'Apples:SELECTEDBananasBlueberriesCarrotsEggplantsLimesPotatoes',
-    'should find the right text, with the first element selected'
+  expect($.text()).toBe(
+    'Apples:SELECTEDBananasBlueberriesCarrotsEggplantsLimesPotatoes'
   );
-
-  t.end();
 });

--- a/packages/react-vis/tests/components/line-series-canvas-test.js
+++ b/packages/react-vis/tests/components/line-series-canvas-test.js
@@ -1,10 +1,9 @@
-import test from 'tape';
 import React from 'react';
 import {mount} from 'enzyme';
 import XYPlot from 'plot/xy-plot';
 import LineSeriesCanvas from 'plot/series/line-series-canvas';
 
-test('LineSeriesCanvas: should be rendered', t => {
+test('LineSeriesCanvas: should be rendered', () => {
   const k = 7;
 
   const $ = mount(
@@ -24,19 +23,16 @@ test('LineSeriesCanvas: should be rendered', t => {
     </XYPlot>
   );
 
-  t.equal(
+  expect(
     $.find('CanvasWrapper')
       .children()
-      .find('LineSeriesCanvas').length,
-    k,
-    'should render correct amount of LineSeriesCanvas children'
-  );
-  t.end();
+      .find('LineSeriesCanvas').length
+  ).toBe(k);
 });
 
-test('LineSeriesCanvas: on onNearestXY should be called and retur ncorrect values', t => {
+test('LineSeriesCanvas: on onNearestXY should be called and retur ncorrect values', () => {
   const k = 7;
-  t.plan(k);
+  expect.assertions(k);
 
   const $ = mount(
     <XYPlot width={300} height={300}>
@@ -49,12 +45,7 @@ test('LineSeriesCanvas: on onNearestXY should be called and retur ncorrect value
             {x: 60, y: 60}
           ]}
           onNearestXY={value => {
-            t.deepEqual(
-              {x: v, y: v * v},
-              value,
-              `onNearestXY called for series # ${v} and returns the correct values for x=${v} and y=${v *
-                v}`
-            );
+            expect({x: v, y: v * v}).toEqual(value);
           }}
         />
       ))}
@@ -64,5 +55,4 @@ test('LineSeriesCanvas: on onNearestXY should be called and retur ncorrect value
   $.find('.rv-xy-plot__inner').simulate('mousemove', {
     nativeEvent: {clientX: 150, clientY: 150}
   });
-  t.end();
 });

--- a/packages/react-vis/tests/components/line-series-tests.js
+++ b/packages/react-vis/tests/components/line-series-tests.js
@@ -1,4 +1,3 @@
-import test from 'tape';
 import React from 'react';
 import {mount} from 'enzyme';
 import XYPlot from 'plot/xy-plot';
@@ -46,184 +45,85 @@ const LINE_WITH_MANY_COLORS_COLORS = [
   'rgb(255, 65, 0)'
 ];
 
-test('LineSeries: basic rendering', t => {
+test('LineSeries: basic rendering', () => {
   const $ = mount(
     <XYPlot width={300} height={300}>
       <LineSeries {...LINE_PROPS} />
     </XYPlot>
   );
-  t.equal(
-    $.find('.rv-xy-plot__series').length,
-    1,
-    'should find the right number of series'
-  );
-  t.equal(
-    $.find('path.rv-xy-plot__series').length,
-    1,
-    'should find the right number of series'
-  );
-  t.equal(
-    $.find('path.line-chart-example').length,
-    1,
-    'should find the right number of custom named series'
-  );
+  expect($.find('.rv-xy-plot__series').length).toBe(1);
+  expect($.find('path.rv-xy-plot__series').length).toBe(1);
+  expect($.find('path.line-chart-example').length).toBe(1);
 
   $.setProps({children: <LineSeries {...{...LINE_PROPS, data: null}} />});
-  t.equal(
-    $.find('.rv-xy-plot__series').length,
-    0,
-    'should find the right number of series'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series path').length,
-    0,
-    'should find the right number of series'
-  );
-  t.equal(
-    $.find('.line-chart-example').length,
-    0,
-    'should find the right number of custom named series'
-  );
-  t.end();
+  expect($.find('.rv-xy-plot__series').length).toBe(0);
+  expect($.find('.rv-xy-plot__series path').length).toBe(0);
+  expect($.find('.line-chart-example').length).toBe(0);
 });
 
-test('LineSeries: Showcase Example - LineChart', t => {
+test('LineSeries: Showcase Example - LineChart', () => {
   const $ = mount(<LineChart />);
-  t.equal(
-    $.find('g.alt-x-label').length,
-    1,
-    'should find custom x class on chart label correctly'
-  );
+  expect($.find('g.alt-x-label').length).toBe(1);
 
-  t.equal(
-    $.find('g.alt-y-label').length,
-    1,
-    'should find custom y class on chart label correctly'
+  expect($.find('g.alt-y-label').length).toBe(1);
+  expect($.text()).toBe(
+    'TOGGLE TO CANVAS1.01.52.02.53.03.54.02468101214X AxisY Axis'
   );
-  t.equal(
-    $.text(),
-    'TOGGLE TO CANVAS1.01.52.02.53.03.54.02468101214X AxisY Axis',
-    'should find the right text content'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series--line').length,
-    3,
-    'should find the right number of series'
-  );
+  expect($.find('.rv-xy-plot__series--line').length).toBe(3);
 
   ['first-series', 'third-series', 'fourth-series'].forEach(customClassName => {
-    t.equal(
-      $.find(`.rv-xy-plot__series--line.${customClassName}`).length,
-      1,
-      `should find the right number of series with the custom class name: ${customClassName}`
+    expect($.find(`.rv-xy-plot__series--line.${customClassName}`).length).toBe(
+      1
     );
   });
 
-  t.equal(
-    $.find('path.second-series').length,
-    0,
-    'there should be no line with the class second series bc it has null data and should be filtered out'
-  );
+  expect($.find('path.second-series').length).toBe(0);
 
   $.find('button').simulate('click');
-  t.equal(
-    $.find('.rv-xy-plot__series--line').length,
-    0,
-    'should find no more line series'
-  );
+  expect($.find('.rv-xy-plot__series--line').length).toBe(0);
 
   $.find('button').simulate('click');
-  t.equal(
-    $.find('.rv-xy-plot__series--line').length,
-    3,
-    'should find no more line series'
-  );
-  t.end();
+  expect($.find('.rv-xy-plot__series--line').length).toBe(3);
 });
 
-test('LineSeries: Showcase Example - LineMarkSeries', t => {
+test('LineSeries: Showcase Example - LineMarkSeries', () => {
   const $ = mount(<LineMarkSeries />);
-  t.equal(
-    $.text(),
-    '1.01.52.02.53.0510152025',
-    'should find the right text content'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series--linemark').length,
-    2,
-    'should find the right number of series'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series circle').length,
-    6,
-    'should find the right number of marks'
-  );
+  expect($.text()).toBe('1.01.52.02.53.0510152025');
+  expect($.find('.rv-xy-plot__series--linemark').length).toBe(2);
+  expect($.find('.rv-xy-plot__series circle').length).toBe(6);
 
   ['linemark-series-example', 'linemark-series-example-2'].forEach(
     customClassName => {
-      t.equal(
-        $.find(`MarkSeries.${customClassName}`).length,
-        1,
-        `should find the right number of MarkSeries with the custom class name: ${customClassName}`
-      );
+      expect($.find(`MarkSeries.${customClassName}`).length).toBe(1);
 
-      t.equal(
-        $.find(`LineSeries.${customClassName}`).length,
-        1,
-        `should find the right number of LineSeries with the custom class name: ${customClassName}`
-      );
+      expect($.find(`LineSeries.${customClassName}`).length).toBe(1);
     }
   );
-  t.end();
 });
 
-test('LineSeries: Showcase Example - LineChartManyColors', t => {
+test('LineSeries: Showcase Example - LineChartManyColors', () => {
   const $ = mount(<LineChartManyColors />);
   const lines = $.find('.rv-xy-plot__series');
-  t.equal(lines.length, 20, 'line with many colors has 20 series');
+  expect(lines.length).toBe(20);
   lines.forEach((node, i) =>
-    t.equal(
-      node.props().style.stroke,
-      LINE_WITH_MANY_COLORS_COLORS[i],
-      `${i}th line series gets the right color`
-    )
+    expect(node.props().style.stroke).toBe(LINE_WITH_MANY_COLORS_COLORS[i])
   );
-  t.end();
 });
 
-test('LineSeries: Showcase Example - TimeChart', t => {
+test('LineSeries: Showcase Example - TimeChart', () => {
   const $ = mount(<TimeChart />);
-  t.equal(
-    $.find('.rv-xy-plot__series--line').length,
-    2,
-    'should find the right number of lines'
+  expect($.find('.rv-xy-plot__series--line').length).toBe(2);
+  expect($.text()).toBe(
+    'Sep 1012 PMMon 1112 PMTue 1212 PMWed 13X Axis2468101214Y Axis'
   );
-  t.equal(
-    $.text(),
-    'Sep 1012 PMMon 1112 PMTue 1212 PMWed 13X Axis2468101214Y Axis',
-    'should find the right number of lines'
-  );
-  t.end();
 });
 
-test('LineSeries: Showcase Example - SyncedCharts', t => {
+test('LineSeries: Showcase Example - SyncedCharts', () => {
   const $ = mount(<SyncedCharts />);
   const tests = () => {
-    t.equal(
-      $.find('.rv-xy-plot').length,
-      2,
-      'should find the right number of lines'
-    );
-    t.equal(
-      $.find('.rv-xy-plot__series--line').length,
-      4,
-      'should find the right number of lines'
-    );
-    t.equal(
-      $.text(),
-      '1.01.52.02.53.024681012141.01.52.02.53.0246810',
-      'should find the right number of lines'
-    );
+    expect($.find('.rv-xy-plot').length).toBe(2);
+    expect($.find('.rv-xy-plot__series--line').length).toBe(4);
+    expect($.text()).toBe('1.01.52.02.53.024681012141.01.52.02.53.0246810');
   };
   tests();
   $.find('.rv-xy-plot__series--line')
@@ -233,10 +133,9 @@ test('LineSeries: Showcase Example - SyncedCharts', t => {
   $.find('.rv-xy-plot')
     .at(0)
     .simulate('mouseLeave');
-  t.end();
 });
 
-test('LineSeries: Line Styling', t => {
+test('LineSeries: Line Styling', () => {
   const $ = mount(
     <XYPlot width={300} height={300}>
       <LineSeries
@@ -251,125 +150,74 @@ test('LineSeries: Line Styling', t => {
 
   const lineStyle = $.find('path.rv-xy-plot__series').prop('style');
 
-  t.equal(lineStyle.opacity, 0.5, 'should render an opaque line');
-  t.equal(lineStyle.strokeWidth, '3px', 'should honor stroke width');
-  t.equal(lineStyle.stroke, 'rgb(255, 255, 255)', 'should honor stroke');
-  t.equal(lineStyle.strokeDasharray, '3, 1', 'should honor stroke dash-array');
-  t.end();
+  expect(lineStyle.opacity).toBe(0.5);
+  expect(lineStyle.strokeWidth).toBe('3px');
+  expect(lineStyle.stroke).toBe('rgb(255, 255, 255)');
+  expect(lineStyle.strokeDasharray).toBe('3, 1');
 });
 
-test('getNull prop: Showcase Example - Null Data Example', t => {
+test('getNull prop: Showcase Example - Null Data Example', () => {
   const $ = mount(<NullData />);
-  t.equal(
-    $.find('path.rv-xy-plot__series').length,
-    2,
-    'should find the right number of series'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series--mark circle').length,
-    3,
-    'should find the right number of circles'
-  );
+  expect($.find('path.rv-xy-plot__series').length).toBe(2);
+  expect($.find('.rv-xy-plot__series--mark circle').length).toBe(3);
 
   simulateMouseMove(35);
-  t.equal(
-    $.find('.rv-crosshair__title').text(),
-    'x: 1',
-    'should find the right crosshair title'
-  );
-  t.equal(
+  expect($.find('.rv-crosshair__title').text()).toBe('x: 1');
+  expect(
     $.find('.rv-crosshair__item')
       .at(0)
-      .text(),
-    '0: 10',
-    'should find the right crosshair series text'
-  );
-  t.equal(
+      .text()
+  ).toBe('0: 10');
+  expect(
     $.find('.rv-crosshair__item')
       .at(1)
-      .text(),
-    '1: 30',
-    'should find the right crosshair series text'
-  );
+      .text()
+  ).toBe('1: 30');
 
   $.find('.rv-xy-plot__inner').simulate('mouseleave');
-  t.equal(
-    $.find('.rv-crosshair').exists(),
-    false,
-    'crosshair should not exist'
-  );
+  expect($.find('.rv-crosshair').exists()).toBe(false);
 
   simulateMouseMove(100);
-  t.equal(
-    $.find('.rv-crosshair__title').text(),
-    'x: 2',
-    'should find the right crosshair title'
-  );
-  t.equal(
+  expect($.find('.rv-crosshair__title').text()).toBe('x: 2');
+  expect(
     $.find('.rv-crosshair__item')
       .at(0)
-      .text(),
-    '0: 10',
-    'should find the right crosshair series text'
-  );
-  t.equal(
+      .text()
+  ).toBe('0: 10');
+  expect(
     $.find('.rv-crosshair__item')
       .at(1)
-      .text(),
-    '1: 0',
-    'should find the right crosshair series text'
-  );
+      .text()
+  ).toBe('1: 0');
 
   simulateMouseMove(165);
-  t.equal(
-    $.find('.rv-crosshair__title').text(),
-    'x: 3',
-    'should find the right crosshair title'
-  );
-  t.equal(
+  expect($.find('.rv-crosshair__title').text()).toBe('x: 3');
+  expect(
     $.find('.rv-crosshair__item')
       .at(0)
-      .text(),
-    '0: 13',
-    'should find the right crosshair series text'
-  );
-  t.equal(
+      .text()
+  ).toBe('0: 13');
+  expect(
     $.find('.rv-crosshair__item')
       .at(1)
-      .exists(),
-    false,
-    'crosshair series text should not exist'
-  );
+      .exists()
+  ).toBe(false);
 
   simulateMouseMove(230);
-  t.equal(
-    $.find('.rv-crosshair__title').text(),
-    'x: 4',
-    'should find the right crosshair title'
-  );
-  t.equal(
+  expect($.find('.rv-crosshair__title').text()).toBe('x: 4');
+  expect(
     $.find('.rv-crosshair__item')
       .at(0)
-      .text(),
-    '0: 7',
-    'should find the right crosshair series text'
-  );
-  t.equal(
+      .text()
+  ).toBe('0: 7');
+  expect(
     $.find('.rv-crosshair__item')
       .at(1)
-      .text(),
-    '1: 15',
-    'should find the right crosshair series text'
-  );
+      .text()
+  ).toBe('1: 15');
 
   simulateMouseMove(295);
-  t.equal(
-    $.find('.rv-crosshair').exists(),
-    false,
-    'crosshair should not exist'
-  );
-
-  t.end();
+  expect($.find('.rv-crosshair').exists()).toBe(false);
 
   function simulateMouseMove(x) {
     $.find('.rv-xy-plot__inner').simulate('mousemove', {

--- a/packages/react-vis/tests/components/make-vis-flexible-tests.js
+++ b/packages/react-vis/tests/components/make-vis-flexible-tests.js
@@ -1,25 +1,16 @@
-import test from 'tape';
 import {makeWidthFlexible} from 'make-vis-flexible';
 
-test('makeWidthFlexible: displayName given', t => {
+test('makeWidthFlexible: displayName given', () => {
   function ChildComponent() {}
   ChildComponent.displayName = 'ChildComponentWithDisplayName';
   const FlexibleComponent = makeWidthFlexible(ChildComponent);
-  t.equal(
-    FlexibleComponent.displayName,
-    'FlexibleChildComponentWithDisplayName',
-    'should use component display name'
+  expect(FlexibleComponent.displayName).toBe(
+    'FlexibleChildComponentWithDisplayName'
   );
-  t.end();
 });
 
-test('makeWidthFlexible: displayName not given', t => {
+test('makeWidthFlexible: displayName not given', () => {
   function ChildComponent() {}
   const FlexibleComponent = makeWidthFlexible(ChildComponent);
-  t.equal(
-    FlexibleComponent.displayName,
-    'FlexibleChildComponent',
-    'should default to component name'
-  );
-  t.end();
+  expect(FlexibleComponent.displayName).toBe('FlexibleChildComponent');
 });

--- a/packages/react-vis/tests/components/mark-series-tests.js
+++ b/packages/react-vis/tests/components/mark-series-tests.js
@@ -1,4 +1,3 @@
-import test from 'tape';
 import React from 'react';
 import {mount} from 'enzyme';
 import MarkSeries from 'plot/series/mark-series';
@@ -8,27 +7,14 @@ import DynamicCrosshairScatterplot from '../../../showcase/axes/dynamic-crosshai
 
 testRenderWithProps(MarkSeries, GENERIC_XYPLOT_SERIES_PROPS);
 
-test('MarkSeries: Showcase Example - Scatterplot', t => {
+test('MarkSeries: Showcase Example - Scatterplot', () => {
   const $ = mount(<Scatterplot />);
-  t.equal(
-    $.text(),
-    '1.01.52.02.53.068101214',
-    'should find the right text content'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series--mark circle').length,
-    5,
-    'should find the right number of circles'
-  );
-  t.equal(
-    $.find('g.mark-series-example').length,
-    1,
-    'should find the right number of custom named series'
-  );
-  t.end();
+  expect($.text()).toBe('1.01.52.02.53.068101214');
+  expect($.find('.rv-xy-plot__series--mark circle').length).toBe(5);
+  expect($.find('g.mark-series-example').length).toBe(1);
 });
 
-test('MarkSeries: Showcase Example - Dynamic Crosshair Scatterplot', t => {
+test('MarkSeries: Showcase Example - Dynamic Crosshair Scatterplot', () => {
   const $ = mount(<DynamicCrosshairScatterplot />);
   // NOTE: Point 0 (P0) and Point 1 (P1) are vertically aligned
   const yDistanceBetweenP0andP1 = 2.5;
@@ -38,31 +24,25 @@ test('MarkSeries: Showcase Example - Dynamic Crosshair Scatterplot', t => {
     highlightedCircle,
     []
   );
-  t.equal(highlightedCircles1.length, 0, 'should not highlight any circles');
+  expect(highlightedCircles1.length).toBe(0);
 
   updateCursor(0, yDistanceBetweenP0andP1 / 2 - 0.01);
   const highlightedCircles2 = $.find('.rv-xy-plot__series--mark circle').reduce(
     highlightedCircle,
     []
   );
-  t.equal(highlightedCircles2.length, 1, 'should highlight one circle');
-  t.deepEqual(
-    highlightedCircles2[0],
-    {cx: 0, cy: 0},
-    'should highlight circle at <0, 0>'
-  );
+  expect(highlightedCircles2.length).toBe(1);
+  expect(highlightedCircles2[0]).toEqual({cx: 0, cy: 0});
 
   updateCursor(0, yDistanceBetweenP0andP1 / 2);
   const highlightedCircles3 = $.find('.rv-xy-plot__series--mark circle').reduce(
     highlightedCircle,
     []
   );
-  t.equal(highlightedCircles3.length, 1, 'should highlight one circle');
+  expect(highlightedCircles3.length).toBe(1);
 
-  t.true(Math.abs(highlightedCircles3[0].cx - 0) < 0.005);
-  t.true(Math.abs(highlightedCircles3[0].cy - 2.5) < 0.005);
-
-  t.end();
+  expect(Math.abs(highlightedCircles3[0].cx - 0) < 0.005).toBeTruthy();
+  expect(Math.abs(highlightedCircles3[0].cy - 2.5) < 0.005).toBeTruthy();
 
   function updateCursor(x, y) {
     $.find('.rv-xy-plot__series--mark').simulate('mousemove', {

--- a/packages/react-vis/tests/components/parallel-coordinates-tests.js
+++ b/packages/react-vis/tests/components/parallel-coordinates-tests.js
@@ -1,4 +1,3 @@
-import test from 'tape';
 import React from 'react';
 import {mount} from 'enzyme';
 import ParallelCoordinates from 'parallel-coordinates';
@@ -31,59 +30,28 @@ const PARALLEL_COODINATES_PROPS = {
 // make sure that the components render at all
 testRenderWithProps(ParallelCoordinates, PARALLEL_COODINATES_PROPS);
 
-test('Parallel Coordinates: Basic Parallel Coordinates', t => {
+test('Parallel Coordinates: Basic Parallel Coordinates', () => {
   const $ = mount(<BasicParallelCoordinates />);
-  t.equal(
-    $.find('div.rv-parallel-coordinates-chart').length,
-    1,
-    'should find a parallel coordinates chart'
+  expect($.find('div.rv-parallel-coordinates-chart').length).toBe(1);
+  expect($.find('.rv-xy-manipulable-axis__ticks').length).toBe(6);
+  expect($.find('LineSeries.rv-parallel-coordinates-chart-line').length).toBe(
+    3
   );
-  t.equal(
-    $.find('.rv-xy-manipulable-axis__ticks').length,
-    6,
-    'should find the right number of axes'
-  );
-  t.equal(
-    $.find('LineSeries.rv-parallel-coordinates-chart-line').length,
-    3,
-    'should find the right number of lines'
-  );
-  t.equal(
-    $.find('MarkSeries.rv-parallel-coordinates-chart-line').length,
-    3,
-    'should find the right number of lines'
+  expect($.find('MarkSeries.rv-parallel-coordinates-chart-line').length).toBe(
+    3
   );
 
-  t.equal(
-    $.find('circle').length,
-    18,
-    'should find the right number of nodes rendered'
+  expect($.find('circle').length).toBe(18);
+  expect($.find('div.rv-parallel-coordinates-chart').text()).toBe(
+    '0.002.004.006.008.0010.0$2.0$4.8$7.6$10$13$165.006.007.008.009.0010.00.002.004.006.008.0010.00.001.402.804.205.607.0010.08.406.805.203.602.00mileagepricesafetyperformanceinteriorwarranty'
   );
-  t.equal(
-    $.find('div.rv-parallel-coordinates-chart').text(),
-    '0.002.004.006.008.0010.0$2.0$4.8$7.6$10$13$165.006.007.008.009.0010.00.002.004.006.008.0010.00.001.402.804.205.607.0010.08.406.805.203.602.00mileagepricesafetyperformanceinteriorwarranty',
-    'should find the right text content'
-  );
-  t.end();
 });
 
-test('Parallel Coordinates: Animated Parallel Coordinates ', t => {
+test('Parallel Coordinates: Animated Parallel Coordinates ', () => {
   const $ = mount(<AnimatedParallelCoordinates />);
-  t.equal(
-    $.find('div.rv-parallel-coordinates-chart').length,
-    1,
-    'should find a parallel coordinates chart'
-  );
-  t.equal(
-    $.find('.rv-xy-manipulable-axis__ticks').length,
-    5,
-    'should find the right number of axes'
-  );
-  t.equal(
-    $.find('path.rv-parallel-coordinates-chart-line').length,
-    1,
-    'should find the right number of axes'
-  );
+  expect($.find('div.rv-parallel-coordinates-chart').length).toBe(1);
+  expect($.find('.rv-xy-manipulable-axis__ticks').length).toBe(5);
+  expect($.find('path.rv-parallel-coordinates-chart-line').length).toBe(1);
   // This relies on floating point
   // t.equal(
   //   $.find('div.rv-parallel-coordinates-chart').text(),
@@ -92,37 +60,15 @@ test('Parallel Coordinates: Animated Parallel Coordinates ', t => {
   // );
 
   $.find('.showcase-button').simulate('click');
-  t.equal(
-    $.find('.rv-xy-manipulable-axis__ticks').length,
-    5,
-    'should find the right number of axes'
-  );
-  t.equal(
-    $.find('path.rv-parallel-coordinates-chart-line').length,
-    1,
-    'should find the right number of axes'
-  );
-  // This relies on floating points
-  // t.equal(
-  //   $.find('div.rv-parallel-coordinates-chart').text(),
-  //   '020406080100niceexplosionswowdogsickMoves',
-  //   'should find the right text content'
-  // );
-
-  t.end();
+  expect($.find('.rv-xy-manipulable-axis__ticks').length).toBe(5);
+  expect($.find('path.rv-parallel-coordinates-chart-line').length).toBe(1);
 });
 
-test('Parallel Coordinates: Brushed Parallel Coordinates', t => {
+test('Parallel Coordinates: Brushed Parallel Coordinates', () => {
   const $ = mount(<BrushedParallelCoordinates />);
-  t.equal(
-    $.find('path.rv-parallel-coordinates-chart-line').length,
-    150,
-    'should find the right number of lines'
-  );
-  t.equal(
-    $.find('div.rv-parallel-coordinates-chart').text(),
-    '4.35.05.76.57.27.92.02.53.03.43.94.41.02.23.44.55.76.90.100.581.11.52.02.5sepal lengthsepal widthpetal lengthpetal width',
-    'should find the right text content'
+  expect($.find('path.rv-parallel-coordinates-chart-line').length).toBe(150);
+  expect($.find('div.rv-parallel-coordinates-chart').text()).toBe(
+    '4.35.05.76.57.27.92.02.53.03.43.94.41.02.23.44.55.76.90.100.581.11.52.02.5sepal lengthsepal widthpetal lengthpetal width'
   );
 
   // brush
@@ -134,21 +80,17 @@ test('Parallel Coordinates: Brushed Parallel Coordinates', t => {
       .at(0)
       .simulate('mouseMove', {nativeEvent: {offsetX: 50, offsetY: 100 + i}});
   }
-  t.equal(
-    $.find('.rv-parallel-coordinates-chart-line-unselected').length,
-    0,
-    'should find no unselected lines before mouse up'
+  expect($.find('.rv-parallel-coordinates-chart-line-unselected').length).toBe(
+    0
   );
 
   $.find('.rv-mouse-target')
     .at(0)
     .simulate('mouseUp', {nativeEvent: {offsetX: 50, offsetY: 200}});
 
-  t.equal(
-    $.find('path.rv-parallel-coordinates-chart-line-unselected').length,
-    102,
-    'should find unselected lines after mouseup'
-  );
+  expect(
+    $.find('path.rv-parallel-coordinates-chart-line-unselected').length
+  ).toBe(102);
 
   // click to clear
   $.find('.rv-mouse-target')
@@ -158,11 +100,7 @@ test('Parallel Coordinates: Brushed Parallel Coordinates', t => {
     .at(0)
     .simulate('mouseUp', {nativeEvent: {offsetX: 50, offsetY: 95}});
 
-  t.equal(
-    $.find('.rv-parallel-coordinates-chart-line-unselected').length,
-    0,
-    'should find no unselected lines after click to clear'
+  expect($.find('.rv-parallel-coordinates-chart-line-unselected').length).toBe(
+    0
   );
-
-  t.end();
 });

--- a/packages/react-vis/tests/components/polygon-series-tests.js
+++ b/packages/react-vis/tests/components/polygon-series-tests.js
@@ -1,4 +1,3 @@
-import test from 'tape';
 import React from 'react';
 import {mount} from 'enzyme';
 import PolygonSeries from 'plot/series/mark-series';
@@ -7,13 +6,8 @@ import TriangleExample from '../../../showcase/misc/triangle-example';
 
 testRenderWithProps(PolygonSeries, GENERIC_XYPLOT_SERIES_PROPS);
 
-test('PolygonSeries: Showcase Example - Triangle Example', t => {
+test('PolygonSeries: Showcase Example - Triangle Example', () => {
   const $ = mount(<TriangleExample />);
-  t.equal($.text(), '024681012024681012', 'should fine the right text content');
-  t.equal(
-    $.find('.rv-xy-plot__series--polygon').length,
-    121,
-    'should find the right number of polygons'
-  );
-  t.end();
+  expect($.text()).toBe('024681012024681012');
+  expect($.find('.rv-xy-plot__series--polygon').length).toBe(121);
 });

--- a/packages/react-vis/tests/components/radar-chart-tests.js
+++ b/packages/react-vis/tests/components/radar-chart-tests.js
@@ -1,4 +1,3 @@
-import test from 'tape';
 import React from 'react';
 import {mount} from 'enzyme';
 import RadialChart from 'radial-chart';
@@ -33,138 +32,63 @@ const RADAR_PROPS = {
 // make sure that the components render at all
 testRenderWithProps(RadialChart, RADAR_PROPS);
 
-test('Radar: Showcase Example - Basic Radar Chart', t => {
+test('Radar: Showcase Example - Basic Radar Chart', () => {
   const $ = mount(<BasicRadarChart />);
-  t.equal($.find('div.rv-radar-chart').length, 1, 'should find a radar chart');
-  t.equal(
-    $.find('.rv-xy-manipulable-axis__ticks').length,
-    6,
-    'should find the right number of axes'
+  expect($.find('div.rv-radar-chart').length).toBe(1);
+  expect($.find('.rv-xy-manipulable-axis__ticks').length).toBe(6);
+  expect($.find('path.rv-radar-chart-polygon').length).toBe(3);
+  expect($.find('div.rv-radar-chart').text()).toBe(
+    '2.004.006.008.0010.0$4.8$7.6$10$13$166.007.008.009.0010.02.004.006.008.0010.01.402.804.205.607.008.406.805.203.602.00mileagepricesafetyperformanceinteriorwarranty'
   );
-  t.equal(
-    $.find('path.rv-radar-chart-polygon').length,
-    3,
-    'should find the right number of axes'
-  );
-  t.equal(
-    $.find('div.rv-radar-chart').text(),
-    '2.004.006.008.0010.0$4.8$7.6$10$13$166.007.008.009.0010.02.004.006.008.0010.01.402.804.205.607.008.406.805.203.602.00mileagepricesafetyperformanceinteriorwarranty',
-    'should find the right text content'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series--custom-svg').length,
-    0,
-    'should find the right number of polygon points (0 because onMouseOver is not defined)'
-  );
-  t.end();
+  expect($.find('.rv-xy-plot__series--custom-svg').length).toBe(0);
 });
 
-test('Radar: Showcase Example - Animated Radial ', t => {
+test('Radar: Showcase Example - Animated Radial ', () => {
   const $ = mount(<AnimatedRadarChart />);
-  t.equal($.find('div.rv-radar-chart').length, 1, 'should find a radar chart');
-  t.equal(
-    $.find('.rv-xy-manipulable-axis__ticks').length,
-    5,
-    'should find the right number of axes'
-  );
-  t.equal(
-    $.find('path.rv-radar-chart-polygon').length,
-    1,
-    'should find the right number of polygons'
-  );
+  expect($.find('div.rv-radar-chart').length).toBe(1);
+  expect($.find('.rv-xy-manipulable-axis__ticks').length).toBe(5);
+  expect($.find('path.rv-radar-chart-polygon').length).toBe(1);
   // Floating point
   // t.equal(
   //   $.find('div.rv-radar-chart').text(),
   //   '20406080100niceexplosionswowdogsickMoves',
   //   'should find the right text content'
   // );
-  t.equal(
-    $.find('.rv-xy-plot__circular-grid-lines__line').length,
-    10,
-    'should find the correct number of rings'
-  );
+  expect($.find('.rv-xy-plot__circular-grid-lines__line').length).toBe(10);
 
   $.find('.showcase-button').simulate('click');
-  t.equal(
-    $.find('.rv-xy-manipulable-axis__ticks').length,
-    5,
-    'should find the right number of axes'
-  );
+  expect($.find('.rv-xy-manipulable-axis__ticks').length).toBe(5);
 
-  t.equal(
-    $.find('path.rv-radar-chart-polygon').length,
-    1,
-    'should find the right number of axes'
-  );
+  expect($.find('path.rv-radar-chart-polygon').length).toBe(1);
   // Floating Point
   // t.equal(
   //   $.find('div.rv-radar-chart').text(),
   //   '20406080100niceexplosionswowdogsickMoves',
   //   'should find the right text content'
   // );
-  t.equal(
-    $.find('.rv-xy-plot__series--custom-svg').length,
-    0,
-    'should find the right number of polygon points (0 because onMouseOver is not defined)'
-  );
-  t.end();
+  expect($.find('.rv-xy-plot__series--custom-svg').length).toBe(0);
 });
 
-test('Radar: Showcase Example - Four Quadrant Radar Chart', t => {
+test('Radar: Showcase Example - Four Quadrant Radar Chart', () => {
   const $ = mount(<FourQuadrantRadarChart />);
-  t.equals($.find('div.rv-radar-chart').length, 1, 'should find a radar chart');
-  t.equals(
-    $.find('.rv-xy-manipulable-axis__ticks').length,
-    4,
-    'should find the right number of total axes'
+  expect($.find('div.rv-radar-chart').length).toBe(1);
+  expect($.find('.rv-xy-manipulable-axis__ticks').length).toBe(4);
+  expect($.find('.rv-xy-manipulable-axis__ticks').children().length).toBe(24);
+  expect($.find('path.rv-radar-chart-polygon').length).toBe(1);
+  expect($.find('div.rv-radar-chart').text()).toBe(
+    '20406080100204060801002040608010020406080100CVisualBasicsExcelAccess'
   );
-  t.equals(
-    $.find('.rv-xy-manipulable-axis__ticks').children().length,
-    24,
-    'should find the right number of total ticks'
-  );
-  t.equal(
-    $.find('path.rv-radar-chart-polygon').length,
-    1,
-    'should find the right number of polygons'
-  );
-  t.equal(
-    $.find('div.rv-radar-chart').text(),
-    '20406080100204060801002040608010020406080100CVisualBasicsExcelAccess',
-    'should find the right text content'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series--custom-svg').length,
-    0,
-    'should find the right number of polygon points (0 because onMouseOver is not defined)'
-  );
-  t.end();
+  expect($.find('.rv-xy-plot__series--custom-svg').length).toBe(0);
 });
 
-test('Radar: Showcase Example - Radar Chart with Tooltips', t => {
+test('Radar: Showcase Example - Radar Chart with Tooltips', () => {
   const $ = mount(<RadarChartWithTooltips />);
   const chartText = 'mileagepricesafetyperformanceinteriorwarranty1234';
-  t.equal($.find('div.rv-radar-chart').length, 1, 'should find a radar chart');
-  t.equal(
-    $.find('.rv-xy-manipulable-axis__ticks').length,
-    6,
-    'should find the right number of axes'
-  );
-  t.equal(
-    $.find('path.rv-radar-chart-polygon').length,
-    7,
-    'should find the right number of polygons'
-  );
-  t.equal(
-    $.find('g.rv-radar-chart-polygonPoint').length,
-    7,
-    'should find the right number of polygon points'
-  );
-  t.equal(
-    $.find('div.rv-radar-chart').text(),
-    chartText,
-    'should find the right text content'
-  );
+  expect($.find('div.rv-radar-chart').length).toBe(1);
+  expect($.find('.rv-xy-manipulable-axis__ticks').length).toBe(6);
+  expect($.find('path.rv-radar-chart-polygon').length).toBe(7);
+  expect($.find('g.rv-radar-chart-polygonPoint').length).toBe(7);
+  expect($.find('div.rv-radar-chart').text()).toBe(chartText);
 
   // Tooltips
   const tooltipText = 'mileage: 3';
@@ -173,48 +97,22 @@ test('Radar: Showcase Example - Radar Chart with Tooltips', t => {
     .children()
     .at(0)
     .simulate('mouseOver');
-  t.equal(
-    $.text(),
-    `${chartText}${tooltipText}`,
-    'should display tooltip text'
-  );
-  t.end();
+  expect($.text()).toBe(`${chartText}${tooltipText}`);
 });
 
-test('Radar: Showcase Example - series tooltips', t => {
+test('Radar: Showcase Example - series tooltips', () => {
   const $ = mount(<RadarChartSeriesTooltips />);
   const chartText =
     '2.004.006.008.0010.0$4.8$7.6$10$13$166.007.008.009.0010.02.004.006.008.0010.01.402.804.205.607.008.406.805.203.602.00mileagepricesafetyperformanceinteriorwarranty';
   const hoverText = 'Mercedes';
 
-  t.equal($.find('div.rv-radar-chart').length, 1, 'should find a radar chart');
-  t.equal(
-    $.find('.rv-xy-manipulable-axis__ticks').length,
-    6,
-    'should find the right number of axes'
-  );
-  t.equal(
-    $.find('path.rv-radar-chart-polygon').length,
-    3,
-    'should find the right number of polygons'
-  );
-  t.equal(
-    $.find('div.rv-radar-chart').text(),
-    chartText,
-    'should find the right text content'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series--custom-svg').length,
-    0,
-    'should find the right number of polygon points (0 because onMouseOver is not defined)'
-  );
+  expect($.find('div.rv-radar-chart').length).toBe(1);
+  expect($.find('.rv-xy-manipulable-axis__ticks').length).toBe(6);
+  expect($.find('path.rv-radar-chart-polygon').length).toBe(3);
+  expect($.find('div.rv-radar-chart').text()).toBe(chartText);
+  expect($.find('.rv-xy-plot__series--custom-svg').length).toBe(0);
   $.find('.rv-radar-chart-polygon')
     .at(0)
     .simulate('mouseOver');
-  t.equal(
-    $.find('div.rv-radar-chart').text(),
-    `${chartText}${hoverText}`,
-    'should find hover text for the series mouseOver'
-  );
-  t.end();
+  expect($.find('div.rv-radar-chart').text()).toBe(`${chartText}${hoverText}`);
 });

--- a/packages/react-vis/tests/components/radial-tests.js
+++ b/packages/react-vis/tests/components/radial-tests.js
@@ -1,4 +1,3 @@
-import test from 'tape';
 import React from 'react';
 import {mount} from 'enzyme';
 import RadialChart from 'radial-chart';
@@ -25,99 +24,50 @@ const RADIAL_PROPS = {
 // make sure that the components render at all
 testRenderWithProps(RadialChart, RADIAL_PROPS);
 
-test('RadialChart: Basic rendering', t => {
+test('RadialChart: Basic rendering', () => {
   const $ = mount(<RadialChart {...RADIAL_PROPS} />);
   const pieSlices = $.find('.rv-radial-chart__series--pie__slice').length;
-  t.equal(
-    pieSlices,
-    RADIAL_PROPS.data.length,
-    'should find the same number of slices as data entries'
-  );
-  t.equal(
+  expect(pieSlices).toBe(RADIAL_PROPS.data.length);
+  expect(
     $.find('.rv-radial-chart__series--pie__slice')
       .at(0)
-      .prop('className'),
-    'rv-xy-plot__series rv-xy-plot__series--arc-path rv-radial-chart__series--pie__slice custom-class',
-    'should have custom class if defined in data entry'
+      .prop('className')
+  ).toBe(
+    'rv-xy-plot__series rv-xy-plot__series--arc-path rv-radial-chart__series--pie__slice custom-class'
   );
 
   const labels = $.find('.rv-xy-plot__series--label-text').length;
-  t.equal(
-    labels,
-    RADIAL_PROPS.data.length,
-    'should find the right number of label wrappers'
-  );
-  t.equal(
-    $.text(),
-    'yellow againmagentacyanyellowgreen',
-    'should find appropriate text'
-  );
+  expect(labels).toBe(RADIAL_PROPS.data.length);
+  expect($.text()).toBe('yellow againmagentacyanyellowgreen');
 
   $.setProps({data: []});
-  t.equal(
-    $.find('.rv-radial-chart__series--pie__slice').length,
-    0,
-    'should find no slives'
-  );
-  t.equal(
-    $.find('.rv-radial-chart__series--pie__slice-overlay').length,
-    0,
-    'should find no overlay slices'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series--label-text').length,
-    0,
-    'should find no labels'
-  );
-  t.equal($.text(), '', 'should find no text');
-  t.end();
+  expect($.find('.rv-radial-chart__series--pie__slice').length).toBe(0);
+  expect($.find('.rv-radial-chart__series--pie__slice-overlay').length).toBe(0);
+  expect($.find('.rv-xy-plot__series--label-text').length).toBe(0);
+  expect($.text()).toBe('');
 });
 
-test('RadialChart: Showcase Example - Simple Radial Chart Example', t => {
+test('RadialChart: Showcase Example - Simple Radial Chart Example', () => {
   const $ = mount(<SimpleRadialChart />);
-  t.equal(
-    $.find('.rv-radial-chart__series--pie__slice').length,
-    5,
-    'should find the same number of slices as data entries'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series--label-text').length,
-    5,
-    'should find the right number of label wrappers'
-  );
-  t.equal(
-    $.text(),
-    'yellow againmagentacyanyellowgreen',
-    'should find appropriate text'
-  );
-  t.end();
+  expect($.find('.rv-radial-chart__series--pie__slice').length).toBe(5);
+  expect($.find('.rv-xy-plot__series--label-text').length).toBe(5);
+  expect($.text()).toBe('yellow againmagentacyanyellowgreen');
 });
 
-test('RadialChart: Showcase Example - DonutChart', t => {
+test('RadialChart: Showcase Example - DonutChart', () => {
   const $ = mount(<DonutChart />);
-  t.equal(
-    $.find('.rv-radial-chart__series--pie__slice').length,
-    5,
-    'should find an appropriate number of slice'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series--label-text').length,
-    0,
-    'should find no label wrappers, as labels is turned off'
-  );
-  t.equal($.text(), '', 'should find no text');
+  expect($.find('.rv-radial-chart__series--pie__slice').length).toBe(5);
+  expect($.find('.rv-xy-plot__series--label-text').length).toBe(0);
+  expect($.text()).toBe('');
   $.find('.rv-radial-chart__series--pie__slice')
     .at(1)
     .simulate('mouseOver');
-  t.equal(
-    $.text(),
-    'theta: 3angle0: -2.9171931783333793angle: -4.263590029871862radius0: 0radius: 1color: 1x: -0.4338837391175583y: 0.900968867902419',
-    'should find appropriate hover text'
+  expect($.text()).toBe(
+    'theta: 3angle0: -2.9171931783333793angle: -4.263590029871862radius0: 0radius: 1color: 1x: -0.4338837391175583y: 0.900968867902419'
   );
-  t.end();
 });
 
-test('RadialChart: Showcase Example - Custom radius example', t => {
+test('RadialChart: Showcase Example - Custom radius example', () => {
   const $ = mount(<CustomRadiusRadialChart />);
   $.find('.rv-radial-chart__series--pie__slice')
     .at(1)
@@ -126,41 +76,17 @@ test('RadialChart: Showcase Example - Custom radius example', t => {
     .at(1)
     .simulate('mouseLeave');
   // multiplied by two to account for the shadow listeners
-  t.equal(
-    $.find('.rv-radial-chart__series--pie__slice').length,
-    2 * 5,
-    'should find the same number of slices as data entries'
+  expect($.find('.rv-radial-chart__series--pie__slice').length).toBe(2 * 5);
+  expect($.find('.rv-xy-plot__series--label-text').length).toBe(4);
+  expect($.text()).toBe(
+    'Sub Label onlyAlt LabelSuper Custom labelWith annotation'
   );
-  t.equal(
-    $.find('.rv-xy-plot__series--label-text').length,
-    4,
-    'should find the right number of label wrappers'
-  );
-  t.equal(
-    $.text(),
-    'Sub Label onlyAlt LabelSuper Custom labelWith annotation',
-    'should find appropriate text'
-  );
-  t.end();
 });
 
-test('RadialChart: Showcase Example - Gradient Pie Example', t => {
+test('RadialChart: Showcase Example - Gradient Pie Example', () => {
   const $ = mount(<GradientPie />);
   // multiplied by two to account for the shadow listeners
-  t.equal(
-    $.find('.rv-radial-chart__series--pie__slice').length,
-    3,
-    'should find the same number of slices as data entries'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series--label-text').length,
-    0,
-    'should find the right number of label wrappers'
-  );
-  t.equal(
-    $.find('.rv-gradient-defs linearGradient').length,
-    3,
-    'should find the right number of gradient defs'
-  );
-  t.end();
+  expect($.find('.rv-radial-chart__series--pie__slice').length).toBe(3);
+  expect($.find('.rv-xy-plot__series--label-text').length).toBe(0);
+  expect($.find('.rv-gradient-defs linearGradient').length).toBe(3);
 });

--- a/packages/react-vis/tests/components/rect-series-tests.js
+++ b/packages/react-vis/tests/components/rect-series-tests.js
@@ -1,4 +1,3 @@
-import test from 'tape';
 import React from 'react';
 import {mount} from 'enzyme';
 import HorizontalRectSeries from 'plot/series/horizontal-bar-series';
@@ -10,45 +9,18 @@ import StackedHistogram from '../../../showcase/plot/stacked-histogram';
 testRenderWithProps(HorizontalRectSeries, GENERIC_XYPLOT_SERIES_PROPS);
 testRenderWithProps(VerticalRectSeries, GENERIC_XYPLOT_SERIES_PROPS);
 
-test('RectSeries: Showcase Example - StackedHistogram', t => {
+test('RectSeries: Showcase Example - StackedHistogram', () => {
   const $ = mount(<StackedHistogram />);
-  t.equal(
-    $.text(),
-    'TOGGLE TO CANVAS01234567051015202530',
-    'should fine the right text content'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series--rect rect').length,
-    6,
-    'should find the right number of bars'
-  );
+  expect($.text()).toBe('TOGGLE TO CANVAS01234567051015202530');
+  expect($.find('.rv-xy-plot__series--rect rect').length).toBe(6);
 
   $.find('.showcase-button').simulate('click');
-  t.equal(
-    $.find('.rv-xy-plot__series--rect rect').length,
-    0,
-    'should now find no rects'
-  );
-  t.equal(
-    $.find('.rv-xy-canvas canvas').length,
-    1,
-    'should now find one canvas'
-  );
-  t.end();
+  expect($.find('.rv-xy-plot__series--rect rect').length).toBe(0);
+  expect($.find('.rv-xy-canvas canvas').length).toBe(1);
 });
 
-test('RectSeries: Showcase Example - Histogram', t => {
+test('RectSeries: Showcase Example - Histogram', () => {
   const $ = mount(<Histogram />);
-  t.equal(
-    $.text(),
-    'May 21May 28Jun 04Jun 11Jun 180.51.01.52.0',
-    'should fine the right text content'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series--rect rect').length,
-    8,
-    'should find the right number of bars'
-  );
-
-  t.end();
+  expect($.text()).toBe('May 21May 28Jun 04Jun 11Jun 180.51.01.52.0');
+  expect($.find('.rv-xy-plot__series--rect rect').length).toBe(8);
 });

--- a/packages/react-vis/tests/components/sankey-tests.js
+++ b/packages/react-vis/tests/components/sankey-tests.js
@@ -1,4 +1,3 @@
-import test from 'tape';
 import React from 'react';
 import {mount} from 'enzyme';
 
@@ -22,7 +21,7 @@ import {testRenderWithProps} from '../test-utils';
 // make sure that the components render at all
 testRenderWithProps(Sankey, SANKEY_PROPS);
 
-test('Sankey: labels', t => {
+test('Sankey: labels', () => {
   const wrap = mount(
     <Sankey
       height={100}
@@ -32,14 +31,12 @@ test('Sankey: labels', t => {
     />
   );
 
-  t.equal(wrap.find('text').length, 2, 'there should be two node labels');
+  expect(wrap.find('text').length).toBe(2);
   wrap.setProps({hideLabels: true});
-  t.equal(wrap.find('text').length, 0, 'the labels should now be hidden');
-
-  t.end();
+  expect(wrap.find('text').length).toBe(0);
 });
 
-test('Sankey: children', t => {
+test('Sankey: children', () => {
   const $ = mount(
     <Sankey
       height={100}
@@ -50,99 +47,51 @@ test('Sankey: children', t => {
       <Hint x={0} y={0} value={{test: 123}} />
     </Sankey>
   );
-  t.equal($.find(Hint).length, 1, 'should find children of sankey');
-
-  t.end();
+  expect($.find(Hint).length).toBe(1);
 });
 
-test('Sankey: Showcase Example - BasicSankey', t => {
+test('Sankey: Showcase Example - BasicSankey', () => {
   const $ = mount(<BasicSankey />);
-  t.equal(
-    $.find('.rv-sankey__link').length,
-    3,
-    'should find the right number of links'
-  );
-  t.equal(
-    $.find('.rv-sankey__node rect').length,
-    3,
-    'should find the right number of nodes'
-  );
-
-  t.end();
+  expect($.find('.rv-sankey__link').length).toBe(3);
+  expect($.find('.rv-sankey__node rect').length).toBe(3);
 });
 
-test('Sankey: Showcase Example - VoronoiSankey', t => {
+test('Sankey: Showcase Example - VoronoiSankey', () => {
   const $ = mount(<VoronoiSankey />);
 
-  t.equal(
-    $.find('.rv-sankey__link').length,
-    3,
-    'should find the right number of links'
-  );
-  t.equal(
-    $.find('.rv-sankey__node rect').length,
-    3,
-    'should find the right number of nodes'
-  );
-  t.equal(
-    $.find('.rv-voronoi').length,
-    1,
-    'should find the right number of voronoi wrappers'
-  );
-  t.equal(
-    $.find('.rv-voronoi__cell').length,
-    3,
-    'should find the right number of voronoi cells'
-  );
+  expect($.find('.rv-sankey__link').length).toBe(3);
+  expect($.find('.rv-sankey__node rect').length).toBe(3);
+  expect($.find('.rv-voronoi').length).toBe(1);
+  expect($.find('.rv-voronoi__cell').length).toBe(3);
 
-  t.equal($.text(), 'None selectedabc', 'should find that no bar is hovered');
+  expect($.text()).toBe('None selectedabc');
   $.find('.rv-voronoi__cell')
     .at(0)
     .simulate('mouseOver');
-  t.equal(
-    $.text(),
-    'a selected!a!bc',
-    'should find that the first bar is hovered bar is hovered'
-  );
+  expect($.text()).toBe('a selected!a!bc');
   $.find('.rv-voronoi__cell')
     .at(0)
     .simulate('mouseLeave');
-
-  t.end();
 });
 
-test('Sankey: Showcase Example - LinkEventSankey', t => {
+test('Sankey: Showcase Example - LinkEventSankey', () => {
   const $ = mount(<LinkEventSankey />);
 
-  t.equal(
-    $.find('.rv-sankey__link').length,
-    3,
-    'should find the right number of links'
-  );
-  t.equal(
-    $.find('.rv-sankey__node rect').length,
-    3,
-    'should find the right number of nodes'
-  );
+  expect($.find('.rv-sankey__link').length).toBe(3);
+  expect($.find('.rv-sankey__node rect').length).toBe(3);
 
-  t.equal($.text(), 'None selectedabc', 'should find that no link is hovered');
+  expect($.text()).toBe('None selectedabc');
   $.find('.rv-sankey__link')
     .at(0)
     .simulate('mouseOver');
-  t.equal(
-    $.text(),
-    'a -> b selectedabc',
-    'should find that the first link is hovered'
-  );
+  expect($.text()).toBe('a -> b selectedabc');
   $.find('.rv-sankey__link')
     .at(0)
     .simulate('mouseOut');
-  t.equal($.text(), 'None selectedabc', 'should find that no bar is hovered');
-
-  t.end();
+  expect($.text()).toBe('None selectedabc');
 });
 
-test('Sankey: Showcase Example - EnergySankey', t => {
+test('Sankey: Showcase Example - EnergySankey', () => {
   const $ = mount(<EnergySankey />);
 
   [
@@ -151,57 +100,29 @@ test('Sankey: Showcase Example - EnergySankey', t => {
     "PREV MODE left NEXT MODEAgricultural 'waste'Bio-conversionLiquidLossesSolidGasBiofuel importsBiomass importsCoal importsCoalCoal reservesDistrict heatingIndustryHeating and cooling - commercialHeating and cooling - homesElectricity gridOver generation / exportsH2 conversionRoad transportAgricultureRail transportLighting & appliances - commercialLighting & appliances - homesGas importsNgasGas reservesThermal generationGeothermalH2HydroInternational shippingDomestic aviationInternational aviationNational navigationMarine algaeNuclearOil importsOilOil reservesOther wastePumped heatSolar PVSolar ThermalSolarTidalUK land based bioenergyWaveWind",
     "PREV MODE right NEXT MODEAgricultural 'waste'Bio-conversionLiquidLossesSolidGasBiofuel importsBiomass importsCoal importsCoalCoal reservesDistrict heatingIndustryHeating and cooling - commercialHeating and cooling - homesElectricity gridOver generation / exportsH2 conversionRoad transportAgricultureRail transportLighting & appliances - commercialLighting & appliances - homesGas importsNgasGas reservesThermal generationGeothermalH2HydroInternational shippingDomestic aviationInternational aviationNational navigationMarine algaeNuclearOil importsOilOil reservesOther wastePumped heatSolar PVSolar ThermalSolarTidalUK land based bioenergyWaveWind"
   ].forEach(testMessage => {
-    t.equal($.text(), testMessage, 'should find that no bar is hovered');
+    expect($.text()).toBe(testMessage);
     $.find('.showcase-button')
       .at(1)
       .simulate('click');
 
-    t.equal(
-      $.find('.rv-sankey__link').length,
-      68,
-      'should find the right number of links'
-    );
-    t.equal(
-      $.find('.rv-sankey__node rect').length,
-      48,
-      'should find the right number of nodes'
-    );
+    expect($.find('.rv-sankey__link').length).toBe(68);
+    expect($.find('.rv-sankey__node rect').length).toBe(48);
   });
-
-  t.end();
 });
 
-test('Sankey: Showcase Example - LinkHintSankey', t => {
+test('Sankey: Showcase Example - LinkHintSankey', () => {
   const $ = mount(<LinkHintSankey />);
 
-  t.equal(
-    $.find('.rv-sankey__link').length,
-    3,
-    'should find the right number of links'
-  );
-  t.equal(
-    $.find('.rv-sankey__node rect').length,
-    3,
-    'should find the right number of nodes'
-  );
+  expect($.find('.rv-sankey__link').length).toBe(3);
+  expect($.find('.rv-sankey__node rect').length).toBe(3);
 
-  t.equal($.find(Hint).length, 0, 'should find that no hint is shown');
+  expect($.find(Hint).length).toBe(0);
   $.find('.rv-sankey__link')
     .at(0)
     .simulate('mouseOver');
-  t.equal(
-    $.find(Hint).length,
-    1,
-    'should find that hint is shown if link is hovered'
-  );
+  expect($.find(Hint).length).toBe(1);
   $.find('.rv-sankey__link')
     .at(0)
     .simulate('mouseOut');
-  t.equal(
-    $.find(Hint).length,
-    0,
-    'should find that no hint is shown if link is not hovered anymore'
-  );
-
-  t.end();
+  expect($.find(Hint).length).toBe(0);
 });

--- a/packages/react-vis/tests/components/sunburst-tests.js
+++ b/packages/react-vis/tests/components/sunburst-tests.js
@@ -1,4 +1,3 @@
-import test from 'tape';
 import React from 'react';
 import {mount} from 'enzyme';
 import Sunburst from 'sunburst';
@@ -50,69 +49,38 @@ const SUNBURST_PROPS = {
 // make sure that the components render at all
 testRenderWithProps(Sunburst, SUNBURST_PROPS);
 
-test('Sunburst: Basic rendering + data changes', t => {
+test('Sunburst: Basic rendering + data changes', () => {
   const $ = mount(<Sunburst {...SUNBURST_PROPS} />);
-  t.equal(
-    $.find('.little-nested-burst-example.rv-xy-plot__series--arc path').length,
-    21,
-    'should find the custom class name used'
-  );
+  expect(
+    $.find('.little-nested-burst-example.rv-xy-plot__series--arc path').length
+  ).toBe(21);
 
   $.setProps({data: INTERPOLATE_DATA});
-  t.equal(
-    $.find('.rv-xy-plot__series--arc-path').length,
-    9,
-    'should find the right number of children'
-  );
-  t.end();
+  expect($.find('.rv-xy-plot__series--arc-path').length).toBe(9);
 });
 
-test('Sunburst: Empty', t => {
+test('Sunburst: Empty', () => {
   const $ = mount(<Sunburst {...{...SUNBURST_PROPS, data: {}}} />);
-  t.equal(
-    $.find('.rv-xy-plot__series--arc-path').length,
-    0,
-    'should find the right number of children'
-  );
-
-  t.end();
+  expect($.find('.rv-xy-plot__series--arc-path').length).toBe(0);
 });
 
-test('Sunburst: BasicSunburst', t => {
+test('Sunburst: BasicSunburst', () => {
   const $ = mount(<BasicSunburst />);
   // multiplied by two to account for the shadow listeners
-  t.equal(
-    $.find('.rv-xy-plot__series--arc path').length,
-    251 * 2,
-    'should find the right number of children'
-  );
-  t.equal(
-    $.text(),
-    'click to lock selectionSUNBURST',
-    'should find the correct text inside of the chart'
-  );
+  expect($.find('.rv-xy-plot__series--arc path').length).toBe(251 * 2);
+  expect($.text()).toBe('click to lock selectionSUNBURST');
   // check hover state
-  t.deepEqual(
-    $.state().pathValue,
-    false,
-    'should initially find no hover path'
-  );
+  expect($.state().pathValue).toEqual(false);
   $.find('.rv-xy-plot__series--arc-path')
     .at(200)
     .simulate('mouseover');
-  t.deepEqual(
-    $.state().pathValue,
-    'root > vis > events > DataEvent',
-    'should find the correct path hovered'
-  );
+  expect($.state().pathValue).toEqual('root > vis > events > DataEvent');
 
   $.find('.rv-xy-plot__series--arc-path')
     .at(1)
     .simulate('click');
-  t.equal(
-    $.text(),
-    'click to unlock selectionDataEventroot > vis > events > DataEvent',
-    'should find the right text'
+  expect($.text()).toBe(
+    'click to unlock selectionDataEventroot > vis > events > DataEvent'
   );
   $.find('.rv-xy-plot__series--arc-path')
     .at(1)
@@ -121,53 +89,27 @@ test('Sunburst: BasicSunburst', t => {
     .at(10)
     .simulate('mouseEnter');
 
-  t.equal(
-    $.text(),
-    'click to unlock selectionDataEventroot > vis > events > DataEvent',
-    'should find the right text'
+  expect($.text()).toBe(
+    'click to unlock selectionDataEventroot > vis > events > DataEvent'
   );
-  t.end();
 });
 
-test('Sunburst: SunburstWithTooltips', t => {
+test('Sunburst: SunburstWithTooltips', () => {
   const $ = mount(<SunburstWithTooltips />);
-  t.equal(
-    $.text(),
-    'cooldogssunglassesexcellentchartgreatlabel',
-    'should find the right text'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series--arc path').length,
-    10,
-    'should find the right number of children'
-  );
+  expect($.text()).toBe('cooldogssunglassesexcellentchartgreatlabel');
+  expect($.find('.rv-xy-plot__series--arc path').length).toBe(10);
   $.find('.rv-xy-plot__series--arc-path')
     .at(1)
     .simulate('mouseOver');
-  t.equal(
-    $.text(),
-    'cooldogssunglassesexcellentchartgreatlabel#FF991F',
-    'should find appropriate hover text'
-  );
-
-  t.end();
+  expect($.text()).toBe('cooldogssunglassesexcellentchartgreatlabel#FF991F');
 });
 
-test('Sunburst: AnimatedSunburst', t => {
+test('Sunburst: AnimatedSunburst', () => {
   const $ = mount(<AnimatedSunburst />);
-  t.equal($.text(), 'UPDATENOT HOVERED', 'should find the right text');
-  t.ok(
-    $.find('.rv-xy-plot__series--arc path').length > 2,
-    'should find a minimum number of elements'
-  );
+  expect($.text()).toBe('UPDATENOT HOVERED');
+  expect($.find('.rv-xy-plot__series--arc path').length > 2).toBeTruthy();
   $.find('.rv-xy-plot__series--arc-path')
     .at(1)
     .simulate('mouseOver');
-  t.equal(
-    $.text(),
-    'UPDATECURRENTLY HOVERING',
-    'should find the sunburst is now hovered'
-  );
-
-  t.end();
+  expect($.text()).toBe('UPDATECURRENTLY HOVERING');
 });

--- a/packages/react-vis/tests/components/treemap-tests.js
+++ b/packages/react-vis/tests/components/treemap-tests.js
@@ -1,4 +1,3 @@
-import test from 'tape';
 import React from 'react';
 import {mount} from 'enzyme';
 import Treemap from 'treemap';
@@ -49,48 +48,23 @@ const TREEMAP_PROPS = {
 // make sure that the components render at all
 testRenderWithProps(Treemap, TREEMAP_PROPS);
 
-test('Treemap: Basic rendering', t => {
+test('Treemap: Basic rendering', () => {
   const $ = mount(<Treemap {...TREEMAP_PROPS} />);
-  t.equal(
-    $.find('.rv-treemap__leaf').length,
-    22,
-    'should find the right number of children'
-  );
+  expect($.find('.rv-treemap__leaf').length).toBe(22);
   const expectedText =
     'EasingNeonateinterpolateISchedulableParallelPauseFunctionSequenceSequenceTransitionTransitionerTransitionEventSchedulerArrayInterpolatorColorInterpolatorDateInterpolatorInterpolatorMatrixInterpolatorNumberInterpolatorObjectInterpolatorPointInterpolatorRectangleInterpolator';
-  t.equal(
-    $.find('.rv-treemap').text(),
-    expectedText,
-    'should find the correct text shown'
-  );
-  t.equal(
-    $.find('div.little-nested-tree-example').length,
-    1,
-    'should find the custom class name used'
-  );
+  expect($.find('.rv-treemap').text()).toBe(expectedText);
+  expect($.find('div.little-nested-tree-example').length).toBe(1);
 
   $.setProps({data: INTERPOLATE_DATA});
-  t.equal(
-    $.find('.rv-treemap__leaf').length,
-    10,
-    'should find the right number of children'
-  );
+  expect($.find('.rv-treemap__leaf').length).toBe(10);
   const newText =
     'interpolateArrayInterpolatorColorInterpolatorDateInterpolatorInterpolatorMatrixInterpolatorNumberInterpolatorObjectInterpolatorPointInterpolatorRectangleInterpolator';
-  t.equal(
-    $.find('.rv-treemap').text(),
-    newText,
-    'should find the correct text shown'
-  );
-  t.equal(
-    $.find('div.little-nested-tree-example').length,
-    1,
-    'should find the custom class name used'
-  );
-  t.end();
+  expect($.find('.rv-treemap').text()).toBe(newText);
+  expect($.find('div.little-nested-tree-example').length).toBe(1);
 });
 
-test('Treemap: Custom Sorting', t => {
+test('Treemap: Custom Sorting', () => {
   const $ = mount(<Treemap {...TREEMAP_PROPS} />);
   const expectedText =
     'interpolateTransitionerEasingTransitionNeonateFunctionSequenceSchedulerSequenceParallelTransitionEventISchedulablePauseInterpolatorMatrixInterpolatorColorInterpolatorRectangleInterpolatorArrayInterpolatorPointInterpolatorObjectInterpolatorNumberInterpolatorDateInterpolator';
@@ -117,62 +91,30 @@ test('Treemap: Custom Sorting', t => {
       sortFunction: (a, b) => b.value - a.value,
       ...TREEMAP_PROPS
     });
-    t.equal(
-      $.find('.rv-treemap').text(),
-      expectedText,
-      `should find the correct text shown for ${mode} with sort`
-    );
+    expect($.find('.rv-treemap').text()).toBe(expectedText);
     $.setProps({sortFunction: (a, b) => a.value - b.value});
-    t.equal(
-      $.find('.rv-treemap').text(),
-      expectedReverseText,
-      `should find the correct text shown for ${mode} with reverse sort`
-    );
+    expect($.find('.rv-treemap').text()).toBe(expectedReverseText);
 
     // circle pack includes the root node, while the other modes do not. The root of INTERPOLATE_DATA has a title, but the root of the default data does not
     $.setProps({
       data: INTERPOLATE_DATA,
       sortFunction: (a, b) => b.value - a.value
     });
-    t.equal(
-      $.find('.rv-treemap').text(),
-      expectedNewText,
-      `should find the correct new text shown for ${mode} with sort`
-    );
+    expect($.find('.rv-treemap').text()).toBe(expectedNewText);
     $.setProps({sortFunction: (a, b) => a.value - b.value});
-    t.equal(
-      $.find('.rv-treemap').text(),
-      expectedReverseNewText,
-      `should find the correct new text shown for ${mode} with reverse sort`
-    );
+    expect($.find('.rv-treemap').text()).toBe(expectedReverseNewText);
   });
-
-  t.end();
 });
 
-test('Treemap: Empty treemap', t => {
+test('Treemap: Empty treemap', () => {
   const $ = mount(<Treemap {...{...TREEMAP_PROPS, data: {}}} />);
   // 1 is the empty root node
-  t.equal(
-    $.find('.rv-treemap__leaf').length,
-    1,
-    'should find the right number of children'
-  );
-  t.equal(
-    $.find('.rv-treemap').text(),
-    '',
-    'should find the correct text shown'
-  );
-  t.equal(
-    $.find('div.little-nested-tree-example').length,
-    1,
-    'should find the custom class name used'
-  );
-
-  t.end();
+  expect($.find('.rv-treemap__leaf').length).toBe(1);
+  expect($.find('.rv-treemap').text()).toBe('');
+  expect($.find('div.little-nested-tree-example').length).toBe(1);
 });
 
-test('Treemap: Hide Root Node', t => {
+test('Treemap: Hide Root Node', () => {
   const $ = mount(<Treemap {...TREEMAP_PROPS} />);
   // the tree from TREEMAP_PROPS doesn't have a title so its text is the same with ot without the root
   const expectedText =
@@ -196,78 +138,32 @@ test('Treemap: Hide Root Node', t => {
     'binary'
   ].forEach(mode => {
     $.setProps({mode, ...TREEMAP_PROPS, hideRootNode: false});
-    t.equal(
-      $.find('.rv-treemap').text(),
-      expectedText,
-      `should find the correct text shown for ${mode} with hideRootNode false`
-    );
-    t.equal(
-      $.find('.rv-treemap__leaf').length,
-      numberOfElementsWithRoot,
-      `should find the correct number of children for ${mode} with  hideRootNode false`
-    );
+    expect($.find('.rv-treemap').text()).toBe(expectedText);
+    expect($.find('.rv-treemap__leaf').length).toBe(numberOfElementsWithRoot);
     $.setProps({hideRootNode: true});
-    t.equal(
-      $.find('.rv-treemap').text(),
-      expectedText,
-      `should find the correct text shown for ${mode} with hideRootNode true`
-    );
-    t.equal(
-      $.find('.rv-treemap__leaf').length,
-      numberOfElements,
-      `should find the right number of children for ${mode} with hideRootNode true`
-    );
+    expect($.find('.rv-treemap').text()).toBe(expectedText);
+    expect($.find('.rv-treemap__leaf').length).toBe(numberOfElements);
 
     $.setProps({data: INTERPOLATE_DATA, hideRootNode: false});
-    t.equal(
-      $.find('.rv-treemap').text(),
-      expectedNewTextWithRoot,
-      `should find the correct new text shown for ${mode} with hideRootNode false`
-    );
-    t.equal(
-      $.find('.rv-treemap__leaf').length,
-      numberOfNewElementsWithRoot,
-      `should find the new right number of children for ${mode} with  hideRootNode false`
+    expect($.find('.rv-treemap').text()).toBe(expectedNewTextWithRoot);
+    expect($.find('.rv-treemap__leaf').length).toBe(
+      numberOfNewElementsWithRoot
     );
     $.setProps({hideRootNode: true});
-    t.equal(
-      $.find('.rv-treemap').text(),
-      expectedNewText,
-      `should find the correct new text shown for ${mode} with hideRootNode true`
-    );
-    t.equal(
-      $.find('.rv-treemap__leaf').length,
-      numberOfNewElements,
-      `should find the new right number of children for ${mode} with  hideRootNode true`
-    );
+    expect($.find('.rv-treemap').text()).toBe(expectedNewText);
+    expect($.find('.rv-treemap__leaf').length).toBe(numberOfNewElements);
   });
-
-  t.end();
 });
 
-test('Treemap: Empty treemap', t => {
+test('Treemap: Empty treemap', () => {
   const $ = mount(<Treemap {...{...TREEMAP_PROPS, data: {}}} />);
   // 1 is the empty root node
-  t.equal(
-    $.find('.rv-treemap__leaf').length,
-    1,
-    'should find the right number of children'
-  );
-  t.equal(
-    $.find('.rv-treemap').text(),
-    '',
-    'should find the correct text shown'
-  );
-  t.equal(
-    $.find('div.little-nested-tree-example').length,
-    1,
-    'should find the custom class name used'
-  );
-
-  t.end();
+  expect($.find('.rv-treemap__leaf').length).toBe(1);
+  expect($.find('.rv-treemap').text()).toBe('');
+  expect($.find('div.little-nested-tree-example').length).toBe(1);
 });
 
-test('Treemap: SimpleTreemap', t => {
+test('Treemap: SimpleTreemap', () => {
   const $ = mount(<SimpleTreemap />);
   [
     'circlePack',
@@ -286,30 +182,14 @@ test('Treemap: SimpleTreemap', t => {
         : 'path.rv-treemap__leaf';
     // circle pack includes the root node, while the other modes do not
     const numberOfElements = 252;
-    t.equal(
-      $.find(selector).length,
-      numberOfElements,
-      `${mode}: should find the right number of SVG children`
-    );
-    t.equal(
-      $.text(),
-      `USE DOMPREV MODE ${mode} NEXT MODE`,
-      `${mode}: should find the correct text shown`
-    );
+    expect($.find(selector).length).toBe(numberOfElements);
+    expect($.text()).toBe(`USE DOMPREV MODE ${mode} NEXT MODE`);
     // switch to svg
     $.find('.showcase-button')
       .at(0)
       .simulate('click');
-    t.equal(
-      $.find('.rv-treemap__leaf').length,
-      numberOfElements,
-      `${mode}: should find the right number of DOM children`
-    );
-    t.equal(
-      $.text(),
-      `USE SVGPREV MODE ${mode} NEXT MODE`,
-      `${mode}: should find the correct text shown`
-    );
+    expect($.find('.rv-treemap__leaf').length).toBe(numberOfElements);
+    expect($.text()).toBe(`USE SVGPREV MODE ${mode} NEXT MODE`);
 
     // switch back to dom and go to next mode
     $.find('.showcase-button')
@@ -319,22 +199,12 @@ test('Treemap: SimpleTreemap', t => {
       .at(2)
       .simulate('click');
   });
-
-  t.end();
 });
 
-test('Treemap: DynamicTreemap', t => {
+test('Treemap: DynamicTreemap', () => {
   const $ = mount(<DynamicTreemap />);
-  t.equal(
-    $.find('.rv-treemap__leaf').length,
-    21,
-    'should find the right number of children'
+  expect($.find('.rv-treemap__leaf').length).toBe(21);
+  expect($.find('.rv-treemap').text()).toBe(
+    '2020202020202020202020202020202020202020'
   );
-  t.equal(
-    $.find('.rv-treemap').text(),
-    '2020202020202020202020202020202020202020',
-    'should find the correct text shown'
-  );
-
-  t.end();
 });

--- a/packages/react-vis/tests/components/voronoi-tests.js
+++ b/packages/react-vis/tests/components/voronoi-tests.js
@@ -1,4 +1,3 @@
-import test from 'tape';
 import React from 'react';
 import {mount} from 'enzyme';
 import Voronoi from '../../src/plot/voronoi.js';
@@ -31,74 +30,46 @@ const StatelessVoronoiWrapper = () => (
   </XYPlot>
 );
 
-test('Voronoi: Basic Chart', t => {
+test('Voronoi: Basic Chart', () => {
   const $ = mount(<StatelessVoronoiWrapper />);
 
-  t.equal(
+  expect(
     $.find('.rv-voronoi__cell')
       .at(30)
-      .prop('style').color,
-    'red',
-    'should apply inline styles'
-  );
-  t.equal(
+      .prop('style').color
+  ).toBe('red');
+  expect(
     $.find('.rv-voronoi__cell')
       .at(30)
-      .hasClass('my-class-30'),
-    true,
-    'should apply css class'
-  );
-  t.equal(
+      .hasClass('my-class-30')
+  ).toBe(true);
+  expect(
     $.find('.rv-voronoi__cell')
       .at(50)
-      .hasClass('my-class-50'),
-    true,
-    'should apply css class'
-  );
-
-  t.end();
+      .hasClass('my-class-50')
+  ).toBe(true);
 });
 
-test('Voronoi: Showcase Example - VoronoiLineChart', t => {
+test('Voronoi: Showcase Example - VoronoiLineChart', () => {
   const $ = mount(<VoronoiLineChart />);
 
-  t.equal(
-    $.text(),
-    'Show Voronoi1.01.52.02.53.03.54.0X Axis2468101214Y Axis',
-    'should find the correct text'
+  expect($.text()).toBe(
+    'Show Voronoi1.01.52.02.53.03.54.0X Axis2468101214Y Axis'
   );
-  t.equal(
-    $.find('.rv-voronoi__cell').length,
-    12,
-    'should find the right number of voronoi cells'
-  );
-  t.equal(
-    $.find('.rv-xy-plot__series--line').length,
-    3,
-    'should find the right number of line series'
-  );
-  t.equal(
-    $.find('circle').length,
-    0,
-    'should initially find no scatterplot dots'
-  );
+  expect($.find('.rv-voronoi__cell').length).toBe(12);
+  expect($.find('.rv-xy-plot__series--line').length).toBe(3);
+  expect($.find('circle').length).toBe(0);
 
   $.find('input').simulate('click');
   $.find('.rv-voronoi__cell')
     .at(0)
     .simulate('mouseOver');
 
-  t.equal($.find('circle').length, 1, 'should now find a single hover dot');
+  expect($.find('circle').length).toBe(1);
 
   $.find('.rv-voronoi__cell')
     .at(0)
     .simulate('mouseOut');
 
-  t.equal(
-    $.find('circle').length,
-    0,
-    'after mouse out should find no hover dots'
-  );
-
-  t.end();
+  expect($.find('circle').length).toBe(0);
 });

--- a/packages/react-vis/tests/components/whisker-series-tests.js
+++ b/packages/react-vis/tests/components/whisker-series-tests.js
@@ -1,4 +1,3 @@
-import test from 'tape';
 import React from 'react';
 import {mount} from 'enzyme';
 import WhiskerSeries from 'plot/series/whisker-series';
@@ -7,23 +6,10 @@ import WhiskerChart from '../../../showcase/plot/whisker-chart';
 
 testRenderWithProps(WhiskerSeries, GENERIC_XYPLOT_SERIES_PROPS);
 
-test('WhiskerSeries: Showcase Example - Whisker Scatterplot', t => {
+test('WhiskerSeries: Showcase Example - Whisker Scatterplot', () => {
   const $ = mount(<WhiskerChart />);
-  t.equal(
-    $.text(),
-    '1.01.52.02.53.068101214',
-    'should find the right text content'
-  );
-  t.equal(
-    $.find('g.whisker-series-example').length,
-    1,
-    'should find the right number of custom named series'
-  );
+  expect($.text()).toBe('1.01.52.02.53.068101214');
+  expect($.find('g.whisker-series-example').length).toBe(1);
   // 8 lines each per 5 (double) whiskers
-  t.equal(
-    $.find('.rv-xy-plot__series--whisker line').length,
-    40,
-    'should find the right number of lines'
-  );
-  t.end();
+  expect($.find('.rv-xy-plot__series--whisker line').length).toBe(40);
 });

--- a/packages/react-vis/tests/components/xy-plot-tests.js
+++ b/packages/react-vis/tests/components/xy-plot-tests.js
@@ -18,7 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import test from 'tape';
 import React from 'react';
 import {mount, shallow} from 'enzyme';
 
@@ -39,7 +38,7 @@ const XYPLOT_PROPS = {width: 10, height: 10};
 
 testRenderWithProps(XYPlot, XYPLOT_PROPS);
 
-test('Render a stacked bar chart', t => {
+test('Render a stacked bar chart', () => {
   const wrapper = shallow(
     <XYPlot width={300} height={300} stackBy="y">
       <VerticalBarSeries
@@ -61,30 +60,20 @@ test('Render a stacked bar chart', t => {
 
   const renderedVerticalBarsWrapper = wrapper.find(VerticalBarSeries);
 
-  t.deepEqual(
-    renderedVerticalBarsWrapper.at(0).prop('data'),
-    [
-      {x: 1, y: 0},
-      {x: 2, y: 1},
-      {x: 3, y: 2}
-    ],
-    'First bar series data is the same'
-  );
+  expect(renderedVerticalBarsWrapper.at(0).prop('data')).toEqual([
+    {x: 1, y: 0},
+    {x: 2, y: 1},
+    {x: 3, y: 2}
+  ]);
 
-  t.deepEqual(
-    renderedVerticalBarsWrapper.at(1).prop('data'),
-    [
-      {x: 1, y: 2, y0: 0},
-      {x: 2, y: 2, y0: 1},
-      {x: 3, y: 2, y0: 2}
-    ],
-    'Second bar series data contains y0 values'
-  );
-
-  t.end();
+  expect(renderedVerticalBarsWrapper.at(1).prop('data')).toEqual([
+    {x: 1, y: 2, y0: 0},
+    {x: 2, y: 2, y0: 1},
+    {x: 3, y: 2, y0: 2}
+  ]);
 });
 
-test('Render a stacked bar chart with other children', t => {
+test('Render a stacked bar chart with other children', () => {
   const wrapper = shallow(
     <XYPlot width={300} height={300} stackBy="y">
       <XAxis />
@@ -99,22 +88,16 @@ test('Render a stacked bar chart with other children', t => {
 
   const renderedVerticalBarsWrapper = wrapper.find(VerticalBarSeries);
 
-  t.deepEqual(
-    renderedVerticalBarsWrapper.at(0).prop('data'),
-    [{x: 1, y: 0}],
-    'First bar series data is the same'
-  );
+  expect(renderedVerticalBarsWrapper.at(0).prop('data')).toEqual([
+    {x: 1, y: 0}
+  ]);
 
-  t.deepEqual(
-    renderedVerticalBarsWrapper.at(1).prop('data'),
-    [{x: 1, y: 2, y0: 0}],
-    'Second bar series data contains y0 values'
-  );
-
-  t.end();
+  expect(renderedVerticalBarsWrapper.at(1).prop('data')).toEqual([
+    {x: 1, y: 2, y0: 0}
+  ]);
 });
 
-test('Render a bar chart with some nonAnimatedProps', t => {
+test('Render a bar chart with some nonAnimatedProps', () => {
   const wrapper = shallow(
     <XYPlot
       width={300}
@@ -129,75 +112,54 @@ test('Render a bar chart with some nonAnimatedProps', t => {
   const renderedXAxisWrapper = wrapper.find(XAxis);
   const renderedVerticalBarsWrapper = wrapper.find(VerticalBarSeries);
 
-  t.deepEqual(
-    renderedXAxisWrapper.at(0).prop('animation'),
-    {nonAnimatedProps: ['xDomain']},
-    'XAxis has nonAnimatedProps'
-  );
+  expect(renderedXAxisWrapper.at(0).prop('animation')).toEqual({
+    nonAnimatedProps: ['xDomain']
+  });
 
-  t.deepEqual(
-    renderedVerticalBarsWrapper.at(0).prop('animation'),
-    {nonAnimatedProps: ['xDomain']},
-    'VerticalBarSeries has nonAnimatedProps'
-  );
-
-  t.end();
+  expect(renderedVerticalBarsWrapper.at(0).prop('animation')).toEqual({
+    nonAnimatedProps: ['xDomain']
+  });
 });
 
-test('testing flexible charts', t => {
+test('testing flexible charts', () => {
   const $ = mount(FlexibleCharts({height: 200, width: 400}));
   const w = $.find('.flexible-width .rv-xy-plot').prop('style');
   const h = $.find('.flexible-height .rv-xy-plot').prop('style');
   const v = $.find('.flexible-vis .rv-xy-plot').prop('style');
 
-  t.notEqual(w.width, '100px', 'flexible width - width is not 100px');
-  t.deepEqual(w.height, '100px', 'flexible width - height is 100px');
-  t.deepEqual(h.width, '100px', 'flexible height - width is 100px');
-  t.notEqual(h.height, '100px', 'flexible height - height is not 100px');
-  t.notEqual(v.width, '100px', 'flexible vis - width is not 100px');
-  t.notEqual(v.height, '100px', 'flexible vis - height is not 100px');
-  t.end();
+  expect(w.width).not.toBe('100px');
+  expect(w.height).toEqual('100px');
+  expect(h.width).toEqual('100px');
+  expect(h.height).not.toBe('100px');
+  expect(v.width).not.toBe('100px');
+  expect(v.height).not.toBe('100px');
 });
 
-test('Render two stacked bar series with a non-stacked line series chart', t => {
+test('Render two stacked bar series with a non-stacked line series chart', () => {
   const $ = mount(<MixedStackedChart />);
 
   const renderedBarsWrapper = $.find(BarSeries);
   const renderedLineWrapper = $.find(LineSeries);
-  t.deepEqual(
-    renderedBarsWrapper.at(0).prop('data'),
-    [
-      {x: 2, y: 10},
-      {x: 4, y: 5},
-      {x: 5, y: 15}
-    ],
-    'First bar series data is the same'
-  );
+  expect(renderedBarsWrapper.at(0).prop('data')).toEqual([
+    {x: 2, y: 10},
+    {x: 4, y: 5},
+    {x: 5, y: 15}
+  ]);
 
-  t.deepEqual(
-    renderedBarsWrapper.at(1).prop('data'),
-    [
-      {x: 2, y: 22, y0: 10},
-      {x: 4, y: 7, y0: 5},
-      {x: 5, y: 26, y0: 15}
-    ],
-    'Second bar series data contains y0 values'
-  );
+  expect(renderedBarsWrapper.at(1).prop('data')).toEqual([
+    {x: 2, y: 22, y0: 10},
+    {x: 4, y: 7, y0: 5},
+    {x: 5, y: 26, y0: 15}
+  ]);
 
-  t.deepEqual(
-    renderedLineWrapper.at(0).prop('data'),
-    [
-      {x: 2, y: 26},
-      {x: 4, y: 8},
-      {x: 5, y: 30}
-    ],
-    'Line series data does not contain y0 values'
-  );
-
-  t.end();
+  expect(renderedLineWrapper.at(0).prop('data')).toEqual([
+    {x: 2, y: 26},
+    {x: 4, y: 8},
+    {x: 5, y: 30}
+  ]);
 });
 
-test('Render a line series with data accessors', t => {
+test('Render a line series with data accessors', () => {
   const $ = mount(
     <XYPlot width={300} height={300} getX={d => d[0]} getY={d => d[1]}>
       <LineSeries
@@ -214,43 +176,21 @@ test('Render a line series with data accessors', t => {
   const dataProp = renderedLineWrapper.at(0).prop('data');
   const getXProp = renderedLineWrapper.at(0).prop('getX');
   const getYProp = renderedLineWrapper.at(0).prop('getY');
-  t.deepEqual(
-    dataProp.map(getXProp),
-    [1, 2, 3],
-    'X values should be mapped correctly'
-  );
-  t.deepEqual(
-    dataProp.map(getYProp),
-    [0, 1, 2],
-    'Y values should be mapped correctly'
-  );
-  t.end();
+  expect(dataProp.map(getXProp)).toEqual([1, 2, 3]);
+  expect(dataProp.map(getYProp)).toEqual([0, 1, 2]);
 });
 
-test('Trigger all onParentMouse handlers on Series components', t => {
-  t.plan(14);
+test('Trigger all onParentMouse handlers on Series components', () => {
+  const onParentMouseHandler = jest.fn();
+
   class ExtendedSeries extends AbstractSeries {
-    onParentMouseUp() {
-      t.pass(`onParentMouseUp on ${this.props.name} is called correctly`);
-    }
-    onParentMouseDown() {
-      t.pass(`onParentMouseDown on ${this.props.name} is called correctly`);
-    }
-    onParentMouseMove() {
-      t.pass(`onParentMouseMove on ${this.props.name} is called correctly`);
-    }
-    onParentMouseLeave() {
-      t.pass(`onParentMouseLeave on ${this.props.name} is called correctly`);
-    }
-    onParentMouseEnter() {
-      t.pass(`onParentMouseEnter on ${this.props.name} is called correctly`);
-    }
-    onParentTouchStart() {
-      t.pass(`onParentTouchStart on ${this.props.name} is called correctly`);
-    }
-    onParentTouchMove() {
-      t.pass(`onParentTouchMove on ${this.props.name} is called correctly`);
-    }
+    onParentMouseUp = onParentMouseHandler;
+    onParentMouseDown = onParentMouseHandler;
+    onParentMouseMove = onParentMouseHandler;
+    onParentMouseLeave = onParentMouseHandler;
+    onParentMouseEnter = onParentMouseHandler;
+    onParentTouchStart = onParentMouseHandler;
+    onParentTouchMove = onParentMouseHandler;
     render() {
       return null;
     }
@@ -297,21 +237,16 @@ test('Trigger all onParentMouse handlers on Series components', t => {
     .at(0)
     .simulate('touchmove');
 
-  t.end();
+  expect(onParentMouseHandler).toHaveBeenCalledTimes(14);
 });
 
-test('XYPlot dontCheckIfEmpty - Showcase example EmptyChart', t => {
+test('XYPlot dontCheckIfEmpty - Showcase example EmptyChart', () => {
   const $ = mount(<EmptyChart />);
-  t.equal($.find('.rv-xy-plot__series').length, 0, 'should find no series');
-  t.equal(
-    $.text(),
-    '1!1.5!2!3!Empty Chart Right Here',
-    'should find the correct text'
-  );
-  t.end();
+  expect($.find('.rv-xy-plot__series').length).toBe(0);
+  expect($.text()).toBe('1!1.5!2!3!Empty Chart Right Here');
 });
 
-test('XYPlot attach ref only to series components', t => {
+test('XYPlot attach ref only to series components', () => {
   const Stateless = () => {
     return <div>stateless</div>;
   };
@@ -342,23 +277,14 @@ test('XYPlot attach ref only to series components', t => {
   const statelessChild = clonedChilds.find(
     element => element.type === Stateless
   );
-  t.ok(
-    horizontalGridLinesChild.ref === null,
-    'Ref not attached to non series components'
-  );
-  t.ok(axisChild.ref === null, 'Ref not attached to axis');
-  t.ok(
-    typeof lineSeriesChild.ref === 'function',
-    'Ref attached to series components'
-  );
-  t.ok(statelessChild.ref === null, 'Ref not attached to stateless components');
-  t.end();
+  expect(horizontalGridLinesChild.ref === null).toBeTruthy();
+  expect(axisChild.ref === null).toBeTruthy();
+  expect(typeof lineSeriesChild.ref === 'function').toBeTruthy();
+  expect(statelessChild.ref === null).toBeTruthy();
 });
 
-test('XYPlot with wheel event callback', t => {
-  t.plan(1);
-
-  const onWheel = () => t.pass('onWheel is called correctly');
+test('XYPlot with wheel event callback', () => {
+  const onWheel = jest.fn();
 
   const $ = mount(
     <XYPlot onWheel={onWheel} width={300} height={300}>
@@ -376,5 +302,5 @@ test('XYPlot with wheel event callback', t => {
     .at(0)
     .simulate('wheel');
 
-  t.end();
+  expect(onWheel).toHaveBeenCalledTimes(1);
 });

--- a/packages/react-vis/tests/test-utils.js
+++ b/packages/react-vis/tests/test-utils.js
@@ -1,4 +1,3 @@
-import test from 'tape';
 import React from 'react';
 import {mount} from 'enzyme';
 
@@ -34,18 +33,12 @@ export const GENERIC_XYPLOT_SERIES_PROPS = {
 };
 
 export const testRenderWithProps = (Component, props) =>
-  test(`Rendering ${Component.displayName}`, assert => {
+  test(`Rendering ${Component.displayName}`, () => {
     const wrapper = mount(<Component {...props} />);
     const wrapperProps = wrapper.props();
-    assert.ok(
-      wrapper.find(Component).length,
-      `${Component.displayName} is rendered`
-    );
+    expect(wrapper.find(Component).length).toBeTruthy();
+
     Object.keys(props).forEach(propName => {
-      assert.ok(
-        wrapperProps[propName] === props[propName],
-        `${propName} is set`
-      );
+      expect(wrapperProps[propName] === props[propName]).toBeTruthy();
     });
-    assert.end();
   });

--- a/packages/react-vis/tests/utils/axis-utils-tests.js
+++ b/packages/react-vis/tests/utils/axis-utils-tests.js
@@ -18,7 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import test from 'tape';
 import {scaleLinear} from 'd3-scale';
 import {range} from 'd3-array';
 
@@ -30,54 +29,44 @@ import {
   generatePoints
 } from 'utils/axis-utils';
 
-test('axis-utils #getTicksTotalFromSize', t => {
-  t.ok(getTicksTotalFromSize(0) === 5, 'Returns valid value for 0px');
-  t.ok(getTicksTotalFromSize(301) === 10, 'Returns valid value for 301px');
-  t.ok(getTicksTotalFromSize(701) === 20, 'Returns valid value for 701px');
-  t.end();
+test('axis-utils #getTicksTotalFromSize', () => {
+  expect(getTicksTotalFromSize(0) === 5).toBeTruthy();
+  expect(getTicksTotalFromSize(301) === 10).toBeTruthy();
+  expect(getTicksTotalFromSize(701) === 20).toBeTruthy();
 });
 
-test('axis-utils #getTickValues', t => {
+test('axis-utils #getTickValues', () => {
   const scale = scaleLinear()
     .domain([0, 1])
     .range(['red', 'blue']);
-  t.deepEqual(
-    getTickValues(scale, 10, false).map(d => Math.round(d * 1000) / 1000),
-    [0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1],
-    'should find the correct tick values'
-  );
+  expect(
+    getTickValues(scale, 10, false).map(d => Math.round(d * 1000) / 1000)
+  ).toEqual([0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1]);
 
   const predefinedVals = ['got dang', 1, undefined, 'lolz'];
-  t.deepEqual(
-    getTickValues(scale, 10, predefinedVals),
-    predefinedVals,
-    'should find the correct tick values'
-  );
-
-  t.end();
+  expect(getTickValues(scale, 10, predefinedVals)).toEqual(predefinedVals);
 });
 
-test('axis-utils #getAxisAngle', t => {
-  t.equal(getAxisAngle({x: 0, y: 0}, {x: 1, y: 1}), Math.PI / 4);
-  t.equal(getAxisAngle({x: 0, y: 0}, {x: 0, y: 1}), Math.PI / 2);
-  t.equal(getAxisAngle({x: 0, y: 0}, {x: 0, y: -1}), (3 * Math.PI) / 2);
-  t.end();
+test('axis-utils #getAxisAngle', () => {
+  expect(getAxisAngle({x: 0, y: 0}, {x: 1, y: 1})).toBe(Math.PI / 4);
+  expect(getAxisAngle({x: 0, y: 0}, {x: 0, y: 1})).toBe(Math.PI / 2);
+  expect(getAxisAngle({x: 0, y: 0}, {x: 0, y: -1})).toBe((3 * Math.PI) / 2);
 });
 
-test('axis-utils #generateFit', t => {
-  t.deepEqual(generateFit({x: 0, y: 0}, {x: 1, y: 1}), {
+test('axis-utils #generateFit', () => {
+  expect(generateFit({x: 0, y: 0}, {x: 1, y: 1})).toEqual({
     left: 0,
     offset: 0,
     right: 1,
     slope: 1
   });
-  t.deepEqual(generateFit({x: 0, y: 0}, {x: 0, y: 1}), {
+  expect(generateFit({x: 0, y: 0}, {x: 0, y: 1})).toEqual({
     left: 0,
     offset: 0,
     right: 1,
     slope: 0
   });
-  t.deepEqual(generateFit({x: 0, y: 0}, {x: 0, y: -1}), {
+  expect(generateFit({x: 0, y: 0}, {x: 0, y: -1})).toEqual({
     left: 0,
     offset: 0,
     right: -1,
@@ -93,15 +82,10 @@ test('axis-utils #generateFit', t => {
   const pointSlope = (right - left) / numberOfTicks;
   const lengthOfGeneratedPoints = range(left, right + pointSlope, pointSlope)
     .length;
-  t.equal(
-    lengthOfGeneratedPoints,
-    7,
-    'should be 7, incorrect length of generated points'
-  );
-  t.end();
+  expect(lengthOfGeneratedPoints).toBe(7);
 });
 
-test('axis-utils #generatePoints', t => {
+test('axis-utils #generatePoints', () => {
   const result = generatePoints({
     axisStart: {x: 0, y: 1},
     axisEnd: {x: 1, y: 1},
@@ -169,24 +153,11 @@ test('axis-utils #generatePoints', t => {
     ],
     slope: -4398046511104000
   };
-  t.deepEqual(result, expectedResult);
+  expect(result).toEqual(expectedResult);
 
   // Relies on testing library to handle differences in floating point numbers.
   // t.deepEqual(result2, expectedResult2);
-  t.equal(
-    expectedResult2.points.length,
-    6,
-    'should be 6, correct length of generated points'
-  );
-  t.deepEqual(
-    result3,
-    expectedResult3,
-    'should return correct points when accounting for floating point errors'
-  );
-  t.deepEqual(
-    result4,
-    expectedResult4,
-    'should not return correct points when not accounting for floating point errors'
-  );
-  t.end();
+  expect(expectedResult2.points.length).toBe(6);
+  expect(result3).toEqual(expectedResult3);
+  expect(result4).toEqual(expectedResult4);
 });

--- a/packages/react-vis/tests/utils/chart-utils-tests.js
+++ b/packages/react-vis/tests/utils/chart-utils-tests.js
@@ -18,42 +18,27 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import test from 'tape';
-
 import {getRadialLayoutMargin} from 'utils/chart-utils';
 
-test('chart-utils #getRadialLayoutMargin', t => {
-  t.deepEqual(
-    getRadialLayoutMargin(500, 300, 120),
-    {
-      bottom: 30,
-      left: 130,
-      right: 130,
-      top: 30
-    },
-    'Get the right margin to center the radial layout chart - landscape container'
-  );
+test('chart-utils #getRadialLayoutMargin', () => {
+  expect(getRadialLayoutMargin(500, 300, 120)).toEqual({
+    bottom: 30,
+    left: 130,
+    right: 130,
+    top: 30
+  });
 
-  t.deepEqual(
-    getRadialLayoutMargin(300, 500, 120),
-    {
-      bottom: 130,
-      left: 30,
-      right: 30,
-      top: 130
-    },
-    'Get the right margin to center the radial layout chart  - portrait container'
-  );
+  expect(getRadialLayoutMargin(300, 500, 120)).toEqual({
+    bottom: 130,
+    left: 30,
+    right: 30,
+    top: 130
+  });
 
-  t.deepEqual(
-    getRadialLayoutMargin(300, 300, 120),
-    {
-      bottom: 30,
-      left: 30,
-      right: 30,
-      top: 30
-    },
-    'Get the right margin to center the radial layout chart  - rectangle container'
-  );
-  t.end();
+  expect(getRadialLayoutMargin(300, 300, 120)).toEqual({
+    bottom: 30,
+    left: 30,
+    right: 30,
+    top: 30
+  });
 });

--- a/packages/react-vis/tests/utils/data-utils-tests.js
+++ b/packages/react-vis/tests/utils/data-utils-tests.js
@@ -18,8 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import test from 'tape';
-
 import {
   getUniquePropertyValues,
   addValueToArray,
@@ -28,48 +26,22 @@ import {
 
 const arr = [{a: 1}, {b: 3, a: 2}, {a: 2}];
 
-test('data-utils #getUniquePropertyValues', t => {
+test('data-utils #getUniquePropertyValues', () => {
   const result = getUniquePropertyValues(arr, d => d.a);
-  t.ok(result.length === 2, 'Should return the array of the proper size');
-  t.ok(
-    result.indexOf(1) !== -1 && result.indexOf(2) !== -1,
-    'Should return unique values of the property'
-  );
-  t.end();
+  expect(result.length === 2).toBeTruthy();
+  expect(result.indexOf(1) !== -1 && result.indexOf(2) !== -1).toBeTruthy();
 });
 
-test('data-utils #addValueToArray', t => {
-  t.deepEqual(
-    addValueToArray([-10, 10], 1),
-    [-10, 10],
-    "Shouldn't add the value if the value is in the array"
-  );
-  t.deepEqual(
-    addValueToArray([-10, 0], 1),
-    [-10, 1],
-    'Should add the value if the value is larger'
-  );
-  t.deepEqual(
-    addValueToArray([0, 10], -1),
-    [-1, 10],
-    'Should add the value if the value is smaller'
-  );
-  t.end();
+test('data-utils #addValueToArray', () => {
+  expect(addValueToArray([-10, 10], 1)).toEqual([-10, 10]);
+  expect(addValueToArray([-10, 0], 1)).toEqual([-10, 1]);
+  expect(addValueToArray([0, 10], -1)).toEqual([-1, 10]);
 });
 
-test('data-utils #transformValueToString', t => {
-  t.deepEqual(
-    transformValueToString(0),
-    0,
-    "Shouldn't transform the number value"
-  );
+test('data-utils #transformValueToString', () => {
+  expect(transformValueToString(0)).toEqual(0);
 
   // 43200000 - this is the timestamp for 12PM on 1970-01-01
   // This plays much nicer when running tests locally for different timezones.
-  t.deepEqual(
-    transformValueToString(new Date(43200000)),
-    'Thu Jan 01 1970',
-    'Should transform the date to string value'
-  );
-  t.end();
+  expect(transformValueToString(new Date(43200000))).toEqual('Thu Jan 01 1970');
 });

--- a/packages/react-vis/tests/utils/react-utils-tests.js
+++ b/packages/react-vis/tests/utils/react-utils-tests.js
@@ -1,7 +1,5 @@
 import {isReactDOMSupported} from 'utils/react-utils';
-import test from 'tape';
 
-test('react-utils #isReactDOMSupported', t => {
-  t.ok(isReactDOMSupported(), 'the app is built in a minimum of version 13');
-  t.end();
+test('react-utils #isReactDOMSupported', () => {
+  expect(isReactDOMSupported()).toBeTruthy();
 });

--- a/packages/react-vis/tests/utils/scales-utils-tests.js
+++ b/packages/react-vis/tests/utils/scales-utils-tests.js
@@ -18,7 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import test from 'tape';
 import {
   _adjustCategoricalScale,
   getScaleObjectFromProps,
@@ -55,28 +54,24 @@ const xDomain = [1, 5];
 const xType = 'ordinal';
 const xDistance = 10;
 
-test('scales-utils #getScaleObjectFromProps ', t => {
+test('scales-utils #getScaleObjectFromProps ', () => {
   // with empty props
   const nullResult = getScaleObjectFromProps({}, 'x');
-  t.equal(nullResult, null, 'Should return null if no props available.');
+  expect(nullResult).toBe(null);
   // with empty domain
   const noRangeResult = getScaleObjectFromProps({xDomain}, 'x');
-  t.equal(noRangeResult, null, 'Should be null if no domain is passed');
+  expect(noRangeResult).toBe(null);
   // with empty range
   const noDomainResult = getScaleObjectFromProps({xRange}, 'x');
-  t.equal(noDomainResult, null, 'Should be null if no range is passed');
+  expect(noDomainResult).toBe(null);
 
   // with all props
   const completeResult = getScaleObjectFromProps(
     {xRange, _allData, xDomain, xType, xDistance},
     'x'
   );
-  t.ok(isScaleConsistent(completeResult, 'x'), 'Should be a consistent scale');
-  t.equal(
-    completeResult.type,
-    xType,
-    'Should have same type that was passed by detault'
-  );
+  expect(isScaleConsistent(completeResult, 'x')).toBeTruthy();
+  expect(completeResult.type).toBe(xType);
   // does not mutate passed domain
   const tXDomain = [1, 5];
   const scaleObj = getScaleObjectFromProps(
@@ -91,21 +86,16 @@ test('scales-utils #getScaleObjectFromProps ', t => {
     'x'
   );
 
-  t.deepEqual(scaleObj.domain, [0.5, 5.5], 'Correct adjustment of domain');
-  t.deepEqual(
-    tXDomain,
-    [1, 5],
-    'original domain object should contain the same values'
-  );
+  expect(scaleObj.domain).toEqual([0.5, 5.5]);
+  expect(tXDomain).toEqual([1, 5]);
 
   // with the value that overrides props
   const valueResult = getScaleObjectFromProps({x: 10, _allData}, 'x');
-  t.ok(isScaleConsistent(valueResult, 'x'), 'Should be a consistent scale');
-  t.equal(valueResult.isValue, true, 'Should have isValue = true');
-  t.end();
+  expect(isScaleConsistent(valueResult, 'x')).toBeTruthy();
+  expect(valueResult.isValue).toBe(true);
 });
 
-test('scales-utils #getScalePropTypesByAttribute', t => {
+test('scales-utils #getScalePropTypesByAttribute', () => {
   const result = Object.keys(getScalePropTypesByAttribute('size'));
   const expectedResult = [
     '_sizeValue',
@@ -117,59 +107,33 @@ test('scales-utils #getScalePropTypesByAttribute', t => {
     'sizeDistance',
     'sizeBaseValue'
   ];
-  t.deepEqual(
-    result,
-    expectedResult,
-    'should find the correct scale prop attributes'
-  );
-  t.end();
+  expect(result).toEqual(expectedResult);
 });
 
-test('scales-utils #getAttributeFunctor', t => {
+test('scales-utils #getAttributeFunctor', () => {
   // without props
   let result = getAttributeFunctor({_xValue}, 'x');
-  t.ok(
-    result({x: Math.random()}) === _xValue,
-    `No props: Fallback value ${_xValue} should be returned by the produced functor`
-  );
-  t.equal(
-    result({}),
-    _xValue,
-    'value from the props is used as default value if no argument passed to functor'
-  );
+  expect(result({x: Math.random()}) === _xValue).toBeTruthy();
+  expect(result({})).toBe(_xValue);
   // with props
   result = getAttributeFunctor({xRange, xDomain}, 'x');
   const isFunction = typeof result === 'function';
-  t.ok(isFunction, 'Result should be a function');
-  t.equal(
-    result(_allData[0][0]),
-    xRange[0],
-    'Function should reflect values properly'
-  );
+  expect(isFunction).toBeTruthy();
+  expect(result(_allData[0][0])).toBe(xRange[0]);
 
-  t.equal(
-    result({data: {x: 10}}),
-    225,
-    'should find the correct transformed value'
-  );
+  expect(result({data: {x: 10}})).toBe(225);
 
   // with custom accessor
   result = getAttributeFunctor({xRange, xDomain, getX: d => d.value}, 'x');
-  t.ok(typeof result === 'function', 'Result should be a function');
+  expect(typeof result === 'function').toBeTruthy();
 
-  t.equal(
-    result({data: {x: 10, value: 1}}),
-    0,
-    'should find the correct transformed value'
-  );
-
-  t.end();
+  expect(result({data: {x: 10, value: 1}})).toBe(0);
 });
 
-test('scales-utils #getAttr0Functor', t => {
+test('scales-utils #getAttr0Functor', () => {
   // without props
   let result = getAttr0Functor({}, 'x');
-  t.equal(null, null, 'should get null when given no props');
+  expect(null).toBe(null);
 
   // using a literal scale to check that the fall back is working correctly
   const exNaughtData = [[{x: 1, x0: 1}, {x: 0}, {x: 3, x0: 3}, {x: 2, x0: 4}]];
@@ -183,23 +147,11 @@ test('scales-utils #getAttr0Functor', t => {
     },
     'x'
   );
-  t.ok(typeof result === 'function', 'Result should be a function');
-  t.equal(
-    result(exNaughtData[0][0]),
-    1,
-    'Function should reflect values properly'
-  );
-  t.equal(
-    result(exNaughtData[0][1]),
-    1,
-    'Function should fallback to base value properly'
-  );
+  expect(typeof result === 'function').toBeTruthy();
+  expect(result(exNaughtData[0][0])).toBe(1);
+  expect(result(exNaughtData[0][1])).toBe(1);
 
-  t.equal(
-    result({data: {x: 10, x0: 5}}),
-    5,
-    'should find the correct transformed value'
-  );
+  expect(result({data: {x: 10, x0: 5}})).toBe(5);
 
   // with custom accessor
   result = getAttr0Functor(
@@ -213,12 +165,8 @@ test('scales-utils #getAttr0Functor', t => {
     },
     'x'
   );
-  t.ok(typeof result === 'function', 'Result should be a function');
-  t.equal(
-    result({data: {x: 10, x0: 5, z: 1}}),
-    1,
-    'should find the correct transformed value'
-  );
+  expect(typeof result === 'function').toBeTruthy();
+  expect(result({data: {x: 10, x0: 5, z: 1}})).toBe(1);
 
   // now with a linear scale
   result = getAttr0Functor(
@@ -232,70 +180,52 @@ test('scales-utils #getAttr0Functor', t => {
     'x'
   );
 
-  t.ok(typeof result === 'function', 'Result should be a function');
-  t.equal(
-    result(exNaughtData[0][0]),
-    xRange[0],
-    'Function should reflect values properly'
-  );
-  t.equal(
-    result(exNaughtData[0][1]),
-    0,
-    'Function should fallback to base value properly'
-  );
+  expect(typeof result === 'function').toBeTruthy();
+  expect(result(exNaughtData[0][0])).toBe(xRange[0]);
+  expect(result(exNaughtData[0][1])).toBe(0);
 
-  t.equal(
-    result({data: {x: 10, x0: 5}}),
-    100,
-    'should find the correct transformed value'
-  );
-  t.end();
+  expect(result({data: {x: 10, x0: 5}})).toBe(100);
 });
 
-test('scales-utils #getAttributeScale', t => {
+test('scales-utils #getAttributeScale', () => {
   // without props
   let result = getAttributeScale({}, 'x');
-  t.ok(result === null, 'No props: Result should be null');
+  expect(result === null).toBeTruthy();
   // with props
   result = getAttributeScale({xRange, xDomain}, 'x');
   const isFunction = typeof result === 'function';
-  t.ok(isFunction, 'Result should be a function');
-  t.equal(result(_allData[0][0].x), xRange[0], 'Result scale is valid');
-
-  t.end();
+  expect(isFunction).toBeTruthy();
+  expect(result(_allData[0][0].x)).toBe(xRange[0]);
 });
 
-test('scales-utils #getAttributeValue ', t => {
+test('scales-utils #getAttributeValue ', () => {
   // without props
   let result = getAttributeValue({_xValue}, 'x');
-  t.ok(result === _xValue, 'No Props: Fallback value should be returned');
+  expect(result === _xValue).toBeTruthy();
   // with props
   result = getAttributeValue({x: 10}, 'x');
-  t.equal(result, 10, 'The value should be returned');
+  expect(result).toBe(10);
   // with props including a scale type
   result = getAttributeValue({opacity: 0.5, opacityType: 'literal'}, 'opacity');
-  t.equal(result, 0.5, 'The value should be returned');
-  t.end();
+  expect(result).toBe(0.5);
 });
 
-test('scales-utils #_getSmallestDistanceIndex', t => {
+test('scales-utils #_getSmallestDistanceIndex', () => {
   const scaleObj = {type: 'linear', domain: [0, 1], range: [0, 1]};
   const runTest = arg => _getSmallestDistanceIndex(arg, scaleObj);
 
-  t.equal(runTest([0, 0, 2]), 1);
-  t.equal(runTest([0, 1, 2]), 1);
-  t.equal(runTest([0, 2, 2]), 2);
-  t.equal(runTest([0, 2, 2]), 2);
-  t.equal(runTest([1, 2, 2]), 2);
-  t.equal(runTest([2, 2, 2]), 1);
-  t.end();
+  expect(runTest([0, 0, 2])).toBe(1);
+  expect(runTest([0, 1, 2])).toBe(1);
+  expect(runTest([0, 2, 2])).toBe(2);
+  expect(runTest([0, 2, 2])).toBe(2);
+  expect(runTest([1, 2, 2])).toBe(2);
+  expect(runTest([2, 2, 2])).toBe(1);
 });
 
-test('scales-utils #extractScalePropsFromProps', t => {
-  t.ok(
-    Object.keys(extractScalePropsFromProps({}, [])).length === 0,
-    'Should return empty object on empty values'
-  );
+test('scales-utils #extractScalePropsFromProps', () => {
+  expect(
+    Object.keys(extractScalePropsFromProps({}, [])).length === 0
+  ).toBeTruthy();
 
   const props = {
     aType: 'linear',
@@ -307,19 +237,17 @@ test('scales-utils #extractScalePropsFromProps', t => {
   };
 
   const result = extractScalePropsFromProps(props, ['a', 'b']);
-  t.ok(
+  expect(
     Object.keys(result).length === 5 &&
       result.aType === props.aType &&
       result.aRange === props.aRange &&
       result._aValue === props._aValue &&
       result.bDomain === props.bDomain &&
-      result.getA === props.getA,
-    'Should return valid object'
-  );
-  t.end();
+      result.getA === props.getA
+  ).toBeTruthy();
 });
 
-test('scales-utils #getMissingScaleProps', t => {
+test('scales-utils #getMissingScaleProps', () => {
   const fakeDataInteger = [
     {x: 10, y: 10},
     {x: 15, y: 15},
@@ -336,33 +264,26 @@ test('scales-utils #getMissingScaleProps', t => {
   const paddedDayTen = dayTen + (dayTen - dayOne) * 0.1;
   const fakePadding = 10;
 
-  t.equal(
-    Object.keys(getMissingScaleProps({}, [], [])).length,
-    0,
-    'Should return empty result on empty arguments'
-  );
+  expect(Object.keys(getMissingScaleProps({}, [], [])).length).toBe(0);
   const result = getMissingScaleProps({}, _allData[0], ['x']);
-  t.ok(
+  expect(
     Boolean(result.xDomain) &&
       result.xDomain.length === 2 &&
       result.xDomain[0] === 1 &&
-      result.xDomain[1] === 3,
-    'Should return a valid object'
-  );
+      result.xDomain[1] === 3
+  ).toBeTruthy();
 
-  t.deepEqual(
+  expect(
     getMissingScaleProps(
       {
         xPadding: fakePadding
       },
       fakeDataInteger,
       ['x']
-    ).xDomain,
-    fakeDataIntegerDomain,
-    'should pad number xDomain'
-  );
+    ).xDomain
+  ).toEqual(fakeDataIntegerDomain);
   // need to use json stringify to peel off the functions
-  t.deepEqual(
+  expect(
     JSON.stringify(
       getMissingScaleProps(
         {
@@ -372,11 +293,9 @@ test('scales-utils #getMissingScaleProps', t => {
         fakeDataInteger,
         ['x']
       )
-    ),
-    '{}',
-    'should not pad if xDomain is already supplied'
-  );
-  t.deepEqual(
+    )
+  ).toEqual('{}');
+  expect(
     Object.keys(
       getMissingScaleProps(
         {
@@ -386,82 +305,57 @@ test('scales-utils #getMissingScaleProps', t => {
         fakeDataInteger,
         ['x']
       )
-    ),
-    ['getX', 'getX0'],
-    'should not pad if xDomain is already supplied, but accessors should be present'
-  );
-  t.deepEqual(
+    )
+  ).toEqual(['getX', 'getX0']);
+  expect(
     getMissingScaleProps(
       {
         yPadding: fakePadding
       },
       fakeDataInteger,
       ['y']
-    ).yDomain,
-    fakeDataIntegerDomain,
-    'should pad number yDomain'
-  );
-  t.deepEqual(
+    ).yDomain
+  ).toEqual(fakeDataIntegerDomain);
+  expect(
     getMissingScaleProps(
       {
         xPadding: fakePadding
       },
       fakeDataString,
       ['x']
-    ).xDomain,
-    fakeDataStringDomain,
-    'should not pad non-number domain'
-  );
-  t.deepEqual(
+    ).xDomain
+  ).toEqual(fakeDataStringDomain);
+  expect(
     getMissingScaleProps(
       {
         xPadding: fakePadding
       },
       fakeDataUnixTime,
       ['x']
-    ).xDomain,
-    [paddedDayOne, paddedDayTen],
-    'should pad unix time xDomain'
-  );
-  t.end();
+    ).xDomain
+  ).toEqual([paddedDayOne, paddedDayTen]);
 });
 
-test('scales-utils #literalScale', t => {
+test('scales-utils #literalScale', () => {
   const s = literalScale(5);
 
-  t.equal(s(0.5), 0.5, 'acts as the identity');
-  t.equal(s(1), 1, 'acts as the identity');
-  t.equal(s(1.5), 1.5, 'acts as the identity');
-  t.equal(s(2), 2, 'acts as the identity');
-  t.equal(s(2.5), 2.5, 'acts as the identity');
-  t.equal(s(), 5, 'accepts a default value');
-  t.equal(s('2'), '2', 'does NOT coerce input to a number');
-
-  t.end();
+  expect(s(0.5)).toBe(0.5);
+  expect(s(1)).toBe(1);
+  expect(s(1.5)).toBe(1.5);
+  expect(s(2)).toBe(2);
+  expect(s(2.5)).toBe(2.5);
+  expect(s()).toBe(5);
+  expect(s('2')).toBe('2');
 });
 
-test('scales-utils #getFontColorFromBackground', t => {
-  t.equal(
-    getFontColorFromBackground('#fff'),
-    '#222',
-    'should find correct color'
-  );
-  t.equal(
-    getFontColorFromBackground('#000'),
-    '#fff',
-    'should find correct color'
-  );
-  t.equal(getFontColorFromBackground(null), null, 'sensible default');
-
-  t.end();
+test('scales-utils #getFontColorFromBackground', () => {
+  expect(getFontColorFromBackground('#fff')).toBe('#222');
+  expect(getFontColorFromBackground('#000')).toBe('#fff');
+  expect(getFontColorFromBackground(null)).toBe(null);
 });
 
-test('scales-utils #getScaleFnFromScaleObject', t => {
-  t.equal(
-    getScaleFnFromScaleObject(),
-    null,
-    'should recieve null for undefined'
-  );
+test('scales-utils #getScaleFnFromScaleObject', () => {
+  expect(getScaleFnFromScaleObject()).toBe(null);
   const linearScale = getScaleFnFromScaleObject({
     type: 'linear',
     domain: [0, 1],
@@ -474,41 +368,25 @@ test('scales-utils #getScaleFnFromScaleObject', t => {
     range: [5]
   });
 
-  t.deepEqual(linearScale.domain(), [0, 1], 'should set the domain correctly');
-  t.deepEqual(linearScale.range(), [1, 0], 'should set the range correctly');
+  expect(linearScale.domain()).toEqual([0, 1]);
+  expect(linearScale.range()).toEqual([1, 0]);
 
-  t.deepEqual(
-    literalScaleWithDefaultValue(),
-    5,
-    'literal scale should handle default values'
-  );
-  t.deepEqual(
-    literalScaleWithDefaultValue(2),
-    2,
-    'literal scale should work as such with argument'
-  );
+  expect(literalScaleWithDefaultValue()).toEqual(5);
+  expect(literalScaleWithDefaultValue(2)).toEqual(2);
 
   const modScaleWithZero = getScaleFnFromScaleObject({
     type: 'linear',
     domain: [0, 0],
     range: [1, 0]
   });
-  t.deepEqual(
-    modScaleWithZero.domain(),
-    [-1, 0],
-    'should build a generic domain about zero if the domain is closed'
-  );
+  expect(modScaleWithZero.domain()).toEqual([-1, 0]);
 
   const modScale = getScaleFnFromScaleObject({
     type: 'linear',
     domain: [1, 1],
     range: [1, 0]
   });
-  t.deepEqual(
-    modScale.domain(),
-    [-1, 1],
-    'should build a generic domain that reflects about zero'
-  );
+  expect(modScale.domain()).toEqual([-1, 1]);
 
   const ordinalScale = getScaleFnFromScaleObject({
     type: 'ordinal',
@@ -516,23 +394,21 @@ test('scales-utils #getScaleFnFromScaleObject', t => {
     range: [20, 120]
   });
 
-  t.equal(ordinalScale.invert(-10), 'a');
-  t.equal(ordinalScale.invert(25), 'a');
-  t.equal(ordinalScale.invert(40), 'a');
-  t.equal(ordinalScale.invert(60), 'b');
-  t.equal(ordinalScale.invert(80), 'c');
-  t.equal(ordinalScale.invert(100), 'd');
-  t.equal(ordinalScale.invert(115), 'e');
-  t.equal(ordinalScale.invert(130), 'e');
-
-  t.end();
+  expect(ordinalScale.invert(-10)).toBe('a');
+  expect(ordinalScale.invert(25)).toBe('a');
+  expect(ordinalScale.invert(40)).toBe('a');
+  expect(ordinalScale.invert(60)).toBe('b');
+  expect(ordinalScale.invert(80)).toBe('c');
+  expect(ordinalScale.invert(100)).toBe('d');
+  expect(ordinalScale.invert(115)).toBe('e');
+  expect(ordinalScale.invert(130)).toBe('e');
 });
 
 function generateFakeData() {
   return new Array(100).fill(0).map((zero, i) => ({xxxx: i}));
 }
 
-test('scales-utils #_getScaleDistanceAndAdjustedDomain', t => {
+test('scales-utils #_getScaleDistanceAndAdjustedDomain', () => {
   const FAKE_DATA = generateFakeData();
   const scaleObject = {
     attr: 'x',
@@ -551,7 +427,7 @@ test('scales-utils #_getScaleDistanceAndAdjustedDomain', t => {
     domain0: -0.5,
     domainN: 100.5
   };
-  t.deepEqual(resultObject, expectedResults, 'should find reasonable results');
+  expect(resultObject).toEqual(expectedResults);
 
   const FAKE_TIME_DATA_WITH_ONE_VALUE_AND_X0 = [
     {
@@ -586,10 +462,8 @@ test('scales-utils #_getScaleDistanceAndAdjustedDomain', t => {
     domain0: 1416207600000,
     domainN: 1431759600000
   };
-  t.deepEqual(
-    timeResultWithOneValueAndX0,
-    expectedTimeResultsWithOneValueAndX0,
-    'should fine reasonable results for time _getScaleDistanceAndAdjustedDomain'
+  expect(timeResultWithOneValueAndX0).toEqual(
+    expectedTimeResultsWithOneValueAndX0
   );
 
   const timeScaleObjectY = {
@@ -609,10 +483,8 @@ test('scales-utils #_getScaleDistanceAndAdjustedDomain', t => {
     domain0: 1416207600000,
     domainN: 1431759600000
   };
-  t.deepEqual(
-    timeResultWithOneValueAndY0,
-    expectedTimeResultsWithOneValueAndY0,
-    'should find reasonable results for y time _getScaleDistanceAndAdjustedDomain'
+  expect(timeResultWithOneValueAndY0).toEqual(
+    expectedTimeResultsWithOneValueAndY0
   );
 
   const timeResult = _getScaleDistanceAndAdjustedDomain(FAKE_DATA, {
@@ -624,11 +496,7 @@ test('scales-utils #_getScaleDistanceAndAdjustedDomain', t => {
     domain0: 1417546799999.5,
     domainN: 1430420400000.5
   };
-  t.deepEqual(
-    timeResult,
-    expectedTimeResults,
-    'should fine reasonable results for a time scale'
-  );
+  expect(timeResult).toEqual(expectedTimeResults);
 
   const logScaleObject = {
     attr: 'x',
@@ -642,16 +510,10 @@ test('scales-utils #_getScaleDistanceAndAdjustedDomain', t => {
     logScaleObject
   );
   const expectedLogResults = {distance: NaN, domain0: 0.1, domainN: 1.5};
-  t.deepEqual(
-    logResult,
-    expectedLogResults,
-    'should fine reasonable results for a log scale'
-  );
-
-  t.end();
+  expect(logResult).toEqual(expectedLogResults);
 });
 
-test('scales-utils getXYPlotValues', t => {
+test('scales-utils getXYPlotValues', () => {
   const XYPlotProps = {
     colorType: 'linear',
     colorRange: ['#000', '#fff'],
@@ -663,20 +525,11 @@ test('scales-utils getXYPlotValues', t => {
     {props: {color: 1}}
   ];
   const result = getXYPlotValues(XYPlotProps, children);
-  t.equals(
-    result[2]._colorValue,
-    'rgb(255, 255, 255)',
-    'children can be colored through a XYPlot scale'
-  );
-  t.equals(
-    result[1]._opacityValue,
-    '0.5',
-    'children can have fallback values without a XYPlot scale'
-  );
-  t.end();
+  expect(result[2]._colorValue).toBe('rgb(255, 255, 255)');
+  expect(result[1]._opacityValue).toBe('0.5');
 });
 
-test('scales-utils #_adjustCategoricalScale', t => {
+test('scales-utils #_adjustCategoricalScale', () => {
   [
     {
       scale: {type: 'category', domain: ['a', 'b', 'c'], range: [0, 10]},
@@ -695,18 +548,13 @@ test('scales-utils #_adjustCategoricalScale', t => {
       distance: 9
     }
   ].forEach(({scale, distance}) => {
-    t.deepEqual(
-      _adjustCategoricalScale(scale),
-      {...scale, distance},
-      'should correctly adjust a categorical scale'
-    );
+    expect(_adjustCategoricalScale(scale)).toEqual({...scale, distance});
   });
-  t.end();
 });
 
-test('scale-utils #getOptionalScaleProps', t => {
+test('scale-utils #getOptionalScaleProps', () => {
   const foundProps = getOptionalScaleProps({node: 1, x: 2, margins: 4});
-  t.deepEqual(foundProps, {}, 'should not find any non-padding optional props');
+  expect(foundProps).toEqual({});
 
   const paddingProps = getOptionalScaleProps({
     node: 1,
@@ -714,10 +562,5 @@ test('scale-utils #getOptionalScaleProps', t => {
     margins: 4,
     coolDogExplosionPadding: 10
   });
-  t.deepEqual(
-    paddingProps,
-    {coolDogExplosionPadding: 10},
-    'should find only padding optional props'
-  );
-  t.end();
+  expect(paddingProps).toEqual({coolDogExplosionPadding: 10});
 });

--- a/packages/react-vis/tests/utils/series-utils-tests.js
+++ b/packages/react-vis/tests/utils/series-utils-tests.js
@@ -18,7 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import test from 'tape';
 import React from 'react';
 import {mount} from 'enzyme';
 
@@ -34,9 +33,9 @@ import HorizontalBarSeries from 'plot/series/horizontal-rect-series';
 import VerticalBarSeries from 'plot/series/vertical-rect-series';
 import LabelSeries from 'plot/series/label-series';
 
-test('series-utils #isSeriesChild', t => {
+test('series-utils #isSeriesChild', () => {
   const series = <LineSeries data={[]} />;
-  t.ok(isSeriesChild(series), 'Should return true for series');
+  expect(isSeriesChild(series)).toBeTruthy();
   const axis = (
     <XAxis
       xRange={[0, 1]}
@@ -48,11 +47,10 @@ test('series-utils #isSeriesChild', t => {
       left={0}
     />
   );
-  t.notOk(isSeriesChild(axis), 'Should return false for non-series');
-  t.end();
+  expect(isSeriesChild(axis)).toBeFalsy();
 });
 
-test('series-utils #getSeriesChildren', t => {
+test('series-utils #getSeriesChildren', () => {
   const children = [
     <span key="wild"> This squid is heavy </span>,
     <input key="wacky" placeholder="i wish i hadnt bought it" />,
@@ -64,12 +62,7 @@ test('series-utils #getSeriesChildren', t => {
     </div>
   );
   const expectedChildren = [{...children[2], key: '.$woah'}];
-  t.deepEqual(
-    getSeriesChildren($.props().children),
-    expectedChildren,
-    'should find the correct children'
-  );
-  t.end();
+  expect(getSeriesChildren($.props().children)).toEqual(expectedChildren);
 });
 
 const arePropsValid = seriesProps => {
@@ -82,19 +75,16 @@ const arePropsValid = seriesProps => {
   );
 };
 
-test('series-utils #collectSeriesTypesInfo', t => {
+test('series-utils #collectSeriesTypesInfo', () => {
   const result = getSeriesPropsFromChildren([
     <LineSeries data={[]} />,
     <LineSeries data={[]} />
   ]);
-  t.ok(result.length === 2, 'Returns array of proper size');
-  result.forEach((props, i) =>
-    t.ok(arePropsValid(props), `Props #${i} are valid`)
-  );
-  t.end();
+  expect(result.length === 2).toBeTruthy();
+  result.forEach(props => expect(arePropsValid(props)).toBeTruthy());
 });
 
-test('series-utils #seriesClusterProps', t => {
+test('series-utils #seriesClusterProps', () => {
   const result = getSeriesPropsFromChildren([
     <HorizontalBarSeries cluster="alpha" data={[]} />,
     <HorizontalBarSeries cluster="beta" data={[]} />,
@@ -102,23 +92,18 @@ test('series-utils #seriesClusterProps', t => {
     <HorizontalBarSeries cluster="gamma" data={[]} />
   ]);
   const expectedClusters = ['alpha', 'beta', 'gamma'];
-  t.ok(result.length === 4, 'Returns array of proper size');
+  expect(result.length === 4).toBeTruthy();
   result.forEach(props => {
-    t.ok(props.sameTypeIndex === expectedClusters.indexOf(props.cluster));
-    t.ok(
-      props.sameTypeTotal === props.clusters.length,
-      'SameTypeTotal is set correctly'
-    );
-    t.ok(
-      props.clusters.length === 3,
-      'Returns correct number of unique clusters'
-    );
+    expect(
+      props.sameTypeIndex === expectedClusters.indexOf(props.cluster)
+    ).toBeTruthy();
+    expect(props.sameTypeTotal === props.clusters.length).toBeTruthy();
+    expect(props.clusters.length === 3).toBeTruthy();
   });
-  t.end();
 });
 
 // eslint-disable-next-line max-statements
-test('series-utils #getStackedData', t => {
+test('series-utils #getStackedData', () => {
   const yData = [
     [
       {y: 2, x: 10},
@@ -197,11 +182,7 @@ test('series-utils #getStackedData', t => {
   ];
 
   let results = getStackedData(children, 'y');
-  t.deepEqual(
-    results,
-    stackByYExpected,
-    'should find the correct results for stacking by y'
-  );
+  expect(results).toEqual(stackByYExpected);
 
   children = [
     <HorizontalBarSeries data={yData[0]} />,
@@ -210,11 +191,7 @@ test('series-utils #getStackedData', t => {
   ];
   results = getStackedData(children, 'x');
 
-  t.deepEqual(
-    results,
-    stackByXExpected,
-    'should find the correct results for stacking by x'
-  );
+  expect(results).toEqual(stackByXExpected);
 
   children = [
     <HorizontalBarSeries cluster="alpha" data={yData[0]} />,
@@ -228,11 +205,7 @@ test('series-utils #getStackedData', t => {
     ...stackByXExpected.slice(0, 2)
   ];
 
-  t.deepEqual(
-    results,
-    expectedResults,
-    'should find the correct results for stacking bar clusters by x'
-  );
+  expect(results).toEqual(expectedResults);
 
   children = [
     <VerticalBarSeries cluster="alpha" data={xData[0]} />,
@@ -245,11 +218,7 @@ test('series-utils #getStackedData', t => {
     ...stackByYExpected.slice(0, 2),
     ...stackByYExpected.slice(0, 2)
   ];
-  t.deepEqual(
-    results,
-    expectedResults,
-    'should find the correct results for stacking bar clusters by y'
-  );
+  expect(results).toEqual(expectedResults);
 
   children = [
     <HorizontalBarSeries cluster="alpha" data={partialYData[0]} />,
@@ -259,11 +228,7 @@ test('series-utils #getStackedData', t => {
   ];
   results = getStackedData(children, 'x');
   expectedResults = [...stackByXExpectedPartial, ...stackByXExpectedPartial];
-  t.deepEqual(
-    results,
-    expectedResults,
-    'should find the correct results for stacking bar clusters by x with incomplete data'
-  );
+  expect(results).toEqual(expectedResults);
 
   children = [
     <VerticalBarSeries cluster="alpha" data={partialXData[0]} />,
@@ -274,11 +239,7 @@ test('series-utils #getStackedData', t => {
   results = getStackedData(children, 'y');
   expectedResults = [...stackByYExpectedPartial, ...stackByYExpectedPartial];
 
-  t.deepEqual(
-    results,
-    expectedResults,
-    'should find the correct results for stacking bar clusters by y with incomplete data'
-  );
+  expect(results).toEqual(expectedResults);
 
   children = [
     <VerticalBarSeries data={yData[0]} stack />,
@@ -302,11 +263,7 @@ test('series-utils #getStackedData', t => {
     ],
     yData[1]
   ];
-  t.deepEqual(
-    results,
-    expectedResults,
-    'should find the correct results for stacking by y only the bars'
-  );
+  expect(results).toEqual(expectedResults);
 
   children = [
     <VerticalBarSeries cluster="alpha" data={xData[0]} stack />,
@@ -321,11 +278,7 @@ test('series-utils #getStackedData', t => {
     ...stackByYExpected.slice(0, 2),
     xData[1]
   ];
-  t.deepEqual(
-    results,
-    expectedResults,
-    'should find the correct results for stacking bar clusters by y with a non stacked line'
-  );
+  expect(results).toEqual(expectedResults);
 
   children = [
     <VerticalBarSeries data={xData[0]} />,
@@ -339,11 +292,5 @@ test('series-utils #getStackedData', t => {
     ...stackByYExpected.slice(0, 2)
   ];
 
-  t.deepEqual(
-    results,
-    expectedResults,
-    'should find the correct results for stacking by x, where different series types are calculated separately'
-  );
-
-  t.end();
+  expect(results).toEqual(expectedResults);
 });

--- a/packages/react-vis/tests/utils/styling-utils-tests.js
+++ b/packages/react-vis/tests/utils/styling-utils-tests.js
@@ -18,11 +18,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import test from 'tape';
-
 import {getCombinedClassName} from 'utils/styling-utils';
 
-test('styling-utils #getCombinedClassName', t => {
+test('styling-utils #getCombinedClassName', () => {
   const allValidStringParams = [
     'test_class--1',
     'test_class--2',
@@ -40,23 +38,15 @@ test('styling-utils #getCombinedClassName', t => {
     }
   ];
 
-  t.equal(
-    getCombinedClassName(...allValidStringParams),
-    expectedAllValidStringParamsCombined,
-    'generated class signature should contain all valid class names'
+  expect(getCombinedClassName(...allValidStringParams)).toBe(
+    expectedAllValidStringParamsCombined
   );
 
-  t.equal(
-    getCombinedClassName(...allValidStringParams, ...falsyValues),
-    expectedAllValidStringParamsCombined,
-    'generated class signature does not contain falsy values'
+  expect(getCombinedClassName(...allValidStringParams, ...falsyValues)).toBe(
+    expectedAllValidStringParamsCombined
   );
 
-  t.equal(
-    getCombinedClassName(...allValidStringParams, ...nonStringValues),
-    expectedAllValidStringParamsCombined,
-    'generated class signature does not contain non-string values'
-  );
-
-  t.end();
+  expect(
+    getCombinedClassName(...allValidStringParams, ...nonStringValues)
+  ).toBe(expectedAllValidStringParamsCombined);
 });

--- a/packages/showcase/webpack.config.js
+++ b/packages/showcase/webpack.config.js
@@ -11,7 +11,7 @@ const jsRule = {
   exclude: [/node_modules/],
   options: {
     rootMode: 'upward'
-  },
+  }
 };
 const isProd = process.env.NODE_ENV === 'production';
 const config = isProd
@@ -24,7 +24,10 @@ const config = isProd
       },
 
       resolve: {
-        modules: ['node_modules', path.join(__dirname,'..', 'react-vis', 'src')],
+        modules: [
+          'node_modules',
+          path.join(__dirname, '..', 'react-vis', 'src')
+        ]
       },
 
       module: {

--- a/packages/website/webpack.config.js
+++ b/packages/website/webpack.config.js
@@ -10,8 +10,8 @@ module.exports = {
         exclude: [/node_modules/],
         options: {
           rootMode: 'upward'
-        },
-      },
+        }
+      }
     ]
   },
   resolve: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -41,7 +41,7 @@
     invariant "^2.2.4"
     semver "^5.5.0"
 
-"@babel/core@^7.0.0", "@babel/core@^7.4.5", "@babel/core@^7.7.5":
+"@babel/core@^7.0.0", "@babel/core@^7.1.0", "@babel/core@^7.4.5", "@babel/core@^7.7.5":
   version "7.9.6"
   resolved "https://registry.yarnpkg.com/@babel%2fcore/-/core-7.9.6.tgz#d9aa1f580abf3b2286ef40b6904d390904c63376"
   integrity sha1-2aofWAq/OyKG70C2kE05CQTGM3Y=
@@ -63,7 +63,7 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/generator@^7.4.0", "@babel/generator@^7.9.6":
+"@babel/generator@^7.9.6":
   version "7.9.6"
   resolved "https://registry.yarnpkg.com/@babel%2fgenerator/-/generator-7.9.6.tgz#5408c82ac5de98cda0d77d8124e99fa1f2170a43"
   integrity sha1-VAjIKsXemM2g132BJOmfofIXCkM=
@@ -306,7 +306,7 @@
     resolve "^1.13.1"
     v8flags "^3.1.1"
 
-"@babel/parser@^7.4.3", "@babel/parser@^7.7.0", "@babel/parser@^7.8.6", "@babel/parser@^7.9.6":
+"@babel/parser@^7.1.0", "@babel/parser@^7.7.0", "@babel/parser@^7.8.6", "@babel/parser@^7.9.6":
   version "7.9.6"
   resolved "https://registry.yarnpkg.com/@babel%2fparser/-/parser-7.9.6.tgz#3b1bbb30dabe600cd72db58720998376ff653bc7"
   integrity sha1-Oxu7MNq+YAzXLbWHIJmDdv9lO8c=
@@ -401,12 +401,26 @@
     "@babel/helper-create-regexp-features-plugin" "^7.8.8"
     "@babel/helper-plugin-utils" "^7.8.3"
 
-"@babel/plugin-syntax-async-generators@^7.8.0":
+"@babel/plugin-syntax-async-generators@^7.8.0", "@babel/plugin-syntax-async-generators@^7.8.4":
   version "7.8.4"
-  resolved "https://registry.yarnpkg.com/@babel%2fplugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz#a983fb1aeb2ec3f6ed042a210f640e90e786fe0d"
-  integrity sha1-qYP7Gusuw/btBCohD2QOkOeG/g0=
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz#a983fb1aeb2ec3f6ed042a210f640e90e786fe0d"
+  integrity sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
+
+"@babel/plugin-syntax-bigint@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz#4c9a6f669f5d0cdf1b90a1671e9a146be5300cea"
+  integrity sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.0"
+
+"@babel/plugin-syntax-class-properties@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.8.3.tgz#6cb933a8872c8d359bfde69bbeaae5162fd1e8f7"
+  integrity sha512-UcAyQWg2bAN647Q+O811tG9MrJ38Z10jjhQdKNAL8fsyPzE3cCN/uT+f55cFVY4aGO4jqJAvmqsuY3GQDwAoXg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.3"
 
 "@babel/plugin-syntax-dynamic-import@^7.2.0", "@babel/plugin-syntax-dynamic-import@^7.8.0":
   version "7.8.3"
@@ -429,10 +443,10 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
 
-"@babel/plugin-syntax-json-strings@^7.8.0":
+"@babel/plugin-syntax-json-strings@^7.8.0", "@babel/plugin-syntax-json-strings@^7.8.3":
   version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel%2fplugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz#01ca21b668cd8218c9e640cb6dd88c5412b2c96a"
-  integrity sha1-AcohtmjNghjJ5kDLbdiMVBKyyWo=
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz#01ca21b668cd8218c9e640cb6dd88c5412b2c96a"
+  integrity sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
@@ -443,10 +457,17 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
 
-"@babel/plugin-syntax-nullish-coalescing-operator@^7.8.0":
+"@babel/plugin-syntax-logical-assignment-operators@^7.8.3":
   version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel%2fplugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz#167ed70368886081f74b5c36c65a88c03b66d1a9"
-  integrity sha1-Fn7XA2iIYIH3S1w2xlqIwDtm0ak=
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.8.3.tgz#3995d7d7ffff432f6ddc742b47e730c054599897"
+  integrity sha512-Zpg2Sgc++37kuFl6ppq2Q7Awc6E6AIW671x5PY8E/f7MCIyPPGK/EoeZXvvY3P42exZ3Q4/t3YOzP/HiN79jDg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.3"
+
+"@babel/plugin-syntax-nullish-coalescing-operator@^7.8.0", "@babel/plugin-syntax-nullish-coalescing-operator@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz#167ed70368886081f74b5c36c65a88c03b66d1a9"
+  integrity sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
@@ -457,24 +478,24 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
 
-"@babel/plugin-syntax-object-rest-spread@^7.8.0":
+"@babel/plugin-syntax-object-rest-spread@^7.8.0", "@babel/plugin-syntax-object-rest-spread@^7.8.3":
   version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel%2fplugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz#60e225edcbd98a640332a2e72dd3e66f1af55871"
-  integrity sha1-YOIl7cvZimQDMqLnLdPmbxr1WHE=
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz#60e225edcbd98a640332a2e72dd3e66f1af55871"
+  integrity sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-optional-catch-binding@^7.8.0":
+"@babel/plugin-syntax-optional-catch-binding@^7.8.0", "@babel/plugin-syntax-optional-catch-binding@^7.8.3":
   version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel%2fplugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz#6111a265bcfb020eb9efd0fdfd7d26402b9ed6c1"
-  integrity sha1-YRGiZbz7Ag6579D9/X0mQCue1sE=
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz#6111a265bcfb020eb9efd0fdfd7d26402b9ed6c1"
+  integrity sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-optional-chaining@^7.8.0":
+"@babel/plugin-syntax-optional-chaining@^7.8.0", "@babel/plugin-syntax-optional-chaining@^7.8.3":
   version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel%2fplugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz#4f69c2ab95167e0180cd5336613f8c5788f7d48a"
-  integrity sha1-T2nCq5UWfgGAzVM2YT+MV4j31Io=
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz#4f69c2ab95167e0180cd5336613f8c5788f7d48a"
+  integrity sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
@@ -909,7 +930,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/template@^7.4.0", "@babel/template@^7.8.3", "@babel/template@^7.8.6":
+"@babel/template@^7.3.3", "@babel/template@^7.8.3", "@babel/template@^7.8.6":
   version "7.8.6"
   resolved "https://registry.yarnpkg.com/@babel%2ftemplate/-/template-7.8.6.tgz#86b22af15f828dfb086474f964dcc3e39c43ce2b"
   integrity sha1-hrIq8V+CjfsIZHT5ZNzD45xDzis=
@@ -918,7 +939,7 @@
     "@babel/parser" "^7.8.6"
     "@babel/types" "^7.8.6"
 
-"@babel/traverse@^7.4.3", "@babel/traverse@^7.7.0", "@babel/traverse@^7.8.3", "@babel/traverse@^7.9.6":
+"@babel/traverse@^7.1.0", "@babel/traverse@^7.7.0", "@babel/traverse@^7.8.3", "@babel/traverse@^7.9.6":
   version "7.9.6"
   resolved "https://registry.yarnpkg.com/@babel%2ftraverse/-/traverse-7.9.6.tgz#5540d7577697bf619cc57b92aa0f1c231a94f442"
   integrity sha1-VUDXV3aXv2GcxXuSqg8cIxqU9EI=
@@ -933,7 +954,7 @@
     globals "^11.1.0"
     lodash "^4.17.13"
 
-"@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.7.0", "@babel/types@^7.8.3", "@babel/types@^7.8.6", "@babel/types@^7.9.0", "@babel/types@^7.9.5", "@babel/types@^7.9.6":
+"@babel/types@^7.0.0", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.7.0", "@babel/types@^7.8.3", "@babel/types@^7.8.6", "@babel/types@^7.9.0", "@babel/types@^7.9.5", "@babel/types@^7.9.6":
   version "7.9.6"
   resolved "https://registry.yarnpkg.com/@babel%2ftypes/-/types-7.9.6.tgz#2c5502b427251e9de1bd2dff95add646d95cc9f7"
   integrity sha1-LFUCtCclHp3hvS3/la3WRtlcyfc=
@@ -946,6 +967,19 @@
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@base2%2fpretty-print-object/-/pretty-print-object-1.0.0.tgz#860ce718b0b73f4009e153541faff2cb6b85d047"
   integrity sha1-hgznGLC3P0AJ4VNUH6/yy2uF0Ec=
+
+"@bcoe/v8-coverage@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
+  integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
+
+"@cnakazawa/watch@^1.0.3":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.4.tgz#f864ae85004d0fcab6f50be9141c4da368d1656a"
+  integrity sha512-v9kIhKwjeZThiWrLmj0y17CWoyddASLj9O2yvbZkbvw/N3rWOYy9zkV66ursAoVr0mV15bL8g0c4QZUE6cdDoQ==
+  dependencies:
+    exec-sh "^0.3.2"
+    minimist "^1.2.0"
 
 "@emotion/cache@^10.0.27", "@emotion/cache@^10.0.9":
   version "10.0.29"
@@ -1054,6 +1088,190 @@
   resolved "https://registry.yarnpkg.com/@icons%2fmaterial/-/material-0.2.4.tgz#e90c9f71768b3736e76d7dd6783fc6c2afa88bc8"
   integrity sha1-6QyfcXaLNzbnbX3WeD/Gwq+oi8g=
 
+"@istanbuljs/load-nyc-config@^1.0.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"
+  integrity sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==
+  dependencies:
+    camelcase "^5.3.1"
+    find-up "^4.1.0"
+    get-package-type "^0.1.0"
+    js-yaml "^3.13.1"
+    resolve-from "^5.0.0"
+
+"@istanbuljs/schema@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.2.tgz#26520bf09abe4a5644cd5414e37125a8954241dd"
+  integrity sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==
+
+"@jest/console@^25.5.0":
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/@jest/console/-/console-25.5.0.tgz#770800799d510f37329c508a9edd0b7b447d9abb"
+  integrity sha512-T48kZa6MK1Y6k4b89sexwmSF4YLeZS/Udqg3Jj3jG/cHH+N/sLFCEoXEDMOKugJQ9FxPN1osxIknvKkxt6MKyw==
+  dependencies:
+    "@jest/types" "^25.5.0"
+    chalk "^3.0.0"
+    jest-message-util "^25.5.0"
+    jest-util "^25.5.0"
+    slash "^3.0.0"
+
+"@jest/core@^25.5.4":
+  version "25.5.4"
+  resolved "https://registry.yarnpkg.com/@jest/core/-/core-25.5.4.tgz#3ef7412f7339210f003cdf36646bbca786efe7b4"
+  integrity sha512-3uSo7laYxF00Dg/DMgbn4xMJKmDdWvZnf89n8Xj/5/AeQ2dOQmn6b6Hkj/MleyzZWXpwv+WSdYWl4cLsy2JsoA==
+  dependencies:
+    "@jest/console" "^25.5.0"
+    "@jest/reporters" "^25.5.1"
+    "@jest/test-result" "^25.5.0"
+    "@jest/transform" "^25.5.1"
+    "@jest/types" "^25.5.0"
+    ansi-escapes "^4.2.1"
+    chalk "^3.0.0"
+    exit "^0.1.2"
+    graceful-fs "^4.2.4"
+    jest-changed-files "^25.5.0"
+    jest-config "^25.5.4"
+    jest-haste-map "^25.5.1"
+    jest-message-util "^25.5.0"
+    jest-regex-util "^25.2.6"
+    jest-resolve "^25.5.1"
+    jest-resolve-dependencies "^25.5.4"
+    jest-runner "^25.5.4"
+    jest-runtime "^25.5.4"
+    jest-snapshot "^25.5.1"
+    jest-util "^25.5.0"
+    jest-validate "^25.5.0"
+    jest-watcher "^25.5.0"
+    micromatch "^4.0.2"
+    p-each-series "^2.1.0"
+    realpath-native "^2.0.0"
+    rimraf "^3.0.0"
+    slash "^3.0.0"
+    strip-ansi "^6.0.0"
+
+"@jest/environment@^25.5.0":
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-25.5.0.tgz#aa33b0c21a716c65686638e7ef816c0e3a0c7b37"
+  integrity sha512-U2VXPEqL07E/V7pSZMSQCvV5Ea4lqOlT+0ZFijl/i316cRMHvZ4qC+jBdryd+lmRetjQo0YIQr6cVPNxxK87mA==
+  dependencies:
+    "@jest/fake-timers" "^25.5.0"
+    "@jest/types" "^25.5.0"
+    jest-mock "^25.5.0"
+
+"@jest/fake-timers@^25.5.0":
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-25.5.0.tgz#46352e00533c024c90c2bc2ad9f2959f7f114185"
+  integrity sha512-9y2+uGnESw/oyOI3eww9yaxdZyHq7XvprfP/eeoCsjqKYts2yRlsHS/SgjPDV8FyMfn2nbMy8YzUk6nyvdLOpQ==
+  dependencies:
+    "@jest/types" "^25.5.0"
+    jest-message-util "^25.5.0"
+    jest-mock "^25.5.0"
+    jest-util "^25.5.0"
+    lolex "^5.0.0"
+
+"@jest/globals@^25.5.2":
+  version "25.5.2"
+  resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-25.5.2.tgz#5e45e9de8d228716af3257eeb3991cc2e162ca88"
+  integrity sha512-AgAS/Ny7Q2RCIj5kZ+0MuKM1wbF0WMLxbCVl/GOMoCNbODRdJ541IxJ98xnZdVSZXivKpJlNPIWa3QmY0l4CXA==
+  dependencies:
+    "@jest/environment" "^25.5.0"
+    "@jest/types" "^25.5.0"
+    expect "^25.5.0"
+
+"@jest/reporters@^25.5.1":
+  version "25.5.1"
+  resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-25.5.1.tgz#cb686bcc680f664c2dbaf7ed873e93aa6811538b"
+  integrity sha512-3jbd8pPDTuhYJ7vqiHXbSwTJQNavczPs+f1kRprRDxETeE3u6srJ+f0NPuwvOmk+lmunZzPkYWIFZDLHQPkviw==
+  dependencies:
+    "@bcoe/v8-coverage" "^0.2.3"
+    "@jest/console" "^25.5.0"
+    "@jest/test-result" "^25.5.0"
+    "@jest/transform" "^25.5.1"
+    "@jest/types" "^25.5.0"
+    chalk "^3.0.0"
+    collect-v8-coverage "^1.0.0"
+    exit "^0.1.2"
+    glob "^7.1.2"
+    graceful-fs "^4.2.4"
+    istanbul-lib-coverage "^3.0.0"
+    istanbul-lib-instrument "^4.0.0"
+    istanbul-lib-report "^3.0.0"
+    istanbul-lib-source-maps "^4.0.0"
+    istanbul-reports "^3.0.2"
+    jest-haste-map "^25.5.1"
+    jest-resolve "^25.5.1"
+    jest-util "^25.5.0"
+    jest-worker "^25.5.0"
+    slash "^3.0.0"
+    source-map "^0.6.0"
+    string-length "^3.1.0"
+    terminal-link "^2.0.0"
+    v8-to-istanbul "^4.1.3"
+  optionalDependencies:
+    node-notifier "^6.0.0"
+
+"@jest/source-map@^25.5.0":
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/@jest/source-map/-/source-map-25.5.0.tgz#df5c20d6050aa292c2c6d3f0d2c7606af315bd1b"
+  integrity sha512-eIGx0xN12yVpMcPaVpjXPnn3N30QGJCJQSkEDUt9x1fI1Gdvb07Ml6K5iN2hG7NmMP6FDmtPEssE3z6doOYUwQ==
+  dependencies:
+    callsites "^3.0.0"
+    graceful-fs "^4.2.4"
+    source-map "^0.6.0"
+
+"@jest/test-result@^25.5.0":
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-25.5.0.tgz#139a043230cdeffe9ba2d8341b27f2efc77ce87c"
+  integrity sha512-oV+hPJgXN7IQf/fHWkcS99y0smKLU2czLBJ9WA0jHITLst58HpQMtzSYxzaBvYc6U5U6jfoMthqsUlUlbRXs0A==
+  dependencies:
+    "@jest/console" "^25.5.0"
+    "@jest/types" "^25.5.0"
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    collect-v8-coverage "^1.0.0"
+
+"@jest/test-sequencer@^25.5.4":
+  version "25.5.4"
+  resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-25.5.4.tgz#9b4e685b36954c38d0f052e596d28161bdc8b737"
+  integrity sha512-pTJGEkSeg1EkCO2YWq6hbFvKNXk8ejqlxiOg1jBNLnWrgXOkdY6UmqZpwGFXNnRt9B8nO1uWMzLLZ4eCmhkPNA==
+  dependencies:
+    "@jest/test-result" "^25.5.0"
+    graceful-fs "^4.2.4"
+    jest-haste-map "^25.5.1"
+    jest-runner "^25.5.4"
+    jest-runtime "^25.5.4"
+
+"@jest/transform@^25.5.1":
+  version "25.5.1"
+  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-25.5.1.tgz#0469ddc17699dd2bf985db55fa0fb9309f5c2db3"
+  integrity sha512-Y8CEoVwXb4QwA6Y/9uDkn0Xfz0finGkieuV0xkdF9UtZGJeLukD5nLkaVrVsODB1ojRWlaoD0AJZpVHCSnJEvg==
+  dependencies:
+    "@babel/core" "^7.1.0"
+    "@jest/types" "^25.5.0"
+    babel-plugin-istanbul "^6.0.0"
+    chalk "^3.0.0"
+    convert-source-map "^1.4.0"
+    fast-json-stable-stringify "^2.0.0"
+    graceful-fs "^4.2.4"
+    jest-haste-map "^25.5.1"
+    jest-regex-util "^25.2.6"
+    jest-util "^25.5.0"
+    micromatch "^4.0.2"
+    pirates "^4.0.1"
+    realpath-native "^2.0.0"
+    slash "^3.0.0"
+    source-map "^0.6.1"
+    write-file-atomic "^3.0.0"
+
+"@jest/types@^25.5.0":
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-25.5.0.tgz#4d6a4793f7b9599fc3680877b856a97dbccf2a9d"
+  integrity sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^1.1.1"
+    "@types/yargs" "^15.0.0"
+    chalk "^3.0.0"
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc%2freaddir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -1076,6 +1294,13 @@
     invariant "^2.2.3"
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
+
+"@sinonjs/commons@^1.7.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.0.tgz#c8d68821a854c555bba172f3b06959a0039b236d"
+  integrity sha512-wEj54PfsZ5jGSwMX68G8ZXFawcSglQSXqCftWX3ec8MDUzQdHgcKvw97awHbY0efQEL5iKUOAmmVtoYgmrSG4Q==
+  dependencies:
+    type-detect "4.0.8"
 
 "@storybook/addon-knobs@^5.3.18":
   version "5.3.19"
@@ -1528,6 +1753,39 @@
   resolved "https://registry.yarnpkg.com/@types%2fanymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
   integrity sha1-M2utwb7sudrMOL6izzKt9ieoQho=
 
+"@types/babel__core@^7.1.7":
+  version "7.1.7"
+  resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.7.tgz#1dacad8840364a57c98d0dd4855c6dd3752c6b89"
+  integrity sha512-RL62NqSFPCDK2FM1pSDH0scHpJvsXtZNiYlMB73DgPBaG1E38ZYVL+ei5EkWRbr+KC4YNiAUNBnRj+bgwpgjMw==
+  dependencies:
+    "@babel/parser" "^7.1.0"
+    "@babel/types" "^7.0.0"
+    "@types/babel__generator" "*"
+    "@types/babel__template" "*"
+    "@types/babel__traverse" "*"
+
+"@types/babel__generator@*":
+  version "7.6.1"
+  resolved "https://registry.yarnpkg.com/@types/babel__generator/-/babel__generator-7.6.1.tgz#4901767b397e8711aeb99df8d396d7ba7b7f0e04"
+  integrity sha512-bBKm+2VPJcMRVwNhxKu8W+5/zT7pwNEqeokFOmbvVSqGzFneNxYcEBro9Ac7/N9tlsaPYnZLK8J1LWKkMsLAew==
+  dependencies:
+    "@babel/types" "^7.0.0"
+
+"@types/babel__template@*":
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/@types/babel__template/-/babel__template-7.0.2.tgz#4ff63d6b52eddac1de7b975a5223ed32ecea9307"
+  integrity sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==
+  dependencies:
+    "@babel/parser" "^7.1.0"
+    "@babel/types" "^7.0.0"
+
+"@types/babel__traverse@*", "@types/babel__traverse@^7.0.6":
+  version "7.0.11"
+  resolved "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.0.11.tgz#1ae3010e8bf8851d324878b42acec71986486d18"
+  integrity sha512-ddHK5icION5U6q11+tV2f9Mo6CZVuT8GJKld2q9LqHSZbvLbH34Kcu2yFGckZut453+eQU6btIA3RihmnRgI+Q==
+  dependencies:
+    "@babel/types" "^7.3.0"
+
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types%2fcolor-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
@@ -1547,6 +1805,13 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
+"@types/graceful-fs@^4.1.2":
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.3.tgz#039af35fe26bec35003e8d86d2ee9c586354348f"
+  integrity sha512-AiHRaEB50LQg0pZmm659vNBb9f4SJ0qrAnteuzhSeAUcJKxoYgEnprg/83kppCnc2zvtCKbdZry1a5pVY3lOTQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/history@*":
   version "4.7.6"
   resolved "https://registry.yarnpkg.com/@types%2fhistory/-/history-4.7.6.tgz#ed8fc802c45b8e8f54419c2d054e55c9ea344356"
@@ -1562,6 +1827,26 @@
   resolved "https://registry.yarnpkg.com/@types%2fis-function/-/is-function-1.0.0.tgz#1b0b819b1636c7baf0d6785d030d12edf70c3e83"
   integrity sha1-GwuBmxY2x7rw1nhdAw0S7fcMPoM=
 
+"@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.2.tgz#79d7a78bad4219f4c03d6557a1c72d9ca6ba62d5"
+  integrity sha512-rsZg7eL+Xcxsxk2XlBt9KcG8nOp9iYdKCOikY9x2RFJCyOdNj4MKPQty0e8oZr29vVAzKXr1BmR+kZauti3o1w==
+
+"@types/istanbul-lib-report@*":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz#c14c24f18ea8190c118ee7562b7ff99a36552686"
+  integrity sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==
+  dependencies:
+    "@types/istanbul-lib-coverage" "*"
+
+"@types/istanbul-reports@^1.1.1":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz#e875cc689e47bce549ec81f3df5e6f6f11cfaeb2"
+  integrity sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==
+  dependencies:
+    "@types/istanbul-lib-coverage" "*"
+    "@types/istanbul-lib-report" "*"
+
 "@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types%2fminimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
@@ -1572,6 +1857,11 @@
   resolved "https://registry.yarnpkg.com/@types%2fnode/-/node-14.0.5.tgz#3d03acd3b3414cf67faf999aed11682ed121f22b"
   integrity sha1-PQOs07NBTPZ/r5ma7RFoLtEh8is=
 
+"@types/normalize-package-data@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
+  integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
+
 "@types/npmlog@^4.1.2":
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/@types%2fnpmlog/-/npmlog-4.1.2.tgz#d070fe6a6b78755d1092a3dc492d34c3d8f871c4"
@@ -1581,6 +1871,11 @@
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types%2fparse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha1-L4u0QUNNFjs1+4/9zNcTiSf/uMA=
+
+"@types/prettier@^1.19.0":
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-1.19.1.tgz#33509849f8e679e4add158959fdb086440e9553f"
+  integrity sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==
 
 "@types/prop-types@*":
   version "15.7.3"
@@ -1634,6 +1929,11 @@
   resolved "https://registry.yarnpkg.com/@types%2fsource-list-map/-/source-list-map-0.1.2.tgz#0078836063ffaf17412349bba364087e0ac02ec9"
   integrity sha1-AHiDYGP/rxdBI0m7o2QIfgrALsk=
 
+"@types/stack-utils@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
+  integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
+
 "@types/tapable@*", "@types/tapable@^1.0.5":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@types%2ftapable/-/tapable-1.0.5.tgz#9adbc12950582aa65ead76bffdf39fe0c27a3c02"
@@ -1671,6 +1971,18 @@
     "@types/uglify-js" "*"
     "@types/webpack-sources" "*"
     source-map "^0.6.0"
+
+"@types/yargs-parser@*":
+  version "15.0.0"
+  resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-15.0.0.tgz#cb3f9f741869e20cce330ffbeb9271590483882d"
+  integrity sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==
+
+"@types/yargs@^15.0.0":
+  version "15.0.5"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.5.tgz#947e9a6561483bdee9adffc983e91a6902af8b79"
+  integrity sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==
+  dependencies:
+    "@types/yargs-parser" "*"
 
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
@@ -1848,6 +2160,11 @@ abab@^1.0.3:
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
   integrity sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=
 
+abab@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.3.tgz#623e2075e02eb2d3f2475e49f99c91846467907a"
+  integrity sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -1875,6 +2192,14 @@ acorn-globals@^3.1.0:
   dependencies:
     acorn "^4.0.4"
 
+acorn-globals@^4.3.2:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-4.3.4.tgz#9fa1926addc11c97308c4e66d7add0d40c3272e7"
+  integrity sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==
+  dependencies:
+    acorn "^6.0.1"
+    acorn-walk "^6.0.1"
+
 acorn-jsx@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
@@ -1896,6 +2221,11 @@ acorn-node@^1.2.0, acorn-node@^1.3.0, acorn-node@^1.5.2:
     acorn-walk "^7.0.0"
     xtend "^4.0.2"
 
+acorn-walk@^6.0.1:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-6.2.0.tgz#123cb8f3b84c2171f1f7fb252615b1c78a6b1a8c"
+  integrity sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==
+
 acorn-walk@^7.0.0:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.1.1.tgz#345f0dffad5c735e7373d2fec9a1023e6a44b83e"
@@ -1916,12 +2246,12 @@ acorn@^5.0.0, acorn@^5.2.1, acorn@^5.5.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.4.tgz#3e8d8a9947d0599a1796d10225d7432f4a4acf5e"
   integrity sha1-Po2KmUfQWZoXltECJddDL0pKz14=
 
-acorn@^6.4.1:
+acorn@^6.0.1, acorn@^6.4.1:
   version "6.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.1.tgz#531e58ba3f51b9dacb9a6646ca4debf5b14ca474"
-  integrity sha1-Ux5Yuj9RudrLmmZGyk3r9bFMpHQ=
+  integrity sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==
 
-acorn@^7.0.0, acorn@^7.1.1:
+acorn@^7.0.0, acorn@^7.1.0, acorn@^7.1.1:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.2.0.tgz#17ea7e40d7c8640ff54a694c889c26f31704effe"
   integrity sha1-F+p+QNfIZA/1SmlMiJwm8xcE7/4=
@@ -2093,7 +2423,7 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
-ansi-styles@^4.1.0:
+ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.2.1.tgz#90ae75c424d008d2624c5bf29ead3177ebfcf359"
   integrity sha1-kK51xCTQCNJiTFvynq0xd+v881k=
@@ -2116,10 +2446,10 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
-anymatch@~3.1.1:
+anymatch@^3.0.3, anymatch@~3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.1.tgz#c55ecf02185e2469259399310c173ce31233b142"
-  integrity sha1-xV7PAhheJGklk5kxDBc84xIzsUI=
+  integrity sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
@@ -2129,22 +2459,10 @@ app-root-dir@^1.0.2:
   resolved "https://registry.yarnpkg.com/app-root-dir/-/app-root-dir-1.0.2.tgz#38187ec2dea7577fff033ffcb12172692ff6e118"
   integrity sha1-OBh+wt6nV3//Az/8sSFyaS/24Rg=
 
-append-transform@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-1.0.0.tgz#046a52ae582a228bd72f58acfbe2967c678759ab"
-  integrity sha1-BGpSrlgqIovXL1is++KWfGeHWas=
-  dependencies:
-    default-require-extensions "^2.0.0"
-
 aproba@^1.0.3, aproba@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
   integrity sha1-aALmJk79GMeQobDVF/DyYnvyyUo=
-
-archy@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/archy/-/archy-1.0.0.tgz#f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40"
-  integrity sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=
 
 are-we-there-yet@~1.1.2:
   version "1.1.5"
@@ -2661,6 +2979,20 @@ babel-helpers@^6.24.1:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
+babel-jest@^25.5.1:
+  version "25.5.1"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-25.5.1.tgz#bc2e6101f849d6f6aec09720ffc7bc5332e62853"
+  integrity sha512-9dA9+GmMjIzgPnYtkhBg73gOo/RHqPmLruP3BaGL4KEX3Dwz6pI8auSN8G8+iuEG90+GSswyKvslN+JYSaacaQ==
+  dependencies:
+    "@jest/transform" "^25.5.1"
+    "@jest/types" "^25.5.0"
+    "@types/babel__core" "^7.1.7"
+    babel-plugin-istanbul "^6.0.0"
+    babel-preset-jest "^25.5.0"
+    chalk "^3.0.0"
+    graceful-fs "^4.2.4"
+    slash "^3.0.0"
+
 babel-loader@^7.1.1:
   version "7.1.5"
   resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-7.1.5.tgz#e3ee0cd7394aa557e013b02d3e492bfd07aa6d68"
@@ -2727,6 +3059,26 @@ babel-plugin-emotion@^10.0.20, babel-plugin-emotion@^10.0.27:
     escape-string-regexp "^1.0.5"
     find-root "^1.1.0"
     source-map "^0.5.7"
+
+babel-plugin-istanbul@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz#e159ccdc9af95e0b570c75b4573b7c34d671d765"
+  integrity sha512-AF55rZXpe7trmEylbaE1Gv54wn6rwU03aptvRoVIGP8YykoSxqdVLV1TfwflBCE/QtHmqtP8SWlTENqbK8GCSQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@istanbuljs/load-nyc-config" "^1.0.0"
+    "@istanbuljs/schema" "^0.1.2"
+    istanbul-lib-instrument "^4.0.0"
+    test-exclude "^6.0.0"
+
+babel-plugin-jest-hoist@^25.5.0:
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-25.5.0.tgz#129c80ba5c7fc75baf3a45b93e2e372d57ca2677"
+  integrity sha512-u+/W+WAjMlvoocYGTwthAiQSxDcJAyHpQ6oWlHdFZaaN+Rlk8Q7iiwDPg2lN/FyJtAYnKjFxbn7xus4HCFkg5g==
+  dependencies:
+    "@babel/template" "^7.3.3"
+    "@babel/types" "^7.3.3"
+    "@types/babel__traverse" "^7.0.6"
 
 babel-plugin-macros@^2.0.0, babel-plugin-macros@^2.7.0:
   version "2.8.0"
@@ -3275,6 +3627,22 @@ babel-polyfill@^6.26.0:
     core-js "^2.5.0"
     regenerator-runtime "^0.10.5"
 
+babel-preset-current-node-syntax@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.2.tgz#fb4a4c51fe38ca60fede1dc74ab35eb843cb41d6"
+  integrity sha512-u/8cS+dEiK1SFILbOC8/rUI3ml9lboKuuMvZ/4aQnQmhecQAgPw5ew066C1ObnEAUmlx7dv/s2z52psWEtLNiw==
+  dependencies:
+    "@babel/plugin-syntax-async-generators" "^7.8.4"
+    "@babel/plugin-syntax-bigint" "^7.8.3"
+    "@babel/plugin-syntax-class-properties" "^7.8.3"
+    "@babel/plugin-syntax-json-strings" "^7.8.3"
+    "@babel/plugin-syntax-logical-assignment-operators" "^7.8.3"
+    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.3"
+    "@babel/plugin-syntax-numeric-separator" "^7.8.3"
+    "@babel/plugin-syntax-object-rest-spread" "^7.8.3"
+    "@babel/plugin-syntax-optional-catch-binding" "^7.8.3"
+    "@babel/plugin-syntax-optional-chaining" "^7.8.3"
+
 babel-preset-es2015@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz#d44050d6bc2c9feea702aaf38d727a0210538939"
@@ -3311,6 +3679,14 @@ babel-preset-flow@^6.23.0:
   integrity sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=
   dependencies:
     babel-plugin-transform-flow-strip-types "^6.22.0"
+
+babel-preset-jest@^25.5.0:
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-25.5.0.tgz#c1d7f191829487a907764c65307faa0e66590b49"
+  integrity sha512-8ZczygctQkBU+63DtSOKGh7tFL0CeCuz+1ieud9lJ1WPQ9O6A1a/r+LGn6Y705PA6whHQ3T1XuB/PmpfNYf8Fw==
+  dependencies:
+    babel-plugin-jest-hoist "^25.5.0"
+    babel-preset-current-node-syntax "^0.1.2"
 
 "babel-preset-minify@^0.5.0 || 0.6.0-alpha.5":
   version "0.5.1"
@@ -3639,10 +4015,15 @@ browser-pack@^6.0.1:
     through2 "^2.0.0"
     umd "^3.0.0"
 
-browser-resolve@^1.11.0, browser-resolve@^1.7.0:
+browser-process-hrtime@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz#3c9b4b7d782c8121e56f10106d84c0d0ffc94626"
+  integrity sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==
+
+browser-resolve@^1.11.0, browser-resolve@^1.11.3, browser-resolve@^1.7.0:
   version "1.11.3"
   resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.3.tgz#9b7cbb3d0f510e4cb86bdbd796124d28b5890af6"
-  integrity sha1-m3y7PQ9RDky4a9vXlhJNKLWJCvY=
+  integrity sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==
   dependencies:
     resolve "1.1.7"
 
@@ -3787,6 +4168,13 @@ browserslist@^4.11.1, browserslist@^4.12.0, browserslist@^4.8.5:
     node-releases "^1.1.53"
     pkg-up "^2.0.0"
 
+bser@2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/bser/-/bser-2.1.1.tgz#e6787da20ece9d07998533cfd9de6f5c38f4bc05"
+  integrity sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==
+  dependencies:
+    node-int64 "^0.4.0"
+
 buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
@@ -3918,16 +4306,6 @@ cached-path-relative@^1.0.0:
   resolved "https://registry.yarnpkg.com/cached-path-relative/-/cached-path-relative-1.0.2.tgz#a13df4196d26776220cc3356eb147a52dba2c6db"
   integrity sha1-oT30GW0md2IgzDNW6xR6Utuixts=
 
-caching-transform@^3.0.1:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/caching-transform/-/caching-transform-3.0.2.tgz#601d46b91eca87687a281e71cef99791b0efca70"
-  integrity sha1-YB1GuR7Kh2h6KB5xzvmXkbDvynA=
-  dependencies:
-    hasha "^3.0.0"
-    make-dir "^2.0.0"
-    package-hash "^3.0.0"
-    write-file-atomic "^2.4.2"
-
 call-me-maybe@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/call-me-maybe/-/call-me-maybe-1.0.1.tgz#26d208ea89e37b5cbde60250a15f031c16a4d66b"
@@ -4049,6 +4427,13 @@ canvas-prebuilt@^1.6.11:
   integrity sha1-mzcHGqDd1PfCtKniebY/stww25s=
   dependencies:
     node-pre-gyp "^0.10.0"
+
+capture-exit@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/capture-exit/-/capture-exit-2.0.0.tgz#fb953bfaebeb781f62898239dabb426d08a509a4"
+  integrity sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==
+  dependencies:
+    rsvp "^4.8.4"
 
 case-sensitive-paths-webpack-plugin@^2.2.0:
   version "2.3.0"
@@ -4292,15 +4677,6 @@ cliui@^3.0.3, cliui@^3.2.0:
     strip-ansi "^3.0.1"
     wrap-ansi "^2.0.0"
 
-cliui@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.1.0.tgz#348422dbe82d800b3022eef4f6ac10bf2e4d1b49"
-  integrity sha1-NIQi2+gtgAswIu709qwQvy5NG0k=
-  dependencies:
-    string-width "^2.1.1"
-    strip-ansi "^4.0.0"
-    wrap-ansi "^2.0.0"
-
 cliui@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-5.0.0.tgz#deefcfdb2e800784aa34f46fa08e06851c7bbbc5"
@@ -4309,6 +4685,15 @@ cliui@^5.0.0:
     string-width "^3.1.0"
     strip-ansi "^5.2.0"
     wrap-ansi "^5.1.0"
+
+cliui@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-6.0.0.tgz#511d702c0c4e41ca156d7d0e96021f23e13225b1"
+  integrity sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^6.2.0"
 
 clone-deep@^0.2.4:
   version "0.2.4"
@@ -4383,6 +4768,11 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
+
+collect-v8-coverage@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz#cc2c8e94fc18bbdffe64d6534570c8a673b27f59"
+  integrity sha512-iBPtljfCNcTKNAto0KEtDfZ3qzjJvqE3aTGZsbhjSBlorqpXJlaWWtPO35D+ZImoC3KWejX64o+yPGxhWSTzfg==
 
 collection-visit@^1.0.0:
   version "1.0.0"
@@ -4613,7 +5003,7 @@ content-type@~1.0.4:
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
   integrity sha1-4TjMdeBAxyexlm/l5fjJruJW/js=
 
-convert-source-map@^1.1.0, convert-source-map@^1.5.0, convert-source-map@^1.5.1, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
+convert-source-map@^1.1.0, convert-source-map@^1.4.0, convert-source-map@^1.5.0, convert-source-map@^1.5.1, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.7.0.tgz#17a2cb882d7f77d3490585e2ce6c524424a3a442"
   integrity sha1-F6LLiC1/d9NJBYXizmxSRCSjpEI=
@@ -4815,14 +5205,6 @@ cross-spawn@^3.0.0:
     lru-cache "^4.0.1"
     which "^1.2.9"
 
-cross-spawn@^4:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
-  integrity sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=
-  dependencies:
-    lru-cache "^4.0.1"
-    which "^1.2.9"
-
 cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -4831,6 +5213,15 @@ cross-spawn@^5.0.1, cross-spawn@^5.1.0:
     lru-cache "^4.0.1"
     shebang-command "^1.2.0"
     which "^1.2.9"
+
+cross-spawn@^7.0.0:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
+  integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
 
 crypto-browserify@^3.0.0, crypto-browserify@^3.11.0:
   version "3.12.0"
@@ -5052,10 +5443,15 @@ csso@~2.3.1:
     clap "^1.0.9"
     source-map "^0.5.3"
 
-cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
+cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0", cssom@~0.3.6:
   version "0.3.8"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.8.tgz#9f1276f5b2b463f2114d3f2c75250af8c1a36f4a"
-  integrity sha1-nxJ29bK0Y/IRTT8sdSUK+MGjb0o=
+  integrity sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==
+
+cssom@^0.4.1:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.4.4.tgz#5a66cf93d2d0b661d80bf6a44fb65f5c2e4e0a10"
+  integrity sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==
 
 "cssstyle@>= 0.2.37 < 0.3.0":
   version "0.2.37"
@@ -5063,6 +5459,13 @@ cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   integrity sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=
   dependencies:
     cssom "0.3.x"
+
+cssstyle@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-2.3.0.tgz#ff665a0ddbdc31864b09647f34163443d90b0852"
+  integrity sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==
+  dependencies:
+    cssom "~0.3.6"
 
 csstype@^2.2.0, csstype@^2.5.7, csstype@^2.6.7:
   version "2.6.10"
@@ -5241,6 +5644,15 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+data-urls@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-1.1.0.tgz#15ee0582baa5e22bb59c77140da8f9c76963bbfe"
+  integrity sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==
+  dependencies:
+    abab "^2.0.0"
+    whatwg-mimetype "^2.2.0"
+    whatwg-url "^7.0.0"
+
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.6, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -5272,7 +5684,7 @@ decode-uri-component@^0.2.0:
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
 
-deep-equal@^1.0.1, deep-equal@^1.1.1, deep-equal@~1.1.1:
+deep-equal@^1.0.1, deep-equal@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.1.1.tgz#b5c98c942ceffaf7cb051e24e1434a25a2e6076a"
   integrity sha1-tcmMlCzv+vfLBR4k4UNKJaLmB2o=
@@ -5309,6 +5721,11 @@ deepmerge@^1.5.1:
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-1.5.2.tgz#10499d868844cdad4fee0842df8c7f6f0c95a753"
   integrity sha1-EEmdhohEza1P7ghC34x/bwyVp1M=
 
+deepmerge@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
+  integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
+
 default-gateway@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/default-gateway/-/default-gateway-4.2.0.tgz#167104c7500c2115f6dd69b0a536bb8ed720552b"
@@ -5316,13 +5733,6 @@ default-gateway@^4.2.0:
   dependencies:
     execa "^1.0.0"
     ip-regex "^2.1.0"
-
-default-require-extensions@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-2.0.0.tgz#f5f8fbb18a7d6d50b21f641f649ebb522cfe24f7"
-  integrity sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=
-  dependencies:
-    strip-bom "^3.0.0"
 
 define-properties@^1.1.2, define-properties@^1.1.3:
   version "1.1.3"
@@ -5353,7 +5763,7 @@ define-property@^2.0.2:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
 
-defined@^1.0.0, defined@~1.0.0:
+defined@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/defined/-/defined-1.0.0.tgz#c98d9bcef75674188e110969151199e39b1fa693"
   integrity sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=
@@ -5443,6 +5853,11 @@ detect-libc@^1.0.2:
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
+detect-newline@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
+  integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
+
 detect-node@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.4.tgz#014ee8f8f669c5c58023da64b8179c083a28c46c"
@@ -5471,6 +5886,11 @@ detective@^4.0.0:
   dependencies:
     acorn "^5.2.1"
     defined "^1.0.0"
+
+diff-sequences@^25.2.6:
+  version "25.2.6"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-25.2.6.tgz#5f467c00edd35352b7bca46d7927d60e687a76dd"
+  integrity sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==
 
 diffie-hellman@^5.0.0:
   version "5.0.3"
@@ -5617,6 +6037,13 @@ domelementtype@^2.0.1:
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.0.1.tgz#1f8bdfe91f5a78063274e803b4bdcedf6e94f94d"
   integrity sha1-H4vf6R9aeAYydOgDtL3O326U+U0=
 
+domexception@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/domexception/-/domexception-1.0.1.tgz#937442644ca6a31261ef36e3ec677fe805582c90"
+  integrity sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==
+  dependencies:
+    webidl-conversions "^4.0.2"
+
 domhandler@^2.3.0:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.4.2.tgz#8805097e933d65e85546f726d60f5eb88b44f803"
@@ -5676,13 +6103,6 @@ dotenv@^8.0.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
   integrity sha1-l+YZJZradQ7qPk6j4mvO6lQksWo=
-
-dotignore@~0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/dotignore/-/dotignore-0.1.2.tgz#f942f2200d28c3a76fbdd6f0ee9f3257c8a2e905"
-  integrity sha1-+ULyIA0ow6dvvdbw7p8yV8ii6QU=
-  dependencies:
-    minimatch "^3.0.4"
 
 duplexer2@0.0.2:
   version "0.0.2"
@@ -5987,11 +6407,6 @@ es5-shim@^4.5.13:
   resolved "https://registry.yarnpkg.com/es5-shim/-/es5-shim-4.5.14.tgz#90009e1019d0ea327447cb523deaff8fe45697ef"
   integrity sha1-kACeEBnQ6jJ0R8tSPer/j+RWl+8=
 
-es6-error@^4.0.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-4.1.1.tgz#9e3af407459deed47e9a91f9b885a84eb05c561d"
-  integrity sha1-njr0B0Wd7tR+mpH5uIWoTrBcVh0=
-
 es6-iterator@^2.0.3, es6-iterator@~2.0.1, es6-iterator@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
@@ -6070,10 +6485,10 @@ escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
-escodegen@^1.6.1:
+escodegen@^1.11.1, escodegen@^1.6.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.14.1.tgz#ba01d0c8278b5e95a9a45350142026659027a457"
-  integrity sha1-ugHQyCeLXpWppFNQFCAmZZAnpFc=
+  integrity sha512-Bmt7NcRySdIfNPfU2ZoXDrrXsG9ZjvDxcAlMfDUgRBjLOWTuIACXPBFJH7Z+cLb40JeQco5toikyc9t9P8E9SQ==
   dependencies:
     esprima "^4.0.1"
     estraverse "^4.2.0"
@@ -6412,6 +6827,11 @@ evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
     md5.js "^1.3.4"
     safe-buffer "^5.1.1"
 
+exec-sh@^0.3.2:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.3.4.tgz#3a018ceb526cc6f6df2bb504b2bfe8e3a4934ec5"
+  integrity sha512-sEFIkc61v75sWeOe72qyrqg2Qg0OuLESziUDk/O/z2qgS15y2gWVFrI6f2Qn/qw/0/NCfCEsmNA4zOjkwEZT1A==
+
 execa@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
@@ -6438,12 +6858,33 @@ execa@^1.0.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+execa@^3.2.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-3.4.0.tgz#c08ed4550ef65d858fac269ffc8572446f37eb89"
+  integrity sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==
+  dependencies:
+    cross-spawn "^7.0.0"
+    get-stream "^5.0.0"
+    human-signals "^1.1.1"
+    is-stream "^2.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^4.0.0"
+    onetime "^5.1.0"
+    p-finally "^2.0.0"
+    signal-exit "^3.0.2"
+    strip-final-newline "^2.0.0"
+
 execall@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/execall/-/execall-1.0.0.tgz#73d0904e395b3cab0658b08d09ec25307f29bb73"
   integrity sha1-c9CQTjlbPKsGWLCNCewlMH8pu3M=
   dependencies:
     clone-regexp "^1.0.0"
+
+exit@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
+  integrity sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=
 
 expand-brackets@^0.1.4:
   version "0.1.5"
@@ -6478,6 +6919,18 @@ expand-tilde@^2.0.0, expand-tilde@^2.0.2:
   integrity sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=
   dependencies:
     homedir-polyfill "^1.0.1"
+
+expect@^25.5.0:
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-25.5.0.tgz#f07f848712a2813bb59167da3fb828ca21f58bba"
+  integrity sha512-w7KAXo0+6qqZZhovCaBVPSIqQp7/UTcx4M9uKt2m6pd2VB1voyC8JizLRqeEqud3AAVP02g+hbErDu5gu64tlA==
+  dependencies:
+    "@jest/types" "^25.5.0"
+    ansi-styles "^4.0.0"
+    jest-get-type "^25.2.6"
+    jest-matcher-utils "^25.5.0"
+    jest-message-util "^25.5.0"
+    jest-regex-util "^25.2.6"
 
 express@^4.16.2, express@^4.17.0, express@^4.17.1:
   version "4.17.1"
@@ -6673,6 +7126,13 @@ faye-websocket@~0.11.0, faye-websocket@~0.11.1:
   integrity sha1-XA6aiWjokSwoZjn96XeosgnyUI4=
   dependencies:
     websocket-driver ">=0.5.1"
+
+fb-watchman@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-2.0.1.tgz#fc84fb39d2709cf3ff6d743706157bb5708a8a85"
+  integrity sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==
+  dependencies:
+    bser "2.1.1"
 
 fbjs@^0.8.9:
   version "0.8.17"
@@ -6931,13 +7391,6 @@ follow-redirects@^1.0.0:
   dependencies:
     debug "^3.0.0"
 
-for-each@~0.3.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
-  integrity sha1-abRH6IoKXTLD5whPPxcQA0shN24=
-  dependencies:
-    is-callable "^1.1.3"
-
 for-in@^0.1.3:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-0.1.8.tgz#d8773908e31256109952b1fdb9b3fa867d2775e1"
@@ -6961,14 +7414,6 @@ for-own@^1.0.0:
   integrity sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=
   dependencies:
     for-in "^1.0.1"
-
-foreground-child@^1.5.6:
-  version "1.5.6"
-  resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-1.5.6.tgz#4fd71ad2dfde96789b980a5c0a295937cb2f5ce9"
-  integrity sha1-T9ca0t/elnibmApcCilZN8svXOk=
-  dependencies:
-    cross-spawn "^4"
-    signal-exit "^3.0.0"
 
 forever-agent@~0.6.1:
   version "0.6.1"
@@ -7090,10 +7535,10 @@ fsevents@^1.2.7:
     bindings "^1.5.0"
     nan "^2.12.1"
 
-fsevents@~2.1.2:
+fsevents@^2.1.2, fsevents@~2.1.2:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e"
-  integrity sha1-+3OHA66NL5/pAMM4Nt3r7ouX8j4=
+  integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
 
 fstream@^1.0.0, fstream@^1.0.12:
   version "1.0.12"
@@ -7105,7 +7550,7 @@ fstream@^1.0.0, fstream@^1.0.12:
     mkdirp ">=0.5 0"
     rimraf "2"
 
-function-bind@^1.1.1, function-bind@~1.1.1:
+function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=
@@ -7180,6 +7625,11 @@ get-caller-file@^2.0.1:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=
 
+get-package-type@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/get-package-type/-/get-package-type-0.1.0.tgz#8de2d803cff44df3bc6c456e6668b36c3926e11a"
+  integrity sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==
+
 get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
@@ -7204,6 +7654,13 @@ get-stream@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5"
   integrity sha1-wbJVV189wh1Zv8ec09K0axw6VLU=
+  dependencies:
+    pump "^3.0.0"
+
+get-stream@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.1.0.tgz#01203cdc92597f9b909067c3e656cc1f4d3c4dc9"
+  integrity sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==
   dependencies:
     pump "^3.0.0"
 
@@ -7254,7 +7711,7 @@ glob-to-regexp@^0.3.0:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
   integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.1.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@~7.1.1, glob@~7.1.6:
+glob@^7.0.0, glob@^7.0.3, glob@^7.1.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@~7.1.1:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha1-FB8zuBp8JJLhJVlDB0gMRmeSeKY=
@@ -7391,10 +7848,15 @@ good-listener@^1.2.2:
   dependencies:
     delegate "^3.1.2"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0, graceful-fs@^4.2.2:
+graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0, graceful-fs@^4.2.2, graceful-fs@^4.2.4:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
-  integrity sha1-Ila94U02MpWMRl68ltxGfKB6Kfs=
+  integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
+
+growly@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
+  integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
 gud@^1.0.0:
   version "1.0.0"
@@ -7495,7 +7957,7 @@ has-values@^1.0.0:
     is-number "^3.0.0"
     kind-of "^4.0.0"
 
-has@^1.0.0, has@^1.0.1, has@^1.0.3, has@~1.0.3:
+has@^1.0.0, has@^1.0.1, has@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
   integrity sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=
@@ -7518,13 +7980,6 @@ hash.js@^1.0.0, hash.js@^1.0.3:
   dependencies:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
-
-hasha@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/hasha/-/hasha-3.0.0.tgz#52a32fab8569d41ca69a61ff1a214f8eb7c8bd39"
-  integrity sha1-UqMvq4Vp1BymmmH/GiFPjrfIvTk=
-  dependencies:
-    is-stream "^1.0.1"
 
 hast-util-parse-selector@^2.0.0:
   version "2.2.4"
@@ -7631,10 +8086,10 @@ html-element-map@^1.2.0:
   dependencies:
     array-filter "^1.0.0"
 
-html-encoding-sniffer@^1.0.1:
+html-encoding-sniffer@^1.0.1, html-encoding-sniffer@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz#e70d84b94da53aa375e11fe3a351be6642ca46f8"
-  integrity sha1-5w2EuU2lOqN14R/jo1G+ZkLKRvg=
+  integrity sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==
   dependencies:
     whatwg-encoding "^1.0.1"
 
@@ -7813,6 +8268,11 @@ https-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
+human-signals@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
+  integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
+
 husky@^1.1.2:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/husky/-/husky-1.3.1.tgz#26823e399300388ca2afff11cfa8a86b0033fae0"
@@ -7933,6 +8393,14 @@ import-local@^1.0.0:
     pkg-dir "^2.0.0"
     resolve-cwd "^2.0.0"
 
+import-local@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/import-local/-/import-local-3.0.2.tgz#a8cfd0431d1de4a2199703d003e3e62364fa6db6"
+  integrity sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==
+  dependencies:
+    pkg-dir "^4.2.0"
+    resolve-cwd "^3.0.0"
+
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
@@ -7978,7 +8446,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3, inherits@~2.0.4:
+inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=
@@ -8221,7 +8689,7 @@ is-buffer@^1.0.2, is-buffer@^1.1.0, is-buffer@^1.1.5:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha1-76ouqdqg16suoTqXsritUf776L4=
 
-is-callable@^1.1.3, is-callable@^1.1.4, is-callable@^1.1.5:
+is-callable@^1.1.4, is-callable@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.5.tgz#f7e46b596890456db74e7f6e976cb3273d06faab"
   integrity sha1-9+RrWWiQRW23Tn9ul2yzJz0G+qs=
@@ -8345,6 +8813,11 @@ is-function@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-function/-/is-function-1.0.2.tgz#4f097f30abf6efadac9833b17ca5dc03f8144e08"
   integrity sha1-Twl/MKv2762smDOxfKXcA/gUTgg=
+
+is-generator-fn@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
+  integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
 
 is-glob@^2.0.0, is-glob@^2.0.1:
   version "2.0.1"
@@ -8473,7 +8946,7 @@ is-primitive@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
   integrity sha1-IHurkWOEmcB7Kt8kCkGochADRXU=
 
-is-regex@^1.0.4, is-regex@^1.0.5, is-regex@~1.0.5:
+is-regex@^1.0.4, is-regex@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.5.tgz#39d589a358bf18967f726967120b8fc1aed74eae"
   integrity sha1-OdWJo1i/GJZ/cmlnEguPwa7XTq4=
@@ -8505,6 +8978,11 @@ is-stream@^1.0.1, is-stream@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
 
+is-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.0.tgz#bde9c32680d6fae04129d6ac9d921ce7815f78e3"
+  integrity sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==
+
 is-string@^1.0.4, is-string@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.5.tgz#40493ed198ef3ff477b8c7f92f644ec82a5cd3a6"
@@ -8534,7 +9012,7 @@ is-symbol@^1.0.2, is-symbol@^1.0.3:
   dependencies:
     has-symbols "^1.0.1"
 
-is-typedarray@~1.0.0:
+is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
@@ -8611,57 +9089,46 @@ isstream@~0.1.2:
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
 
-istanbul-lib-coverage@^2.0.3, istanbul-lib-coverage@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz#675f0ab69503fad4b1d849f736baaca803344f49"
-  integrity sha1-Z18KtpUD+tSx2En3NrqsqAM0T0k=
+istanbul-lib-coverage@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz#f5944a37c70b550b02a78a5c3b2055b280cec8ec"
+  integrity sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==
 
-istanbul-lib-hook@^2.0.3:
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-2.0.7.tgz#c95695f383d4f8f60df1f04252a9550e15b5b133"
-  integrity sha1-yVaV84PU+PYN8fBCUqlVDhW1sTM=
+istanbul-lib-instrument@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz#873c6fff897450118222774696a3f28902d77c1d"
+  integrity sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==
   dependencies:
-    append-transform "^1.0.0"
+    "@babel/core" "^7.7.5"
+    "@istanbuljs/schema" "^0.1.2"
+    istanbul-lib-coverage "^3.0.0"
+    semver "^6.3.0"
 
-istanbul-lib-instrument@^3.1.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz#a5f63d91f0bbc0c3e479ef4c5de027335ec6d630"
-  integrity sha1-pfY9kfC7wMPkee9MXeAnM17G1jA=
+istanbul-lib-report@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz#7518fe52ea44de372f460a76b5ecda9ffb73d8a6"
+  integrity sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==
   dependencies:
-    "@babel/generator" "^7.4.0"
-    "@babel/parser" "^7.4.3"
-    "@babel/template" "^7.4.0"
-    "@babel/traverse" "^7.4.3"
-    "@babel/types" "^7.4.0"
-    istanbul-lib-coverage "^2.0.5"
-    semver "^6.0.0"
+    istanbul-lib-coverage "^3.0.0"
+    make-dir "^3.0.0"
+    supports-color "^7.1.0"
 
-istanbul-lib-report@^2.0.4:
-  version "2.0.8"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz#5a8113cd746d43c4889eba36ab10e7d50c9b4f33"
-  integrity sha1-WoETzXRtQ8SInro2qxDn1QybTzM=
-  dependencies:
-    istanbul-lib-coverage "^2.0.5"
-    make-dir "^2.1.0"
-    supports-color "^6.1.0"
-
-istanbul-lib-source-maps@^3.0.2:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz#284997c48211752ec486253da97e3879defba8c8"
-  integrity sha1-KEmXxIIRdS7EhiU9qX44ed77qMg=
+istanbul-lib-source-maps@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz#75743ce6d96bb86dc7ee4352cf6366a23f0b1ad9"
+  integrity sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==
   dependencies:
     debug "^4.1.1"
-    istanbul-lib-coverage "^2.0.5"
-    make-dir "^2.1.0"
-    rimraf "^2.6.3"
+    istanbul-lib-coverage "^3.0.0"
     source-map "^0.6.1"
 
-istanbul-reports@^2.1.1:
-  version "2.2.7"
-  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-2.2.7.tgz#5d939f6237d7b48393cc0959eab40cd4fd056931"
-  integrity sha1-XZOfYjfXtIOTzAlZ6rQM1P0FaTE=
+istanbul-reports@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.0.2.tgz#d593210e5000683750cb09fc0644e4b6e27fd53b"
+  integrity sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==
   dependencies:
     html-escaper "^2.0.0"
+    istanbul-lib-report "^3.0.0"
 
 iterate-iterator@^1.0.1:
   version "1.0.1"
@@ -8676,13 +9143,369 @@ iterate-value@^1.0.0:
     es-get-iterator "^1.0.2"
     iterate-iterator "^1.0.1"
 
-jest-worker@^25.4.0:
+jest-changed-files@^25.5.0:
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-25.5.0.tgz#141cc23567ceb3f534526f8614ba39421383634c"
+  integrity sha512-EOw9QEqapsDT7mKF162m8HFzRPbmP8qJQny6ldVOdOVBz3ACgPm/1nAn5fPQ/NDaYhX/AHkrGwwkCncpAVSXcw==
+  dependencies:
+    "@jest/types" "^25.5.0"
+    execa "^3.2.0"
+    throat "^5.0.0"
+
+jest-cli@^25.5.4:
+  version "25.5.4"
+  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-25.5.4.tgz#b9f1a84d1301a92c5c217684cb79840831db9f0d"
+  integrity sha512-rG8uJkIiOUpnREh1768/N3n27Cm+xPFkSNFO91tgg+8o2rXeVLStz+vkXkGr4UtzH6t1SNbjwoiswd7p4AhHTw==
+  dependencies:
+    "@jest/core" "^25.5.4"
+    "@jest/test-result" "^25.5.0"
+    "@jest/types" "^25.5.0"
+    chalk "^3.0.0"
+    exit "^0.1.2"
+    graceful-fs "^4.2.4"
+    import-local "^3.0.2"
+    is-ci "^2.0.0"
+    jest-config "^25.5.4"
+    jest-util "^25.5.0"
+    jest-validate "^25.5.0"
+    prompts "^2.0.1"
+    realpath-native "^2.0.0"
+    yargs "^15.3.1"
+
+jest-config@^25.5.4:
+  version "25.5.4"
+  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-25.5.4.tgz#38e2057b3f976ef7309b2b2c8dcd2a708a67f02c"
+  integrity sha512-SZwR91SwcdK6bz7Gco8qL7YY2sx8tFJYzvg216DLihTWf+LKY/DoJXpM9nTzYakSyfblbqeU48p/p7Jzy05Atg==
+  dependencies:
+    "@babel/core" "^7.1.0"
+    "@jest/test-sequencer" "^25.5.4"
+    "@jest/types" "^25.5.0"
+    babel-jest "^25.5.1"
+    chalk "^3.0.0"
+    deepmerge "^4.2.2"
+    glob "^7.1.1"
+    graceful-fs "^4.2.4"
+    jest-environment-jsdom "^25.5.0"
+    jest-environment-node "^25.5.0"
+    jest-get-type "^25.2.6"
+    jest-jasmine2 "^25.5.4"
+    jest-regex-util "^25.2.6"
+    jest-resolve "^25.5.1"
+    jest-util "^25.5.0"
+    jest-validate "^25.5.0"
+    micromatch "^4.0.2"
+    pretty-format "^25.5.0"
+    realpath-native "^2.0.0"
+
+jest-diff@^25.5.0:
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-25.5.0.tgz#1dd26ed64f96667c068cef026b677dfa01afcfa9"
+  integrity sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==
+  dependencies:
+    chalk "^3.0.0"
+    diff-sequences "^25.2.6"
+    jest-get-type "^25.2.6"
+    pretty-format "^25.5.0"
+
+jest-docblock@^25.3.0:
+  version "25.3.0"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-25.3.0.tgz#8b777a27e3477cd77a168c05290c471a575623ef"
+  integrity sha512-aktF0kCar8+zxRHxQZwxMy70stc9R1mOmrLsT5VO3pIT0uzGRSDAXxSlz4NqQWpuLjPpuMhPRl7H+5FRsvIQAg==
+  dependencies:
+    detect-newline "^3.0.0"
+
+jest-each@^25.5.0:
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-25.5.0.tgz#0c3c2797e8225cb7bec7e4d249dcd96b934be516"
+  integrity sha512-QBogUxna3D8vtiItvn54xXde7+vuzqRrEeaw8r1s+1TG9eZLVJE5ZkKoSUlqFwRjnlaA4hyKGiu9OlkFIuKnjA==
+  dependencies:
+    "@jest/types" "^25.5.0"
+    chalk "^3.0.0"
+    jest-get-type "^25.2.6"
+    jest-util "^25.5.0"
+    pretty-format "^25.5.0"
+
+jest-environment-jsdom@^25.5.0:
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-25.5.0.tgz#dcbe4da2ea997707997040ecf6e2560aec4e9834"
+  integrity sha512-7Jr02ydaq4jaWMZLY+Skn8wL5nVIYpWvmeatOHL3tOcV3Zw8sjnPpx+ZdeBfc457p8jCR9J6YCc+Lga0oIy62A==
+  dependencies:
+    "@jest/environment" "^25.5.0"
+    "@jest/fake-timers" "^25.5.0"
+    "@jest/types" "^25.5.0"
+    jest-mock "^25.5.0"
+    jest-util "^25.5.0"
+    jsdom "^15.2.1"
+
+jest-environment-node@^25.5.0:
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-25.5.0.tgz#0f55270d94804902988e64adca37c6ce0f7d07a1"
+  integrity sha512-iuxK6rQR2En9EID+2k+IBs5fCFd919gVVK5BeND82fYeLWPqvRcFNPKu9+gxTwfB5XwBGBvZ0HFQa+cHtIoslA==
+  dependencies:
+    "@jest/environment" "^25.5.0"
+    "@jest/fake-timers" "^25.5.0"
+    "@jest/types" "^25.5.0"
+    jest-mock "^25.5.0"
+    jest-util "^25.5.0"
+    semver "^6.3.0"
+
+jest-get-type@^25.2.6:
+  version "25.2.6"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-25.2.6.tgz#0b0a32fab8908b44d508be81681487dbabb8d877"
+  integrity sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==
+
+jest-haste-map@^25.5.1:
+  version "25.5.1"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-25.5.1.tgz#1df10f716c1d94e60a1ebf7798c9fb3da2620943"
+  integrity sha512-dddgh9UZjV7SCDQUrQ+5t9yy8iEgKc1AKqZR9YDww8xsVOtzPQSMVLDChc21+g29oTRexb9/B0bIlZL+sWmvAQ==
+  dependencies:
+    "@jest/types" "^25.5.0"
+    "@types/graceful-fs" "^4.1.2"
+    anymatch "^3.0.3"
+    fb-watchman "^2.0.0"
+    graceful-fs "^4.2.4"
+    jest-serializer "^25.5.0"
+    jest-util "^25.5.0"
+    jest-worker "^25.5.0"
+    micromatch "^4.0.2"
+    sane "^4.0.3"
+    walker "^1.0.7"
+    which "^2.0.2"
+  optionalDependencies:
+    fsevents "^2.1.2"
+
+jest-jasmine2@^25.5.4:
+  version "25.5.4"
+  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-25.5.4.tgz#66ca8b328fb1a3c5364816f8958f6970a8526968"
+  integrity sha512-9acbWEfbmS8UpdcfqnDO+uBUgKa/9hcRh983IHdM+pKmJPL77G0sWAAK0V0kr5LK3a8cSBfkFSoncXwQlRZfkQ==
+  dependencies:
+    "@babel/traverse" "^7.1.0"
+    "@jest/environment" "^25.5.0"
+    "@jest/source-map" "^25.5.0"
+    "@jest/test-result" "^25.5.0"
+    "@jest/types" "^25.5.0"
+    chalk "^3.0.0"
+    co "^4.6.0"
+    expect "^25.5.0"
+    is-generator-fn "^2.0.0"
+    jest-each "^25.5.0"
+    jest-matcher-utils "^25.5.0"
+    jest-message-util "^25.5.0"
+    jest-runtime "^25.5.4"
+    jest-snapshot "^25.5.1"
+    jest-util "^25.5.0"
+    pretty-format "^25.5.0"
+    throat "^5.0.0"
+
+jest-leak-detector@^25.5.0:
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-25.5.0.tgz#2291c6294b0ce404241bb56fe60e2d0c3e34f0bb"
+  integrity sha512-rV7JdLsanS8OkdDpZtgBf61L5xZ4NnYLBq72r6ldxahJWWczZjXawRsoHyXzibM5ed7C2QRjpp6ypgwGdKyoVA==
+  dependencies:
+    jest-get-type "^25.2.6"
+    pretty-format "^25.5.0"
+
+jest-matcher-utils@^25.5.0:
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-25.5.0.tgz#fbc98a12d730e5d2453d7f1ed4a4d948e34b7867"
+  integrity sha512-VWI269+9JS5cpndnpCwm7dy7JtGQT30UHfrnM3mXl22gHGt/b7NkjBqXfbhZ8V4B7ANUsjK18PlSBmG0YH7gjw==
+  dependencies:
+    chalk "^3.0.0"
+    jest-diff "^25.5.0"
+    jest-get-type "^25.2.6"
+    pretty-format "^25.5.0"
+
+jest-message-util@^25.5.0:
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-25.5.0.tgz#ea11d93204cc7ae97456e1d8716251185b8880ea"
+  integrity sha512-ezddz3YCT/LT0SKAmylVyWWIGYoKHOFOFXx3/nA4m794lfVUskMcwhip6vTgdVrOtYdjeQeis2ypzes9mZb4EA==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@jest/types" "^25.5.0"
+    "@types/stack-utils" "^1.0.1"
+    chalk "^3.0.0"
+    graceful-fs "^4.2.4"
+    micromatch "^4.0.2"
+    slash "^3.0.0"
+    stack-utils "^1.0.1"
+
+jest-mock@^25.5.0:
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-25.5.0.tgz#a91a54dabd14e37ecd61665d6b6e06360a55387a"
+  integrity sha512-eXWuTV8mKzp/ovHc5+3USJMYsTBhyQ+5A1Mak35dey/RG8GlM4YWVylZuGgVXinaW6tpvk/RSecmF37FKUlpXA==
+  dependencies:
+    "@jest/types" "^25.5.0"
+
+jest-pnp-resolver@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz#ecdae604c077a7fbc70defb6d517c3c1c898923a"
+  integrity sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==
+
+jest-regex-util@^25.2.6:
+  version "25.2.6"
+  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-25.2.6.tgz#d847d38ba15d2118d3b06390056028d0f2fd3964"
+  integrity sha512-KQqf7a0NrtCkYmZZzodPftn7fL1cq3GQAFVMn5Hg8uKx/fIenLEobNanUxb7abQ1sjADHBseG/2FGpsv/wr+Qw==
+
+jest-resolve-dependencies@^25.5.4:
+  version "25.5.4"
+  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-25.5.4.tgz#85501f53957c8e3be446e863a74777b5a17397a7"
+  integrity sha512-yFmbPd+DAQjJQg88HveObcGBA32nqNZ02fjYmtL16t1xw9bAttSn5UGRRhzMHIQbsep7znWvAvnD4kDqOFM0Uw==
+  dependencies:
+    "@jest/types" "^25.5.0"
+    jest-regex-util "^25.2.6"
+    jest-snapshot "^25.5.1"
+
+jest-resolve@^25.5.1:
+  version "25.5.1"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-25.5.1.tgz#0e6fbcfa7c26d2a5fe8f456088dc332a79266829"
+  integrity sha512-Hc09hYch5aWdtejsUZhA+vSzcotf7fajSlPA6EZPE1RmPBAD39XtJhvHWFStid58iit4IPDLI/Da4cwdDmAHiQ==
+  dependencies:
+    "@jest/types" "^25.5.0"
+    browser-resolve "^1.11.3"
+    chalk "^3.0.0"
+    graceful-fs "^4.2.4"
+    jest-pnp-resolver "^1.2.1"
+    read-pkg-up "^7.0.1"
+    realpath-native "^2.0.0"
+    resolve "^1.17.0"
+    slash "^3.0.0"
+
+jest-runner@^25.5.4:
+  version "25.5.4"
+  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-25.5.4.tgz#ffec5df3875da5f5c878ae6d0a17b8e4ecd7c71d"
+  integrity sha512-V/2R7fKZo6blP8E9BL9vJ8aTU4TH2beuqGNxHbxi6t14XzTb+x90B3FRgdvuHm41GY8ch4xxvf0ATH4hdpjTqg==
+  dependencies:
+    "@jest/console" "^25.5.0"
+    "@jest/environment" "^25.5.0"
+    "@jest/test-result" "^25.5.0"
+    "@jest/types" "^25.5.0"
+    chalk "^3.0.0"
+    exit "^0.1.2"
+    graceful-fs "^4.2.4"
+    jest-config "^25.5.4"
+    jest-docblock "^25.3.0"
+    jest-haste-map "^25.5.1"
+    jest-jasmine2 "^25.5.4"
+    jest-leak-detector "^25.5.0"
+    jest-message-util "^25.5.0"
+    jest-resolve "^25.5.1"
+    jest-runtime "^25.5.4"
+    jest-util "^25.5.0"
+    jest-worker "^25.5.0"
+    source-map-support "^0.5.6"
+    throat "^5.0.0"
+
+jest-runtime@^25.5.4:
+  version "25.5.4"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-25.5.4.tgz#dc981fe2cb2137abcd319e74ccae7f7eeffbfaab"
+  integrity sha512-RWTt8LeWh3GvjYtASH2eezkc8AehVoWKK20udV6n3/gC87wlTbE1kIA+opCvNWyyPeBs6ptYsc6nyHUb1GlUVQ==
+  dependencies:
+    "@jest/console" "^25.5.0"
+    "@jest/environment" "^25.5.0"
+    "@jest/globals" "^25.5.2"
+    "@jest/source-map" "^25.5.0"
+    "@jest/test-result" "^25.5.0"
+    "@jest/transform" "^25.5.1"
+    "@jest/types" "^25.5.0"
+    "@types/yargs" "^15.0.0"
+    chalk "^3.0.0"
+    collect-v8-coverage "^1.0.0"
+    exit "^0.1.2"
+    glob "^7.1.3"
+    graceful-fs "^4.2.4"
+    jest-config "^25.5.4"
+    jest-haste-map "^25.5.1"
+    jest-message-util "^25.5.0"
+    jest-mock "^25.5.0"
+    jest-regex-util "^25.2.6"
+    jest-resolve "^25.5.1"
+    jest-snapshot "^25.5.1"
+    jest-util "^25.5.0"
+    jest-validate "^25.5.0"
+    realpath-native "^2.0.0"
+    slash "^3.0.0"
+    strip-bom "^4.0.0"
+    yargs "^15.3.1"
+
+jest-serializer@^25.5.0:
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-25.5.0.tgz#a993f484e769b4ed54e70e0efdb74007f503072b"
+  integrity sha512-LxD8fY1lByomEPflwur9o4e2a5twSQ7TaVNLlFUuToIdoJuBt8tzHfCsZ42Ok6LkKXWzFWf3AGmheuLAA7LcCA==
+  dependencies:
+    graceful-fs "^4.2.4"
+
+jest-snapshot@^25.5.1:
+  version "25.5.1"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-25.5.1.tgz#1a2a576491f9961eb8d00c2e5fd479bc28e5ff7f"
+  integrity sha512-C02JE1TUe64p2v1auUJ2ze5vcuv32tkv9PyhEb318e8XOKF7MOyXdJ7kdjbvrp3ChPLU2usI7Rjxs97Dj5P0uQ==
+  dependencies:
+    "@babel/types" "^7.0.0"
+    "@jest/types" "^25.5.0"
+    "@types/prettier" "^1.19.0"
+    chalk "^3.0.0"
+    expect "^25.5.0"
+    graceful-fs "^4.2.4"
+    jest-diff "^25.5.0"
+    jest-get-type "^25.2.6"
+    jest-matcher-utils "^25.5.0"
+    jest-message-util "^25.5.0"
+    jest-resolve "^25.5.1"
+    make-dir "^3.0.0"
+    natural-compare "^1.4.0"
+    pretty-format "^25.5.0"
+    semver "^6.3.0"
+
+jest-util@^25.5.0:
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-25.5.0.tgz#31c63b5d6e901274d264a4fec849230aa3fa35b0"
+  integrity sha512-KVlX+WWg1zUTB9ktvhsg2PXZVdkI1NBevOJSkTKYAyXyH4QSvh+Lay/e/v+bmaFfrkfx43xD8QTfgobzlEXdIA==
+  dependencies:
+    "@jest/types" "^25.5.0"
+    chalk "^3.0.0"
+    graceful-fs "^4.2.4"
+    is-ci "^2.0.0"
+    make-dir "^3.0.0"
+
+jest-validate@^25.5.0:
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-25.5.0.tgz#fb4c93f332c2e4cf70151a628e58a35e459a413a"
+  integrity sha512-okUFKqhZIpo3jDdtUXUZ2LxGUZJIlfdYBvZb1aczzxrlyMlqdnnws9MOxezoLGhSaFc2XYaHNReNQfj5zPIWyQ==
+  dependencies:
+    "@jest/types" "^25.5.0"
+    camelcase "^5.3.1"
+    chalk "^3.0.0"
+    jest-get-type "^25.2.6"
+    leven "^3.1.0"
+    pretty-format "^25.5.0"
+
+jest-watcher@^25.5.0:
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-25.5.0.tgz#d6110d101df98badebe435003956fd4a465e8456"
+  integrity sha512-XrSfJnVASEl+5+bb51V0Q7WQx65dTSk7NL4yDdVjPnRNpM0hG+ncFmDYJo9O8jaSRcAitVbuVawyXCRoxGrT5Q==
+  dependencies:
+    "@jest/test-result" "^25.5.0"
+    "@jest/types" "^25.5.0"
+    ansi-escapes "^4.2.1"
+    chalk "^3.0.0"
+    jest-util "^25.5.0"
+    string-length "^3.1.0"
+
+jest-worker@^25.4.0, jest-worker@^25.5.0:
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-25.5.0.tgz#2611d071b79cea0f43ee57a3d118593ac1547db1"
-  integrity sha1-JhHQcbec6g9D7lej0RhZOsFUfbE=
+  integrity sha512-/dsSmUkIy5EBGfv/IjjqmFxrNAUpBERfGs1oHROyD7yxjG/w+t0GOJDX8O1k32ySmd7+a5IhnJU2qQFcJ4n1vw==
   dependencies:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
+
+jest@^25.5.4:
+  version "25.5.4"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-25.5.4.tgz#f21107b6489cfe32b076ce2adcadee3587acb9db"
+  integrity sha512-hHFJROBTqZahnO+X+PMtT6G2/ztqAZJveGqz//FnWWHurizkD05PQGzRZOhF3XP6z7SJmL+5tCfW8qV06JypwQ==
+  dependencies:
+    "@jest/core" "^25.5.4"
+    import-local "^3.0.2"
+    jest-cli "^25.5.4"
 
 js-base64@^2.1.8, js-base64@^2.1.9:
   version "2.5.2"
@@ -8730,6 +9553,38 @@ jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
+
+jsdom@^15.2.1:
+  version "15.2.1"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-15.2.1.tgz#d2feb1aef7183f86be521b8c6833ff5296d07ec5"
+  integrity sha512-fAl1W0/7T2G5vURSyxBzrJ1LSdQn6Tr5UX/xD4PXDx/PDgwygedfW6El/KIj3xJ7FU61TTYnc/l/B7P49Eqt6g==
+  dependencies:
+    abab "^2.0.0"
+    acorn "^7.1.0"
+    acorn-globals "^4.3.2"
+    array-equal "^1.0.0"
+    cssom "^0.4.1"
+    cssstyle "^2.0.0"
+    data-urls "^1.1.0"
+    domexception "^1.0.1"
+    escodegen "^1.11.1"
+    html-encoding-sniffer "^1.0.2"
+    nwsapi "^2.2.0"
+    parse5 "5.1.0"
+    pn "^1.1.0"
+    request "^2.88.0"
+    request-promise-native "^1.0.7"
+    saxes "^3.1.9"
+    symbol-tree "^3.2.2"
+    tough-cookie "^3.0.1"
+    w3c-hr-time "^1.0.1"
+    w3c-xmlserializer "^1.1.2"
+    webidl-conversions "^4.0.2"
+    whatwg-encoding "^1.0.5"
+    whatwg-mimetype "^2.3.0"
+    whatwg-url "^7.0.0"
+    ws "^7.0.0"
+    xml-name-validator "^3.0.0"
 
 jsdom@^9.9.1:
   version "9.12.0"
@@ -8947,6 +9802,11 @@ klaw@^1.0.0:
   optionalDependencies:
     graceful-fs "^4.1.9"
 
+kleur@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
+  integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
+
 known-css-properties@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/known-css-properties/-/known-css-properties-0.2.0.tgz#899c94be368e55b42d7db8d5be7d73a4a4a41454"
@@ -9047,16 +9907,6 @@ load-json-file@^2.0.0:
     graceful-fs "^4.1.2"
     parse-json "^2.2.0"
     pify "^2.0.0"
-    strip-bom "^3.0.0"
-
-load-json-file@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-4.0.0.tgz#2f5f45ab91e33216234fd53adab668eb4ec0993b"
-  integrity sha1-L19Fq5HjMhYjT9U62rZo607AmTs=
-  dependencies:
-    graceful-fs "^4.1.2"
-    parse-json "^4.0.0"
-    pify "^3.0.0"
     strip-bom "^3.0.0"
 
 loader-runner@^2.3.0, loader-runner@^2.4.0:
@@ -9169,6 +10019,11 @@ lodash.merge@^4.6.1:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha1-VYqlO0O2YeGSWgr9+japoQhf5Xo=
 
+lodash.sortby@^4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
+  integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
+
 lodash.tail@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.tail/-/lodash.tail-4.1.1.tgz#d2333a36d9e7717c8ad2f7cacafec7c32b444664"
@@ -9200,6 +10055,13 @@ loglevel@^1.4.1, loglevel@^1.6.8:
   version "1.6.8"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.8.tgz#8a25fb75d092230ecd4457270d80b54e28011171"
   integrity sha1-iiX7ddCSIw7NRFcnDYC1TigBEXE=
+
+lolex@^5.0.0:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-5.1.2.tgz#953694d098ce7c07bc5ed6d0e42bc6c0c6d5a367"
+  integrity sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==
+  dependencies:
+    "@sinonjs/commons" "^1.7.0"
 
 longest@^1.0.1:
   version "1.0.1"
@@ -9256,7 +10118,7 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
-make-dir@^1.0.0, make-dir@^1.3.0:
+make-dir@^1.0.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.3.0.tgz#79c1033b80515bd6d24ec9933e860ca75ee27f0c"
   integrity sha1-ecEDO4BRW9bSTsmTPoYMp17ifww=
@@ -9271,12 +10133,19 @@ make-dir@^2.0.0, make-dir@^2.1.0:
     pify "^4.0.1"
     semver "^5.6.0"
 
-make-dir@^3.0.2:
+make-dir@^3.0.0, make-dir@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"
-  integrity sha1-QV6WcEazp/HRhSd9hKpYIDcmoT8=
+  integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
   dependencies:
     semver "^6.0.0"
+
+makeerror@1.0.x:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
+  integrity sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=
+  dependencies:
+    tmpl "1.0.x"
 
 map-age-cleaner@^0.1.1:
   version "0.1.3"
@@ -9437,13 +10306,6 @@ merge-descriptors@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
   integrity sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=
-
-merge-source-map@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/merge-source-map/-/merge-source-map-1.1.0.tgz#2fdde7e6020939f70906a68f2d7ae685e4c8c646"
-  integrity sha1-L93n5gIJOfcJBqaPLXrmheTIxkY=
-  dependencies:
-    source-map "^0.6.1"
 
 merge-stream@^2.0.0:
   version "2.0.0"
@@ -9613,7 +10475,7 @@ minimatch@3.0.4, minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.1.0, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5, minimist@~1.2.0:
+minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI=
@@ -9935,6 +10797,11 @@ node-gyp@^3.8.0:
     tar "^2.0.0"
     which "1"
 
+node-int64@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
+  integrity sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=
+
 node-libs-browser@^2.0.0, node-libs-browser@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/node-libs-browser/-/node-libs-browser-2.2.1.tgz#b64f513d18338625f90346d27b0d235e631f6425"
@@ -9968,6 +10835,17 @@ node-modules-regexp@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
   integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
+
+node-notifier@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-6.0.0.tgz#cea319e06baa16deec8ce5cd7f133c4a46b68e12"
+  integrity sha512-SVfQ/wMw+DesunOm5cKqr6yDcvUTDl/yc97ybGHMrteNEY6oekXpNpS3lZwgLlwz0FLgHoiW28ZpmBHUDg37cw==
+  dependencies:
+    growly "^1.3.0"
+    is-wsl "^2.1.1"
+    semver "^6.3.0"
+    shellwords "^0.1.1"
+    which "^1.3.1"
 
 node-pre-gyp@^0.10.0:
   version "0.10.3"
@@ -10028,7 +10906,7 @@ nopt@^4.0.1, nopt@~4.0.1:
     abbrev "1"
     osenv "^0.1.4"
 
-normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
+normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-data@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
   integrity sha1-5m2xg4sgDB38IzIl0SyzZSDiNKg=
@@ -10098,6 +10976,13 @@ npm-run-path@^2.0.0:
   dependencies:
     path-key "^2.0.0"
 
+npm-run-path@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-4.0.1.tgz#b7ecd1e5ed53da8e37a55e1c2269e0b97ed748ea"
+  integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
+  dependencies:
+    path-key "^3.0.0"
+
 "npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.0, npmlog@^4.0.2, npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
@@ -10130,35 +11015,10 @@ number-is-nan@^1.0.0:
   resolved "https://registry.yarnpkg.com/nwmatcher/-/nwmatcher-1.4.4.tgz#2285631f34a95f0d0395cd900c96ed39b58f346e"
   integrity sha1-IoVjHzSpXw0Dlc2QDJbtObWPNG4=
 
-nyc@^13.0.1:
-  version "13.3.0"
-  resolved "https://registry.yarnpkg.com/nyc/-/nyc-13.3.0.tgz#da4dbe91a9c8b9ead3f4f3344c76f353e3c78c75"
-  integrity sha1-2k2+kanIuerT9PM0THbzU+PHjHU=
-  dependencies:
-    archy "^1.0.0"
-    arrify "^1.0.1"
-    caching-transform "^3.0.1"
-    convert-source-map "^1.6.0"
-    find-cache-dir "^2.0.0"
-    find-up "^3.0.0"
-    foreground-child "^1.5.6"
-    glob "^7.1.3"
-    istanbul-lib-coverage "^2.0.3"
-    istanbul-lib-hook "^2.0.3"
-    istanbul-lib-instrument "^3.1.0"
-    istanbul-lib-report "^2.0.4"
-    istanbul-lib-source-maps "^3.0.2"
-    istanbul-reports "^2.1.1"
-    make-dir "^1.3.0"
-    merge-source-map "^1.1.0"
-    resolve-from "^4.0.0"
-    rimraf "^2.6.3"
-    signal-exit "^3.0.2"
-    spawn-wrap "^1.4.2"
-    test-exclude "^5.1.0"
-    uuid "^3.3.2"
-    yargs "^12.0.5"
-    yargs-parser "^11.1.1"
+nwsapi@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.0.tgz#204879a9e3d068ff2a55139c2c772780681a38b7"
+  integrity sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==
 
 oauth-sign@~0.9.0:
   version "0.9.0"
@@ -10179,7 +11039,7 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-inspect@^1.7.0, object-inspect@~1.7.0:
+object-inspect@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.7.0.tgz#f4f6bd181ad77f006b5ece60bd0b6f398ff74a67"
   integrity sha1-9Pa9GBrXfwBrXs5gvQtvOY/3Smc=
@@ -10450,7 +11310,7 @@ os-locale@^2.0.0:
     lcid "^1.0.0"
     mem "^1.1.0"
 
-os-locale@^3.0.0, os-locale@^3.1.0:
+os-locale@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-3.1.0.tgz#a802a6ee17f24c10483ab9935719cef4ed16bf1a"
   integrity sha1-qAKm7hfyTBBIOrmTVxnO9O0Wvxo=
@@ -10477,10 +11337,20 @@ p-defer@^1.0.0:
   resolved "https://registry.yarnpkg.com/p-defer/-/p-defer-1.0.0.tgz#9f6eb182f6c9aa8cd743004a7d4f96b196b0fb0c"
   integrity sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=
 
+p-each-series@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/p-each-series/-/p-each-series-2.1.0.tgz#961c8dd3f195ea96c747e636b262b800a6b1af48"
+  integrity sha512-ZuRs1miPT4HrjFa+9fRfOFXxGJfORgelKV9f9nNOWw2gl6gVsRaVDOQP0+MI0G0wGKns1Yacsu0GjOFbTK0JFQ==
+
 p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
   integrity sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
+
+p-finally@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-2.0.1.tgz#bd6fcaa9c559a096b680806f4d657b3f0f240561"
+  integrity sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==
 
 p-is-promise@^2.0.0:
   version "2.1.0"
@@ -10555,16 +11425,6 @@ p-try@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=
-
-package-hash@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/package-hash/-/package-hash-3.0.0.tgz#50183f2d36c9e3e528ea0a8605dff57ce976f88e"
-  integrity sha1-UBg/LTbJ4+Uo6gqGBd/1fOl2+I4=
-  dependencies:
-    graceful-fs "^4.1.15"
-    hasha "^3.0.0"
-    lodash.flattendeep "^4.4.0"
-    release-zalgo "^1.0.0"
 
 pako@~1.0.5:
   version "1.0.11"
@@ -10678,6 +11538,11 @@ parse-passwd@^1.0.0:
   resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
   integrity sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=
 
+parse5@5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.0.tgz#c59341c9723f414c452975564c7c00a68d58acd2"
+  integrity sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==
+
 parse5@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-1.5.1.tgz#9b7f3b0de32be78dc2401b17573ccaf0f6f59d94"
@@ -10749,6 +11614,11 @@ path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
   integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
+
+path-key@^3.0.0, path-key@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
+  integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
 path-parse@^1.0.6:
   version "1.0.6"
@@ -10861,10 +11731,10 @@ pipetteur@^2.0.0:
     onecolor "^3.0.4"
     synesthesia "^1.0.1"
 
-pirates@^4.0.0:
+pirates@^4.0.0, pirates@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.1.tgz#643a92caf894566f91b2b986d2c66950a8e2fb87"
-  integrity sha1-ZDqSyviUVm+RsrmG0sZpUKji+4c=
+  integrity sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==
   dependencies:
     node-modules-regexp "^1.0.0"
 
@@ -10882,10 +11752,10 @@ pkg-dir@^3.0.0:
   dependencies:
     find-up "^3.0.0"
 
-pkg-dir@^4.1.0:
+pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
-  integrity sha1-8JkTPfft5CLoHR2ESCcO6z5CYfM=
+  integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
 
@@ -10921,6 +11791,11 @@ pluralize@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
   integrity sha1-KYuJ34uTsCIdv0Ia0rGx6iP8Z3c=
+
+pn@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
+  integrity sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==
 
 pnp-webpack-plugin@1.5.0:
   version "1.5.0"
@@ -11401,6 +12276,16 @@ pretty-error@^2.0.2, pretty-error@^2.1.1:
     renderkid "^2.0.1"
     utila "~0.4"
 
+pretty-format@^25.5.0:
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-25.5.0.tgz#7873c1d774f682c34b8d48b6743a2bf2ac55791a"
+  integrity sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==
+  dependencies:
+    "@jest/types" "^25.5.0"
+    ansi-regex "^5.0.0"
+    ansi-styles "^4.0.0"
+    react-is "^16.12.0"
+
 pretty-hrtime@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
@@ -11490,6 +12375,14 @@ promise@^7.1.1:
   integrity sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=
   dependencies:
     asap "~2.0.3"
+
+prompts@^2.0.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.3.2.tgz#480572d89ecf39566d2bd3fe2c9fccb7c4c0b068"
+  integrity sha512-Q06uKs2CkNYVID0VqwfAl9mipo99zkBv/n2JtWY89Yxa3ZabWSrs0e2KTudKVa3peLUvYXMefDqIleLPVUBZMA==
+  dependencies:
+    kleur "^3.0.3"
+    sisteransi "^1.0.4"
 
 prop-types-exact@^1.2.0:
   version "1.2.0"
@@ -12158,13 +13051,14 @@ read-pkg-up@^2.0.0:
     find-up "^2.0.0"
     read-pkg "^2.0.0"
 
-read-pkg-up@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-4.0.0.tgz#1b221c6088ba7799601c808f91161c66e58f8978"
-  integrity sha1-GyIcYIi6d5lgHICPkRYcZuWPiXg=
+read-pkg-up@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-7.0.1.tgz#f3a6135758459733ae2b95638056e1854e7ef507"
+  integrity sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==
   dependencies:
-    find-up "^3.0.0"
-    read-pkg "^3.0.0"
+    find-up "^4.1.0"
+    read-pkg "^5.2.0"
+    type-fest "^0.8.1"
 
 read-pkg@^1.0.0:
   version "1.1.0"
@@ -12184,15 +13078,6 @@ read-pkg@^2.0.0:
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
 
-read-pkg@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-3.0.0.tgz#9cbc686978fee65d16c00e2b19c237fcf6e38389"
-  integrity sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=
-  dependencies:
-    load-json-file "^4.0.0"
-    normalize-package-data "^2.3.2"
-    path-type "^3.0.0"
-
 read-pkg@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-4.0.1.tgz#963625378f3e1c4d48c85872b5a6ec7d5d093237"
@@ -12201,6 +13086,16 @@ read-pkg@^4.0.1:
     normalize-package-data "^2.3.2"
     parse-json "^4.0.0"
     pify "^3.0.0"
+
+read-pkg@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-5.2.0.tgz#7bf295438ca5a33e56cd30e053b34ee7250c93cc"
+  integrity sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==
+  dependencies:
+    "@types/normalize-package-data" "^2.4.0"
+    normalize-package-data "^2.5.0"
+    parse-json "^5.0.0"
+    type-fest "^0.6.0"
 
 "readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.7"
@@ -12271,6 +13166,11 @@ readdirp@~3.4.0:
   integrity sha1-n9zN+ekVWAVEkiGsZF6DA6tbmto=
   dependencies:
     picomatch "^2.2.1"
+
+realpath-native@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/realpath-native/-/realpath-native-2.0.0.tgz#7377ac429b6e1fd599dc38d08ed942d0d7beb866"
+  integrity sha512-v1SEYUOXXdbBZK8ZuNgO4TBjamPsiSgcFr0aP+tEKpQZK8vooEUqV6nm6Cv502mX4NF2EfsnVqtNAHG+/6Ur1Q==
 
 recast@^0.14.7:
   version "0.14.7"
@@ -12492,13 +13392,6 @@ relateurl@0.2.x, relateurl@^0.2.7:
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
   integrity sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=
 
-release-zalgo@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/release-zalgo/-/release-zalgo-1.0.0.tgz#09700b7e5074329739330e535c5a90fb67851730"
-  integrity sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=
-  dependencies:
-    es6-error "^4.0.1"
-
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
@@ -12531,6 +13424,22 @@ repeating@^2.0.0:
   integrity sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=
   dependencies:
     is-finite "^1.0.0"
+
+request-promise-core@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.3.tgz#e9a3c081b51380dfea677336061fea879a829ee9"
+  integrity sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==
+  dependencies:
+    lodash "^4.17.15"
+
+request-promise-native@^1.0.7:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.8.tgz#a455b960b826e44e2bf8999af64dff2bfe58cb36"
+  integrity sha512-dapwLGqkHtwL5AEbfenuzjTYg35Jd6KPytsC2/TLkVMz8rm+tNt72MGUWT1RP/aYawMpN6HqbNGBQaRcBtjQMQ==
+  dependencies:
+    request-promise-core "1.1.3"
+    stealthy-require "^1.1.1"
+    tough-cookie "^2.3.3"
 
 request@^2.79.0, request@^2.87.0, request@^2.88.0:
   version "2.88.2"
@@ -12608,6 +13517,13 @@ resolve-cwd@^2.0.0:
   dependencies:
     resolve-from "^3.0.0"
 
+resolve-cwd@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-3.0.0.tgz#0f0075f1bb2544766cf73ba6a6e2adfebcb13f2d"
+  integrity sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==
+  dependencies:
+    resolve-from "^5.0.0"
+
 resolve-dir@^1.0.0, resolve-dir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-dir/-/resolve-dir-1.0.1.tgz#79a40644c362be82f26effe739c9bb5382046f43"
@@ -12651,17 +13567,10 @@ resolve@1.1.7:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
-resolve@^1.1.3, resolve@^1.1.4, resolve@^1.1.6, resolve@^1.10.0, resolve@^1.11.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.15.1, resolve@^1.2.0, resolve@^1.3.2:
+resolve@^1.1.3, resolve@^1.1.4, resolve@^1.1.6, resolve@^1.10.0, resolve@^1.11.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.15.1, resolve@^1.17.0, resolve@^1.2.0, resolve@^1.3.2:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
   integrity sha1-sllBtUloIxzC0bt2p5y38sC/hEQ=
-  dependencies:
-    path-parse "^1.0.6"
-
-resolve@~1.15.1:
-  version "1.15.1"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.15.1.tgz#27bdcdeffeaf2d6244b95bb0f9f4b4653451f3e8"
-  integrity sha1-J73N7/6vLWJEuVuw+fS0ZTRR8+g=
   dependencies:
     path-parse "^1.0.6"
 
@@ -12680,13 +13589,6 @@ restore-cursor@^3.1.0:
   dependencies:
     onetime "^5.1.0"
     signal-exit "^3.0.2"
-
-resumer@~0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/resumer/-/resumer-0.0.0.tgz#f1e8f461e4064ba39e82af3cdc2a8c893d076759"
-  integrity sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=
-  dependencies:
-    through "~2.3.4"
 
 ret@~0.1.10:
   version "0.1.15"
@@ -12719,6 +13621,13 @@ rimraf@2.6.3, rimraf@~2.6.2:
   dependencies:
     glob "^7.1.3"
 
+rimraf@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
+
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"
@@ -12734,6 +13643,11 @@ rst-selector-parser@^2.2.3:
   dependencies:
     lodash.flattendeep "^4.4.0"
     nearley "^2.7.10"
+
+rsvp@^4.8.4:
+  version "4.8.5"
+  resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
+  integrity sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==
 
 run-async@^2.2.0, run-async@^2.4.0:
   version "2.4.1"
@@ -12798,6 +13712,21 @@ safe-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=
 
+sane@^4.0.3:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/sane/-/sane-4.1.0.tgz#ed881fd922733a6c461bc189dc2b6c006f3ffded"
+  integrity sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==
+  dependencies:
+    "@cnakazawa/watch" "^1.0.3"
+    anymatch "^2.0.0"
+    capture-exit "^2.0.0"
+    exec-sh "^0.3.2"
+    execa "^1.0.0"
+    fb-watchman "^2.0.0"
+    micromatch "^3.1.4"
+    minimist "^1.1.1"
+    walker "~1.0.5"
+
 sass-graph@2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/sass-graph/-/sass-graph-2.2.5.tgz#a981c87446b8319d96dce0671e487879bd24c2e8"
@@ -12834,6 +13763,13 @@ sax@^1.2.1, sax@^1.2.4, sax@~1.2.1, sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha1-KBYjTiN4vdxOU1T6tcqold9xANk=
+
+saxes@^3.1.9:
+  version "3.1.11"
+  resolved "https://registry.yarnpkg.com/saxes/-/saxes-3.1.11.tgz#d59d1fd332ec92ad98a2e0b2ee644702384b1c5b"
+  integrity sha512-Ydydq3zC+WYDJK1+gRxRapLIED9PWeSuuS41wqyoRmzvhhh9nc+QQrVMKJYzJFULazeGhzSV0QleN2wD3boh2g==
+  dependencies:
+    xmlchars "^2.1.1"
 
 scheduler@^0.19.1:
   version "0.19.1"
@@ -13089,10 +14025,22 @@ shebang-command@^1.2.0:
   dependencies:
     shebang-regex "^1.0.0"
 
+shebang-command@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
+  integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
+  dependencies:
+    shebang-regex "^3.0.0"
+
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
+
+shebang-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
+  integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
 shell-quote@1.7.2, shell-quote@^1.6.1:
   version "1.7.2"
@@ -13107,6 +14055,11 @@ shelljs@^0.8.3:
     glob "^7.0.0"
     interpret "^1.0.0"
     rechoir "^0.6.2"
+
+shellwords@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
+  integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
 side-channel@^1.0.2:
   version "1.0.2"
@@ -13151,6 +14104,11 @@ simplebar@^4.2.3:
     lodash.throttle "^4.1.1"
     resize-observer-polyfill "^1.5.1"
 
+sisteransi@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
+  integrity sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==
+
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
@@ -13160,6 +14118,11 @@ slash@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
   integrity sha1-3lUoUaF1nfOo8gZTVEL17E3eq0Q=
+
+slash@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
+  integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
 slice-ansi@1.0.0:
   version "1.0.0"
@@ -13290,10 +14253,10 @@ source-map-support@^0.4.15:
   dependencies:
     source-map "^0.5.6"
 
-source-map-support@^0.5.16, source-map-support@~0.5.12:
+source-map-support@^0.5.16, source-map-support@^0.5.6, source-map-support@~0.5.12:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
-  integrity sha1-qYti+G3K9PZzmWSMCFKRq56P7WE=
+  integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
@@ -13329,18 +14292,6 @@ space-separated-tokens@^1.0.0:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz#85f32c3d10d9682007e917414ddc5c26d1aa6899"
   integrity sha1-hfMsPRDZaCAH6RdBTdxcJtGqaJk=
-
-spawn-wrap@^1.4.2:
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/spawn-wrap/-/spawn-wrap-1.4.3.tgz#81b7670e170cca247d80bf5faf0cfb713bdcf848"
-  integrity sha1-gbdnDhcMyiR9gL9frwz7cTvc+Eg=
-  dependencies:
-    foreground-child "^1.5.6"
-    mkdirp "^0.5.0"
-    os-homedir "^1.0.1"
-    rimraf "^2.6.2"
-    signal-exit "^3.0.2"
-    which "^1.3.0"
 
 spdx-correct@^3.0.0:
   version "3.1.1"
@@ -13457,6 +14408,11 @@ stable@^0.1.8:
   resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.8.tgz#836eb3c8382fe2936feaf544631017ce7d47a3cf"
   integrity sha1-g26zyDgv4pNv6vVEYxAXzn1Ho88=
 
+stack-utils@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.2.tgz#33eba3897788558bebfc2db059dc158ec36cebb8"
+  integrity sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==
+
 static-extend@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
@@ -13476,6 +14432,11 @@ stdout-stream@^1.4.0:
   integrity sha1-WsF0zdXNcmEEqgwLK9g4FdjVNd4=
   dependencies:
     readable-stream "^2.0.1"
+
+stealthy-require@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
+  integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
 
 store2@^2.7.1:
   version "2.11.2"
@@ -13558,6 +14519,14 @@ strict-uri-encode@^1.0.0:
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
   integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
 
+string-length@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/string-length/-/string-length-3.1.0.tgz#107ef8c23456e187a8abd4a61162ff4ac6e25837"
+  integrity sha512-Ttp5YvkGm5v9Ijagtaz1BnN+k9ObpvS0eIBblPMp2YWL8FBmi9qblQ9fexc2k/CXFgrTIteU3jAw3payCnwSTA==
+  dependencies:
+    astral-regex "^1.0.0"
+    strip-ansi "^5.2.0"
+
 string-width@^1.0.1, string-width@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
@@ -13584,7 +14553,7 @@ string-width@^3.0.0, string-width@^3.1.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
 
-string-width@^4.0.0, string-width@^4.1.0:
+string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.0.tgz#952182c46cc7b2c313d1596e623992bd163b72b5"
   integrity sha1-lSGCxGzHssMT0VluYjmSvRY7crU=
@@ -13621,7 +14590,7 @@ string.prototype.padstart@^3.0.0:
     define-properties "^1.1.3"
     es-abstract "^1.17.0-next.1"
 
-string.prototype.trim@^1.2.1, string.prototype.trim@~1.2.1:
+string.prototype.trim@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.2.1.tgz#141233dff32c82bfad80684d7e5f0869ee0fb782"
   integrity sha1-FBIz3/Msgr+tgGhNfl8Iae4Pt4I=
@@ -13730,10 +14699,20 @@ strip-bom@^3.0.0:
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
   integrity sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=
 
+strip-bom@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-4.0.0.tgz#9c3505c1db45bcedca3d9cf7a16f5c5aa3901878"
+  integrity sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==
+
 strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
   integrity sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=
+
+strip-final-newline@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
+  integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
 
 strip-indent@^1.0.1:
   version "1.0.1"
@@ -13908,6 +14887,14 @@ supports-color@^7.0.0, supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
+supports-hyperlinks@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/supports-hyperlinks/-/supports-hyperlinks-2.1.0.tgz#f663df252af5f37c5d49bbd7eeefa9e0b9e59e47"
+  integrity sha512-zoE5/e+dnEijk6ASB6/qrK+oYdm2do1hjoLWrqUC/8WEIW1gbxFcKuBof7sW8ArN6e+AYvsE8HBGiVRWL/F5CA==
+  dependencies:
+    has-flag "^4.0.0"
+    supports-color "^7.0.0"
+
 svg-parser@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/svg-parser/-/svg-parser-2.0.4.tgz#fdc2e29e13951736140b76cb122c8ee6630eb6b5"
@@ -13955,10 +14942,10 @@ symbol-observable@^1.0.3:
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
   integrity sha1-wiaIrtTqs83C3+rLtWFmBWCgCAQ=
 
-symbol-tree@^3.2.1:
+symbol-tree@^3.2.1, symbol-tree@^3.2.2:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
-  integrity sha1-QwY30ki6d+B4iDlR+5qg7tfGP6I=
+  integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
 symbol.prototype.description@^1.0.0:
   version "1.0.2"
@@ -14026,27 +15013,6 @@ tapable@^1.0.0, tapable@^1.1.3:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha1-ofzMBrWNth/XpF2i2kT186Pme6I=
 
-tape@^4.6.3:
-  version "4.13.2"
-  resolved "https://registry.yarnpkg.com/tape/-/tape-4.13.2.tgz#eb419b9d9bc004025b1a81a5b63093e07f425629"
-  integrity sha1-60GbnZvABAJbGoGltjCT4H9CVik=
-  dependencies:
-    deep-equal "~1.1.1"
-    defined "~1.0.0"
-    dotignore "~0.1.2"
-    for-each "~0.3.3"
-    function-bind "~1.1.1"
-    glob "~7.1.6"
-    has "~1.0.3"
-    inherits "~2.0.4"
-    is-regex "~1.0.5"
-    minimist "~1.2.0"
-    object-inspect "~1.7.0"
-    resolve "~1.15.1"
-    resumer "~0.0.0"
-    string.prototype.trim "~1.2.1"
-    through "~2.3.8"
-
 tar@^2.0.0:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.2.tgz#0ca8848562c7299b8b446ff6a4d60cdbb23edc40"
@@ -14088,6 +15054,14 @@ term-size@^2.1.0:
   resolved "https://registry.yarnpkg.com/term-size/-/term-size-2.2.0.tgz#1f16adedfe9bdc18800e1776821734086fcc6753"
   integrity sha1-Hxat7f6b3BiADhd2ghc0CG/MZ1M=
 
+terminal-link@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/terminal-link/-/terminal-link-2.1.1.tgz#14a64a27ab3c0df933ea546fba55f2d078edc994"
+  integrity sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==
+  dependencies:
+    ansi-escapes "^4.2.1"
+    supports-hyperlinks "^2.0.0"
+
 terser-webpack-plugin@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz#5ecaf2dbdc5fb99745fd06791f46fc9ddb1c9a7c"
@@ -14127,20 +15101,24 @@ terser@^4.1.2, terser@^4.6.12, terser@^4.6.3:
     source-map "~0.6.1"
     source-map-support "~0.5.12"
 
-test-exclude@^5.1.0:
-  version "5.2.3"
-  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-5.2.3.tgz#c3d3e1e311eb7ee405e092dac10aefd09091eac0"
-  integrity sha1-w9Ph4xHrfuQF4JLawQrv0JCR6sA=
+test-exclude@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-6.0.0.tgz#04a8698661d805ea6fa293b6cb9e63ac044ef15e"
+  integrity sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==
   dependencies:
-    glob "^7.1.3"
+    "@istanbuljs/schema" "^0.1.2"
+    glob "^7.1.4"
     minimatch "^3.0.4"
-    read-pkg-up "^4.0.0"
-    require-main-filename "^2.0.0"
 
 text-table@0.2.0, text-table@^0.2.0, text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
+
+throat@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/throat/-/throat-5.0.0.tgz#c5199235803aad18754a667d659b5e72ce16764b"
+  integrity sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==
 
 throttle-debounce@^2.1.0:
   version "2.1.0"
@@ -14163,7 +15141,7 @@ through2@^2.0.0:
     readable-stream "~2.3.6"
     xtend "~4.0.1"
 
-"through@>=2.2.7 <3", through@^2.3.6, through@~2.3.4, through@~2.3.8:
+"through@>=2.2.7 <3", through@^2.3.6, through@~2.3.4:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
@@ -14223,6 +15201,11 @@ tmp@^0.0.33:
   integrity sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=
   dependencies:
     os-tmpdir "~1.0.2"
+
+tmpl@1.0.x:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.4.tgz#23640dd7b42d00433911140820e5cf440e521dd1"
+  integrity sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=
 
 to-arraybuffer@^1.0.0:
   version "1.0.1"
@@ -14381,13 +15364,29 @@ toposort@^1.0.0:
   resolved "https://registry.yarnpkg.com/toposort/-/toposort-1.0.7.tgz#2e68442d9f64ec720b8cc89e6443ac6caa950029"
   integrity sha1-LmhELZ9k7HILjMieZEOsbKqVACk=
 
-tough-cookie@^2.3.2, tough-cookie@~2.5.0:
+tough-cookie@^2.3.2, tough-cookie@^2.3.3, tough-cookie@~2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
   integrity sha1-zZ+yoKodWhK0c72fuW+j3P9lreI=
   dependencies:
     psl "^1.1.28"
     punycode "^2.1.1"
+
+tough-cookie@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-3.0.1.tgz#9df4f57e739c26930a018184887f4adb7dca73b2"
+  integrity sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==
+  dependencies:
+    ip-regex "^2.1.0"
+    psl "^1.1.28"
+    punycode "^2.1.1"
+
+tr46@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-1.0.1.tgz#a8b13fd6bfd2489519674ccde55ba3693b706d09"
+  integrity sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=
+  dependencies:
+    punycode "^2.1.0"
 
 tr46@~0.0.3:
   version "0.0.3"
@@ -14455,10 +15454,20 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
+type-detect@4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
+  integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
+
 type-fest@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.11.0.tgz#97abf0872310fed88a5c466b25681576145e33f1"
   integrity sha1-l6vwhyMQ/tiKXEZrJWgVdhReM/E=
+
+type-fest@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
+  integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
 
 type-fest@^0.8.1:
   version "0.8.1"
@@ -14487,6 +15496,13 @@ typed-styles@^0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/typed-styles/-/typed-styles-0.0.7.tgz#93392a008794c4595119ff62dde6809dbc40a3d9"
   integrity sha1-kzkqAIeUxFlRGf9i3eaAnbxAo9k=
+
+typedarray-to-buffer@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
+  integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
+  dependencies:
+    is-typedarray "^1.0.0"
 
 typedarray@^0.0.6, typedarray@~0.0.5:
   version "0.0.6"
@@ -14778,6 +15794,15 @@ v8-compile-cache@^2.0.3:
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz#e14de37b31a6d194f5690d67efc4e7f6fc6ab30e"
   integrity sha1-4U3jezGm0ZT1aQ1n78Tn9vxqsw4=
 
+v8-to-istanbul@^4.1.3:
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-4.1.4.tgz#b97936f21c0e2d9996d4985e5c5156e9d4e49cd6"
+  integrity sha512-Rw6vJHj1mbdK8edjR7+zuJrpDtKIgNdAvTSAcpYfgMIw+u2dPDntD3dgN4XQFLU2/fvFQdzj+EeSGfd/jnY5fQ==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.1"
+    convert-source-map "^1.6.0"
+    source-map "^0.7.3"
+
 v8flags@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/v8flags/-/v8flags-3.1.3.tgz#fc9dc23521ca20c5433f81cc4eb9b3033bb105d8"
@@ -14829,6 +15854,29 @@ vm-browserify@~0.0.1:
   dependencies:
     indexof "0.0.1"
 
+w3c-hr-time@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz#0a89cdf5cc15822df9c360543676963e0cc308cd"
+  integrity sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==
+  dependencies:
+    browser-process-hrtime "^1.0.0"
+
+w3c-xmlserializer@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/w3c-xmlserializer/-/w3c-xmlserializer-1.1.2.tgz#30485ca7d70a6fd052420a3d12fd90e6339ce794"
+  integrity sha512-p10l/ayESzrBMYWRID6xbuCKh2Fp77+sA0doRuGn4tTIMrrZVeqfpKjXHY+oDh3K4nLdPgNwMTVP6Vp4pvqbNg==
+  dependencies:
+    domexception "^1.0.1"
+    webidl-conversions "^4.0.2"
+    xml-name-validator "^3.0.0"
+
+walker@^1.0.7, walker@~1.0.5:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"
+  integrity sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=
+  dependencies:
+    makeerror "1.0.x"
+
 warning@^4.0.1, warning@^4.0.2, warning@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
@@ -14866,10 +15914,10 @@ webidl-conversions@^3.0.0:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
   integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
 
-webidl-conversions@^4.0.0:
+webidl-conversions@^4.0.0, webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
-  integrity sha1-qFWYCx8LazWbodXZ+zmulB+qY60=
+  integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
 
 webpack-cli@^3.3.11:
   version "3.3.11"
@@ -15093,7 +16141,7 @@ websocket-extensions@>=0.1.1:
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.3.tgz#5d2ff22977003ec687a4b87073dfbbac146ccf29"
   integrity sha1-XS/yKXcAPsaHpLhwc9+7rBRszyk=
 
-whatwg-encoding@^1.0.1:
+whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz#5abacf777c32166a51d085d6b4f3e7d27113ddb0"
   integrity sha1-WrrPd3wyFmpR0IXWtPPn0nET3bA=
@@ -15110,6 +16158,11 @@ whatwg-fetch@^2.0.3:
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
   integrity sha1-3eal3zFfnTmZGqF2IYU9cguFVm8=
 
+whatwg-mimetype@^2.2.0, whatwg-mimetype@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
+  integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
+
 whatwg-url@^4.3.0:
   version "4.8.0"
   resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-4.8.0.tgz#d2981aa9148c1e00a41c5a6131166ab4683bbcc0"
@@ -15117,6 +16170,15 @@ whatwg-url@^4.3.0:
   dependencies:
     tr46 "~0.0.3"
     webidl-conversions "^3.0.0"
+
+whatwg-url@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-7.1.0.tgz#c2c492f1eca612988efd3d2266be1b9fc6170d06"
+  integrity sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==
+  dependencies:
+    lodash.sortby "^4.7.0"
+    tr46 "^1.0.1"
+    webidl-conversions "^4.0.2"
 
 whet.extend@~0.9.9:
   version "0.9.9"
@@ -15133,10 +16195,17 @@ which-module@^2.0.0:
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
 
-which@1, which@^1.2.14, which@^1.2.9, which@^1.3.0, which@^1.3.1:
+which@1, which@^1.2.14, which@^1.2.9, which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=
+  dependencies:
+    isexe "^2.0.0"
+
+which@^2.0.1, which@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
+  integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
 
@@ -15205,19 +16274,29 @@ wrap-ansi@^5.1.0:
     string-width "^3.0.0"
     strip-ansi "^5.0.0"
 
+wrap-ansi@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
+  integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
-write-file-atomic@^2.4.2:
-  version "2.4.3"
-  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.4.3.tgz#1fd2e9ae1df3e75b8d8c367443c692d4ca81f481"
-  integrity sha1-H9Lprh3z51uNjDZ0Q8aS1MqB9IE=
+write-file-atomic@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-3.0.3.tgz#56bd5c5a5c70481cd19c571bd39ab965a5de56e8"
+  integrity sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==
   dependencies:
-    graceful-fs "^4.1.11"
     imurmurhash "^0.1.4"
+    is-typedarray "^1.0.0"
     signal-exit "^3.0.2"
+    typedarray-to-buffer "^3.1.5"
 
 write-file-stdout@0.0.2:
   version "0.0.2"
@@ -15245,10 +16324,25 @@ ws@^6.2.1:
   dependencies:
     async-limiter "~1.0.0"
 
+ws@^7.0.0:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.3.0.tgz#4b2f7f219b3d3737bc1a2fbf145d825b94d38ffd"
+  integrity sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w==
+
 xml-name-validator@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"
   integrity sha1-TYuPHszTQZqjYgYb7O9RXh5VljU=
+
+xml-name-validator@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
+  integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
+
+xmlchars@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
+  integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
 xregexp@^4.3.0:
   version "4.3.0"
@@ -15267,7 +16361,7 @@ y18n@^3.2.0, y18n@^3.2.1:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
   integrity sha1-bRX7qITAhnnA136I53WegR4H+kE=
 
-"y18n@^3.2.1 || ^4.0.0", y18n@^4.0.0:
+y18n@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
   integrity sha1-le+U+F7MgdAHwmThkKEg8KPIVms=
@@ -15292,18 +16386,18 @@ yaml@^1.7.2:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.0.tgz#3b593add944876077d4d683fee01081bd9fff31e"
   integrity sha1-O1k63ZRIdgd9TWg/7gEIG9n/8x4=
 
-yargs-parser@^11.1.1:
-  version "11.1.1"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-11.1.1.tgz#879a0865973bca9f6bab5cbdf3b1c67ec7d3bcf4"
-  integrity sha1-h5oIZZc7yp9rq1y987HGfsfTvPQ=
-  dependencies:
-    camelcase "^5.0.0"
-    decamelize "^1.2.0"
-
 yargs-parser@^13.1.0, yargs-parser@^13.1.2:
   version "13.1.2"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.2.tgz#130f09702ebaeef2650d54ce6e3e5706f7a4fb38"
   integrity sha1-Ew8JcC667vJlDVTObj5XBvek+zg=
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
+yargs-parser@^18.1.1:
+  version "18.1.3"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
+  integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
@@ -15363,24 +16457,6 @@ yargs@^1.2.6:
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-1.3.3.tgz#054de8b61f22eefdb7207059eaef9d6b83fb931a"
   integrity sha1-BU3oth8i7v23IHBZ6u+da4P7kxo=
 
-yargs@^12.0.5:
-  version "12.0.5"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-12.0.5.tgz#05f5997b609647b64f66b81e3b4b10a368e7ad13"
-  integrity sha1-BfWZe2CWR7ZPZrgeO0sQo2jnrRM=
-  dependencies:
-    cliui "^4.0.0"
-    decamelize "^1.2.0"
-    find-up "^3.0.0"
-    get-caller-file "^1.0.1"
-    os-locale "^3.0.0"
-    require-directory "^2.1.1"
-    require-main-filename "^1.0.1"
-    set-blocking "^2.0.0"
-    string-width "^2.0.0"
-    which-module "^2.0.0"
-    y18n "^3.2.1 || ^4.0.0"
-    yargs-parser "^11.1.1"
-
 yargs@^13.3.2:
   version "13.3.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.3.2.tgz#ad7ffefec1aa59565ac915f82dccb38a9c31a2dd"
@@ -15396,6 +16472,23 @@ yargs@^13.3.2:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^13.1.2"
+
+yargs@^15.3.1:
+  version "15.3.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.3.1.tgz#9505b472763963e54afe60148ad27a330818e98b"
+  integrity sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==
+  dependencies:
+    cliui "^6.0.0"
+    decamelize "^1.2.0"
+    find-up "^4.1.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^4.2.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^18.1.1"
 
 yargs@^3.5.4:
   version "3.32.0"


### PR DESCRIPTION
- remove tape by jest
- migrate all tests to use jest API thanks to [jest-codemods](https://github.com/skovhus/jest-codemods) and some manual modifications
- remove nfc since jest can generate a coverage report without it

The downside compared to the previous setup is that with jest it's not as easy to add custom message on assertions [liek this one](https://github.com/uber/react-vis/pull/1336/files#diff-753830e44e0f494cf072b29f7afca188L111 ) 

If we want to keep the messages, I think we can try [jest-expect-message](https://github.com/mattphillips/jest-expect-message) but I didn't want to add a new dependency before discussing it


