### PR TITLE
using set -e instead of short-circuit evaluation to exit early on failure

### DIFF
--- a/publish-docs.sh
+++ b/publish-docs.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
-cd website &&
-npm run build &&
-rm -rf /tmp/dist-vis &&
-mv dist /tmp/dist-vis &&
-git checkout gh-pages &&
-rm -rf dist &&
-mv /tmp/dist-vis dist &&
-mv dist/index.html .. &&
-cd .. &&
-git add . &&
-git commit -m 'Upgrade docs' &&
+set -e
+cd website
+npm run build
+rm -rf /tmp/dist-vis
+mv dist /tmp/dist-vis
+git checkout gh-pages
+rm -rf dist
+mv /tmp/dist-vis dist
+mv dist/index.html ..
+cd ..
+git add .
+git commit -m 'Upgrade docs'
 git push && git checkout master


### PR DESCRIPTION
added [`set -e`](https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html) at the top of the script and removed ` &&` suffix from the end of every line.