### PR TITLE
Update search to lower case as well

### DIFF
--- a/packages/react-vis/src/legends/searchable-discrete-color-legend.js
+++ b/packages/react-vis/src/legends/searchable-discrete-color-legend.js
@@ -40,7 +40,7 @@ const defaultProps = {
       item =>
         String(item.title || item)
           .toLowerCase()
-          .indexOf(s) !== -1
+          .indexOf(s.toLowerCase()) !== -1
     )
 };
 


### PR DESCRIPTION
This will covert the search text to lower case as well for usability.

I noticed that in the Searchable Discrete Legend example [here](https://github.com/uber/react-vis/blob/premodern/showcase/legends/searchable-discrete-color.js) that if you search for "Apples", it doesn't find it, but "apples" will. This just changes the search term to lower case when searching as well. 