### PR TITLE
Add onTouchStart event listener to support touch actions

### DIFF
--- a/packages/react-vis/src/plot/highlight.js
+++ b/packages/react-vis/src/plot/highlight.js
@@ -262,6 +262,10 @@ class Highlight extends AbstractSeries {
           onMouseUp={e => this.stopBrushing(e)}
           onMouseLeave={e => this.stopBrushing(e)}
           // preventDefault() so that mouse event emulation does not happen
+          onTouchStart={e => {
+            e.preventDefault();
+            this.startBrushing(e);
+          }}
           onTouchEnd={e => {
             e.preventDefault();
             this.stopBrushing(e);


### PR DESCRIPTION
If we want zoom to work with touch devides we need to also register onTouchStart event that sets brushing to true in order to not return immediately in onBrushEnd method (where is both brushing and dragging false)