### PR TITLE
Fix flexible chart during initial load

### DIFF
--- a/packages/react-vis/src/make-vis-flexible.js
+++ b/packages/react-vis/src/make-vis-flexible.js
@@ -101,6 +101,7 @@ function getDisplayName(Component) {
 function makeFlexible(Component, isWidthFlexible, isHeightFlexible) {
   const ResultFunctionalComponent = function(props) {
     const containerRef = useRef();
+
     const [size, setSize] = useState({height: 0, width: 0});
 
     useEffect(() => {

--- a/packages/react-vis/src/make-vis-flexible.js
+++ b/packages/react-vis/src/make-vis-flexible.js
@@ -101,7 +101,6 @@ function getDisplayName(Component) {
 function makeFlexible(Component, isWidthFlexible, isHeightFlexible) {
   const ResultFunctionalComponent = function(props) {
     const containerRef = useRef();
-
     const [size, setSize] = useState({height: 0, width: 0});
 
     useEffect(() => {
@@ -120,6 +119,8 @@ function makeFlexible(Component, isWidthFlexible, isHeightFlexible) {
           ...newWidth
         }));
       }
+
+      _onResize();
 
       const cancelSubscription = subscribeToDebouncedResize(_onResize);
 

--- a/packages/showcase/showcase-sections/misc-showcase.js
+++ b/packages/showcase/showcase-sections/misc-showcase.js
@@ -15,7 +15,8 @@ const {
   SelectionPlotExample,
   DragableChartExample,
   BidirectionDragChart,
-  ClipExample
+  ClipExample,
+  FlexibleCharts
 } = showCase;
 
 const MISC = [
@@ -96,6 +97,11 @@ const MISC = [
     name: '2d Dragable Chart',
     component: BidirectionDragChart,
     componentName: 'BidirectionDragChart'
+  },
+  {
+    name: 'Flexible Chart',
+    component: FlexibleCharts,
+    componentName: 'FlexibleCharts'
   }
 ];
 


### PR DESCRIPTION
Flexible chart doesn't retrieve size information without triggering resize event, causing issue in initial load. Fixing the bug.
This bug was not published in v1.11.7 but was caused by a migration happening post v1.11.7