### PR TITLE
Update problematic showcase examples to use hooks

### DIFF
--- a/packages/showcase/examples/force-directed-graph/force-directed-example.js
+++ b/packages/showcase/examples/force-directed-graph/force-directed-example.js
@@ -26,14 +26,14 @@ import ForceDirectedGraph from './force-directed-graph';
 
 const makeStrength = () => Math.random() * 60 - 30;
 export default function ForceDirectedExample() {
-  const [strength, setStrength] = useState(makeStrength());
+  const [strength, setStrength] = useState(makeStrength);
   return (
     <div className="force-directed-example">
       <button
         className="showcase-button"
         onClick={() => setStrength(makeStrength())}
       >
-        {' REWEIGHT '}
+        REWEIGHT
       </button>
       <ForceDirectedGraph
         data={LesMisData}

--- a/packages/showcase/examples/force-directed-graph/force-directed-example.js
+++ b/packages/showcase/examples/force-directed-graph/force-directed-example.js
@@ -18,36 +18,30 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import React from 'react';
+import React, {useState} from 'react';
 import LesMisData from './les-mis-data.json';
 
 import './force-directed.scss';
 import ForceDirectedGraph from './force-directed-graph';
 
-export default class ForceDirectedExample extends React.Component {
-  state = {
-    strength: Math.random() * 60 - 30
-  };
-
-  render() {
-    const {strength} = this.state;
-    return (
-      <div className="force-directed-example">
-        <button
-          className="showcase-button"
-          onClick={() => this.setState({strength: Math.random() * 60 - 30})}
-        >
-          {' '}
-          REWEIGHT{' '}
-        </button>
-        <ForceDirectedGraph
-          data={LesMisData}
-          height={500}
-          width={500}
-          animation
-          strength={strength}
-        />
-      </div>
-    );
-  }
+const makeStrength = () => Math.random() * 60 - 30;
+export default function ForceDirectedExample() {
+  const [strength, setStrength] = useState(makeStrength());
+  return (
+    <div className="force-directed-example">
+      <button
+        className="showcase-button"
+        onClick={() => setStrength(makeStrength())}
+      >
+        {' REWEIGHT '}
+      </button>
+      <ForceDirectedGraph
+        data={LesMisData}
+        height={500}
+        width={500}
+        animation
+        strength={strength}
+      />
+    </div>
+  );
 }

--- a/packages/showcase/examples/force-directed-graph/force-directed-graph.js
+++ b/packages/showcase/examples/force-directed-graph/force-directed-graph.js
@@ -45,7 +45,6 @@ const colors = [
  * @returns {Array} Array of nodes.
  */
 function generateSimulation(props) {
-  console.log('generate sim');
   const {data, height, width, maxSteps, strength} = props;
   if (!data) {
     return {nodes: [], links: []};

--- a/packages/showcase/examples/force-directed-graph/force-directed-graph.js
+++ b/packages/showcase/examples/force-directed-graph/force-directed-graph.js
@@ -18,8 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import React from 'react';
-import PropTypes from 'prop-types';
+import React, {useState, useEffect} from 'react';
 import {forceSimulation, forceLink, forceManyBody, forceCenter} from 'd3-force';
 
 import {XYPlot, MarkSeriesCanvas, LineSeriesCanvas} from 'react-vis';
@@ -44,9 +43,9 @@ const colors = [
 /**
  * Create the list of nodes to render.
  * @returns {Array} Array of nodes.
- * @private
  */
 function generateSimulation(props) {
+  console.log('generate sim');
   const {data, height, width, maxSteps, strength} = props;
   if (!data) {
     return {nodes: [], links: []};
@@ -54,7 +53,7 @@ function generateSimulation(props) {
   // copy the data
   const nodes = data.nodes.map(d => ({...d}));
   const links = data.links.map(d => ({...d}));
-  // build the simuatation
+  // build the simulation
   const simulation = forceSimulation(nodes)
     .force(
       'link',
@@ -76,71 +75,51 @@ function generateSimulation(props) {
   return {nodes, links};
 }
 
-class ForceDirectedGraph extends React.Component {
-  static get defaultProps() {
-    return {
-      className: '',
-      data: {nodes: [], links: []},
-      maxSteps: 50
-    };
-  }
+export default function ForceDirectedGraph(props) {
+  const {
+    className = '',
+    height,
+    width,
+    animation,
+    data = {
+      nodes: [],
+      links: []
+    },
+    maxSteps = 50,
+    strength
+  } = props;
+  const [{nodes, links}, setData] = useState({
+    nodes: [],
+    links: []
+  });
+  useEffect(() => {
+    setData(generateSimulation({data, height, width, maxSteps, strength}));
+  }, [data, height, width, maxSteps, strength]);
 
-  static get propTypes() {
-    return {
-      className: PropTypes.string,
-      data: PropTypes.object.isRequired,
-      height: PropTypes.number.isRequired,
-      width: PropTypes.number.isRequired,
-      steps: PropTypes.number
-    };
-  }
-
-  constructor(props) {
-    super(props);
-    this.state = {
-      data: generateSimulation(props)
-    };
-  }
-
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    this.setState({
-      data: generateSimulation(nextProps)
-    });
-  }
-
-  render() {
-    const {className, height, width, animation} = this.props;
-    const {data} = this.state;
-    const {nodes, links} = data;
-    return (
-      <XYPlot width={width} height={height} className={className}>
-        {links.map(({source, target}, index) => {
-          return (
-            <LineSeriesCanvas
-              animation={animation}
-              color={'#B3AD9E'}
-              key={`link-${index}`}
-              opacity={0.3}
-              data={[
-                {...source, color: null},
-                {...target, color: null}
-              ]}
-            />
-          );
-        })}
-        <MarkSeriesCanvas
-          data={nodes}
-          animation={animation}
-          colorType={'category'}
-          stroke={'#ddd'}
-          strokeWidth={2}
-          colorRange={colors}
-        />
-      </XYPlot>
-    );
-  }
+  return (
+    <XYPlot width={width} height={height} className={className}>
+      {links.map(({source, target}, index) => {
+        return (
+          <LineSeriesCanvas
+            animation={animation}
+            color={'#B3AD9E'}
+            key={`link-${index}`}
+            opacity={0.3}
+            data={[
+              {...source, color: null},
+              {...target, color: null}
+            ]}
+          />
+        );
+      })}
+      <MarkSeriesCanvas
+        data={nodes}
+        animation={animation}
+        colorType={'category'}
+        stroke={'#ddd'}
+        strokeWidth={2}
+        colorRange={colors}
+      />
+    </XYPlot>
+  );
 }
-
-ForceDirectedGraph.displayName = 'ForceDirectedGraph';
-
-export default ForceDirectedGraph;

--- a/packages/showcase/examples/responsive-vis/responsive-bar-chart.js
+++ b/packages/showcase/examples/responsive-vis/responsive-bar-chart.js
@@ -48,59 +48,56 @@ function updateDataForArea(data, ppp) {
   return sample;
 }
 
-export default class ResponsiveBarChart extends React.Component {
-  // todo build a root responsive class that has this as a class method
-  getFeatures() {
-    const {data, height, margin, width} = this.props;
-    const innerWidth = width - margin.left - margin.right;
-    const innerHeight = height - margin.top - margin.bottom;
-    const ppp = getPPP(innerWidth, innerHeight, data, 'HEIGHT');
-    return filterFeatures(BARCHART_FEATURES, ppp);
-  }
+export function getFeatures(props) {
+  const {data, height, margin, width} = props;
+  const innerWidth = width - margin.left - margin.right;
+  const innerHeight = height - margin.top - margin.bottom;
+  const ppp = getPPP(innerWidth, innerHeight, data, 'HEIGHT');
+  return filterFeatures(BARCHART_FEATURES, ppp);
+}
 
-  render() {
-    const {data, height, margin, width} = this.props;
+export default function ResponsiveBarChart(props) {
+  const {data, height, margin, width} = props;
 
-    const innerWidth = width - margin.left - margin.right;
-    const innerHeight = height - margin.top - margin.bottom;
-    const ppp = getPPP(innerWidth, innerHeight, data, 'HEIGHT');
-    const featuresToRender = filterFeatures(BARCHART_FEATURES, ppp);
-    const updatedData = featuresToRender.area
-      ? updateDataForArea(data, ppp)
-      : data;
+  const innerWidth = width - margin.left - margin.right;
+  const innerHeight = height - margin.top - margin.bottom;
+  const ppp = getPPP(innerWidth, innerHeight, data, 'HEIGHT');
+  const featuresToRender = filterFeatures(BARCHART_FEATURES, ppp);
+  const updatedData = featuresToRender.area
+    ? updateDataForArea(data, ppp)
+    : data;
 
-    return (
-      <div className="responsive-bar-chart">
-        <XYPlot
-          yType="ordinal"
-          xType="linear"
-          margin={margin}
-          height={height}
-          width={width}
-        >
-          {featuresToRender.xaxis && <XAxis orientation="top" />}
-          {featuresToRender.yaxis && <YAxis />}
-          {featuresToRender.bars && (
-            <HorizontalBarSeries
-              colorType="literal"
-              yRange={[0, innerHeight]}
-              xRange={[0, innerWidth]}
-              data={updatedData}
-            />
-          )}
-          {featuresToRender.area && (
-            <AreaSeries
-              colorType="literal"
-              color="#12939A"
-              yType="linear"
-              yDomain={[0, updatedData.length]}
-              yRange={[0, innerHeight]}
-              xRange={[innerWidth, 0]}
-              data={updatedData}
-            />
-          )}
-        </XYPlot>
-      </div>
-    );
-  }
+  return (
+    <div className="responsive-bar-chart">
+      <XYPlot
+        yType="ordinal"
+        xType="linear"
+        margin={margin}
+        height={height}
+        width={width}
+      >
+        {featuresToRender.xaxis && <XAxis orientation="top" />}
+        {featuresToRender.yaxis && <YAxis />}
+        {featuresToRender.bars && (
+          <HorizontalBarSeries
+            colorType="literal"
+            yRange={[0, innerHeight]}
+            xRange={[0, innerWidth]}
+            data={updatedData}
+          />
+        )}
+        {featuresToRender.area && (
+          <AreaSeries
+            colorType="literal"
+            color="#12939A"
+            yType="linear"
+            yDomain={[0, updatedData.length]}
+            yRange={[0, innerHeight]}
+            xRange={[innerWidth, 0]}
+            data={updatedData}
+          />
+        )}
+      </XYPlot>
+    </div>
+  );
 }

--- a/packages/showcase/examples/responsive-vis/responsive-vis-example.js
+++ b/packages/showcase/examples/responsive-vis/responsive-vis-example.js
@@ -18,11 +18,15 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import React from 'react';
+import React, {useState} from 'react';
 
 import {createData, getPPP} from './responsive-vis-utils';
-import ResponsiveScatterplot from './responsive-scatterplot';
-import ResponsiveBarChart from './responsive-bar-chart';
+import ResponsiveScatterplot, {
+  getFeatures as getScatterplotFeatures
+} from './responsive-scatterplot';
+import ResponsiveBarChart, {
+  getFeatures as getBarFeatures
+} from './responsive-bar-chart';
 
 import 'styles/examples.scss';
 import './responsive-vis.scss';
@@ -30,105 +34,92 @@ import './responsive-vis.scss';
 const ASPECT_RATIO = 1.2;
 const EXAMPLE_MARGIN = {left: 60, top: 60, bottom: 50, right: 50};
 
-export default class ResponsiveVisDemo extends React.Component {
-  state = {
-    dataSize: 1,
-    visSize: 400,
-    data: createData(5, true),
-    chartType: 'barChart'
+export default function ResponsiveVisDemo() {
+  const [chartType, setChartType] = useState('barChart');
+  const [data, setData] = useState(createData(5, true));
+  const [visSize, setVisSize] = useState(400);
+  const [dataSize, setDataSize] = useState(1);
+
+  const ResponsiveChartType =
+    chartType === 'barChart' ? ResponsiveBarChart : ResponsiveScatterplot;
+
+  const handleTypeClick = chartType => () => {
+    setChartType(chartType);
+    setData(createData(~~Math.pow(10, dataSize), chartType === 'barChart'));
   };
 
-  handleTypeClick(chartType) {
-    const {dataSize} = this.state;
-    return () => {
-      this.setState({
-        chartType,
-        data: createData(~~Math.pow(10, dataSize), chartType === 'barChart')
-      });
-    };
-  }
+  const width = visSize;
+  const height = visSize * ASPECT_RATIO;
+  const ppp = getPPP(width, height, data, 'TWOD');
+  const featuresProps = {width, height, data, margin: EXAMPLE_MARGIN};
+  const featuresToRender = (chartType === 'barChart'
+    ? getBarFeatures
+    : getScatterplotFeatures)(featuresProps);
 
-  renderControls() {
-    const {chartType, data, dataSize, visSize} = this.state;
-    const width = visSize;
-    const height = visSize * ASPECT_RATIO;
-    const ppp = getPPP(width, height, data, 'TWOD');
-    const featuresToRender =
-      (this.responsiveExample && this.responsiveExample.getFeatures()) || {};
-
-    return (
-      <div className="responsive-controls">
-        <div className="points-per-pixel-label">{`Points Per Pixel: ${ppp}`}</div>
-        <div className="features-label">
-          {`Features: ${Object.keys(featuresToRender).join(', ')}`}
-        </div>
-        <div className="chart-type-selector">
-          <div
-            className={
-              chartType === 'scatterplot'
-                ? 'selected-chart-type'
-                : 'unselected-chart-type'
-            }
-            onClick={this.handleTypeClick('scatterplot')}
-          >
-            Scatterplot
+  return (
+    <div className="responsive-vis-example">
+      <div className="controls-wrapper">
+        <div className="responsive-controls">
+          <div className="points-per-pixel-label">{`Points Per Pixel: ${ppp}`}</div>
+          <div className="features-label">
+            {`Features: ${Object.keys(featuresToRender).join(', ')}`}
           </div>
-          <div
-            className={
-              chartType === 'barChart'
-                ? 'selected-chart-type'
-                : 'unselected-chart-type'
-            }
-            onClick={this.handleTypeClick('barChart')}
-          >
-            BarChart
+          <div className="chart-type-selector">
+            <div
+              className={
+                chartType === 'scatterplot'
+                  ? 'selected-chart-type'
+                  : 'unselected-chart-type'
+              }
+              onClick={handleTypeClick('scatterplot')}
+            >
+              Scatterplot
+            </div>
+            <div
+              className={
+                chartType === 'barChart'
+                  ? 'selected-chart-type'
+                  : 'unselected-chart-type'
+              }
+              onClick={handleTypeClick('barChart')}
+            >
+              BarChart
+            </div>
           </div>
+          {`Data Size: ${~~Math.pow(10, dataSize)}`}
+          <input
+            onChange={e => {
+              setDataSize(e.target.value);
+              setData(
+                createData(
+                  ~~Math.pow(10, e.target.value),
+                  chartType === 'barChart'
+                )
+              );
+            }}
+            type="range"
+            min={1}
+            max={6}
+            step={0.1}
+            value={dataSize}
+          />
+
+          {`Visualization size: ${visSize}`}
+          <input
+            onChange={e => setVisSize(~~e.target.value)}
+            type="range"
+            min={100}
+            max={1000}
+            value={visSize}
+          />
         </div>
-        {`Data Size: ${~~Math.pow(10, dataSize)}`}
-        <input
-          onChange={e => {
-            this.setState({
-              dataSize: e.target.value,
-              data: createData(
-                ~~Math.pow(10, e.target.value),
-                this.state.chartType === 'barChart'
-              )
-            });
-          }}
-          type="range"
-          min={1}
-          max={6}
-          step={0.1}
-          value={dataSize}
-        />
-
-        {`Visualization size: ${visSize}`}
-        <input
-          onChange={e => this.setState({visSize: ~~e.target.value})}
-          type="range"
-          min={100}
-          max={1000}
-          value={visSize}
-        />
       </div>
-    );
-  }
-
-  render() {
-    const {chartType, data, visSize} = this.state;
-    const ResponsiveChartType =
-      chartType === 'barChart' ? ResponsiveBarChart : ResponsiveScatterplot;
-    return (
-      <div className="responsive-vis-example">
-        <div className="controls-wrapper">{this.renderControls()}</div>
-        <ResponsiveChartType
-          data={data}
-          ref={ref => (this.responsiveExample = ref)}
-          margin={EXAMPLE_MARGIN}
-          height={ASPECT_RATIO * visSize}
-          width={visSize}
-        />
-      </div>
-    );
-  }
+      <ResponsiveChartType
+        data={data}
+        margin={EXAMPLE_MARGIN}
+        height={height}
+        width={width}
+      />
+    </div>
+  );
 }

--- a/packages/showcase/examples/responsive-vis/responsive-vis-example.js
+++ b/packages/showcase/examples/responsive-vis/responsive-vis-example.js
@@ -36,7 +36,7 @@ const EXAMPLE_MARGIN = {left: 60, top: 60, bottom: 50, right: 50};
 
 export default function ResponsiveVisDemo() {
   const [chartType, setChartType] = useState('barChart');
-  const [data, setData] = useState(createData(5, true));
+  const [data, setData] = useState(() => createData(5, true));
   const [visSize, setVisSize] = useState(400);
   const [dataSize, setDataSize] = useState(1);
 

--- a/packages/showcase/sunbursts/clock-example.js
+++ b/packages/showcase/sunbursts/clock-example.js
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import React from 'react';
+import React, {useState, useEffect} from 'react';
 
 import {XYPlot, ArcSeries} from 'react-vis';
 
@@ -30,53 +30,41 @@ function getSeconds() {
   return Math.floor(new Date().getTime() / 1000);
 }
 
-export default class ClockExample extends React.Component {
-  state = {
-    time: 0
-  };
-
-  componentDidMount() {
-    this._timerId = setInterval(() => this.setState({time: getSeconds()}), 100);
-  }
-
-  componentWillUnmount() {
-    clearInterval(this._timerId);
-    this.setState({timerId: false});
-  }
-
-  render() {
-    const {time} = this.state;
-    const seconds = time % 60;
-    const minutes = (time / 60) % 60;
-    const hours = (time / (60 * 24)) % 24;
-    return (
-      <XYPlot
-        xDomain={[-3, 3]}
-        yDomain={[-3, 3]}
-        width={300}
-        getAngle={d => d.time}
-        getAngle0={() => 0}
-        height={300}
-      >
-        <ArcSeries
-          animation={{
-            damping: 9,
-            stiffness: 300
-          }}
-          radiusDomain={[0, 3]}
-          data={[
-            {time: (seconds / 60) * 2 * PI, radius0: 1, radius: 1.5, color: 0},
-            {
-              time: (minutes / 60) * 2 * PI,
-              radius0: 1.6,
-              radius: 2.1,
-              color: 1
-            },
-            {time: (hours / 24) * 2 * PI, radius0: 2.2, radius: 2.7, color: 2}
-          ]}
-          colorRange={EXTENDED_DISCRETE_COLOR_RANGE}
-        />
-      </XYPlot>
-    );
-  }
+export default function ClockExample() {
+  const [time, setTime] = useState(getSeconds());
+  useEffect(() => {
+    setInterval(() => setTime(getSeconds()), 100);
+  }, []);
+  const seconds = time % 60;
+  const minutes = (time / 60) % 60;
+  const hours = (time / (60 * 24)) % 24;
+  return (
+    <XYPlot
+      xDomain={[-3, 3]}
+      yDomain={[-3, 3]}
+      width={300}
+      getAngle={d => d.time}
+      getAngle0={() => 0}
+      height={300}
+    >
+      <ArcSeries
+        animation={{
+          damping: 9,
+          stiffness: 300
+        }}
+        radiusDomain={[0, 3]}
+        data={[
+          {time: (seconds / 60) * 2 * PI, radius0: 1, radius: 1.5, color: 0},
+          {
+            time: (minutes / 60) * 2 * PI,
+            radius0: 1.6,
+            radius: 2.1,
+            color: 1
+          },
+          {time: (hours / 24) * 2 * PI, radius0: 2.2, radius: 2.7, color: 2}
+        ]}
+        colorRange={EXTENDED_DISCRETE_COLOR_RANGE}
+      />
+    </XYPlot>
+  );
 }

--- a/packages/showcase/sunbursts/clock-example.js
+++ b/packages/showcase/sunbursts/clock-example.js
@@ -33,7 +33,8 @@ function getSeconds() {
 export default function ClockExample() {
   const [time, setTime] = useState(getSeconds());
   useEffect(() => {
-    setInterval(() => setTime(getSeconds()), 100);
+    const handle = setInterval(() => setTime(getSeconds()), 100);
+    return () => clearInterval(handle);
   }, []);
   const seconds = time % 60;
   const minutes = (time / 60) % 60;


### PR DESCRIPTION
This converts the showcase examples listed in #1335 to use hooks. This is slightly in conflict with #1343 which addresses those same examples, although it does so via replacing componentWillRecieve with componentWillUpdate.