### PR TITLE
doc: Revert "Re-deprecate (#1445)"

### DIFF
--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -1,9 +1,0 @@
-# Deprecated
-
-Unfortunately, `react-vis` currently has no active maintainers. As such, we have
-decided to deprecate the library. This deprecation means that `react-vis` won't
-receive any patches or new features. If you're interested to take on ownership,
-please discuss on #1303. Anyone is welcome to fork this library.
-
-We're working on a new charting library that we'll introduce in 2020. We will
-keep you folks updated on this repo on the new library!

--- a/docs/animation.md
+++ b/docs/animation.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 ## Animation
 
 Animation makes your charts feel physical, it makes them feel alive, shoot it makes them feel l33t. `react-vis` offers a simple portal into the [react-motion](https://github.com/chenglou/react-motion) animation system by exposing a simple animation prop on most components! This prop accepts three types of values:

--- a/docs/arc-series.md
+++ b/docs/arc-series.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 ## ArcSeries:
 
 <!-- INJECT:"ArcSeriesExampleWithLink" -->

--- a/docs/area-series.md
+++ b/docs/area-series.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 # AreaSeries
 
 <!-- INJECT:"AreaChartWithLink" -->

--- a/docs/axes.md
+++ b/docs/axes.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 ## Axes
 
 <!-- INJECT:"CustomAxesOrientationWithLink" -->

--- a/docs/bar-series.md
+++ b/docs/bar-series.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 # Bar Series
 
 **TLDR**: use bar series to make bar charts, but not histograms.

--- a/docs/borders.md
+++ b/docs/borders.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 ## Borders
 
 Sometimes when modifying the domain of the XYPlot it can be useful to enforce a border, so that some components appear, and others do not. One way to do this is to use the `Borders` component. It is a simple component that creates rectangles the directly correspond to the margins of the plot.

--- a/docs/chart-label.md
+++ b/docs/chart-label.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 ## ChartLabel
 
 When you are styling your chart sometimes you just want to take complete control of label placements. Maybe you want to annotate something, or maybe you just want to place your axis labels in a very specific place, ChartLabel allows you to do just that. Let's look at an example:

--- a/docs/clip.md
+++ b/docs/clip.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 ## Clip
 
 Depending on the data and domain, sometimes the series in the plot will extend into the axis. This can either be solved with a [Border](border.md), or the elements can be clipped.

--- a/docs/colors.md
+++ b/docs/colors.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 ## Color
 
 Color can be set and affected in many ways in React-vis.

--- a/docs/contour-series.md
+++ b/docs/contour-series.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 ## ContourSeries
 
 The contour series allows for the easy creation of contour density plots. These can be more effective for visualizing heat map data than a rectangular heat map! Given a number of points in a space the relative contour lines are computed, so as to simplify the output into a more legible format!

--- a/docs/crosshair.md
+++ b/docs/crosshair.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 ## Crosshair
 
 <!-- INJECT:"DynamicCrosshairWithLink" -->

--- a/docs/custom-svg-series.md
+++ b/docs/custom-svg-series.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 ## CustomSVGSeries
 
 When creating visualizations, it is sometimes necessary to get your hands dirty and completely take control over what SVG components will be shown. This could be necessary in situations where you have predefined SVG code that you just want to appear the way you drew it in Sketch (but positioned using coordinates), or maybe you have multiline text annotations that you want to formatted in a particular way, or you just want to use an alternative type of mark instead of the usual scatterplot mark to differentiate series in a set. To serve these and many other tasks, we use the CustomSVGSeries.

--- a/docs/decorative-axis.md
+++ b/docs/decorative-axis.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 ## DecorativeAxis
 
 <!-- INJECT:"ParallelCoordinatesExampleWithLink" -->

--- a/docs/examples/building-things-other-than-charts.md
+++ b/docs/examples/building-things-other-than-charts.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 <!-- INJECT:"ForceDirectedGraph" -->
 
 [Source code](https://github.com/uber/react-vis/blob/master/packages/showcase/examples/force-directed-graph/force-directed-graph.js)

--- a/docs/examples/extensibility.md
+++ b/docs/examples/extensibility.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 <!-- INJECT:"Candlestick" -->
 
 

--- a/docs/examples/iris-dashboard.md
+++ b/docs/examples/iris-dashboard.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 <!-- STYLETYPE:"example-page" -->
 <!-- INJECT:"IrisDashboard" -->
 

--- a/docs/examples/responsive-vis.md
+++ b/docs/examples/responsive-vis.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 <!-- STYLETYPE:"example-page" -->
 <!-- INJECT:"ResponsiveVis" -->
 

--- a/docs/examples/showcases/axes-showcase.md
+++ b/docs/examples/showcases/axes-showcase.md
@@ -1,3 +1,1 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 <!-- INJECT:"AxesShowcase" -->

--- a/docs/examples/showcases/legends-showcase.md
+++ b/docs/examples/showcases/legends-showcase.md
@@ -1,3 +1,1 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 <!-- INJECT:"LegendsShowcase" -->

--- a/docs/examples/showcases/misc-showcase.md
+++ b/docs/examples/showcases/misc-showcase.md
@@ -1,3 +1,1 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 <!-- INJECT:"MiscShowcase" -->

--- a/docs/examples/showcases/plots-showcase.md
+++ b/docs/examples/showcases/plots-showcase.md
@@ -1,3 +1,1 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 <!-- INJECT:"PlotsShowcase" -->

--- a/docs/examples/showcases/radar-chart-showcase.md
+++ b/docs/examples/showcases/radar-chart-showcase.md
@@ -1,3 +1,1 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 <!-- INJECT:"RadarShowcase" -->

--- a/docs/examples/showcases/radial-showcase.md
+++ b/docs/examples/showcases/radial-showcase.md
@@ -1,3 +1,1 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 <!-- INJECT:"RadialShowcase" -->

--- a/docs/examples/showcases/sankeys-showcase.md
+++ b/docs/examples/showcases/sankeys-showcase.md
@@ -1,3 +1,1 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 <!-- INJECT:"SankeysShowcase" -->

--- a/docs/examples/showcases/sunburst-showcase.md
+++ b/docs/examples/showcases/sunburst-showcase.md
@@ -1,3 +1,1 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 <!-- INJECT:"SunburstSection" -->

--- a/docs/examples/showcases/treemaps-showcase.md
+++ b/docs/examples/showcases/treemaps-showcase.md
@@ -1,3 +1,1 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 <!-- INJECT:"TreemapShowcase" -->

--- a/docs/examples/stream-graph.md
+++ b/docs/examples/stream-graph.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 <!-- STYLETYPE:"example-page" -->
 <!-- INJECT:"StreamgraphExample" -->
 

--- a/docs/flexible-plots.md
+++ b/docs/flexible-plots.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 ## Flexible plots
 
 By default, XYPlot requires a width and a height. There are times, however, when you'd like your chart to take all the space it can.

--- a/docs/getting-started/getting-started.md
+++ b/docs/getting-started/getting-started.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 ### Getting started
 
 #### Jump right in on codepen!

--- a/docs/getting-started/installing-react-vis.md
+++ b/docs/getting-started/installing-react-vis.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 ### Install the react-vis module
 
 If you want to use react-vis in your project, add it from the command line: 

--- a/docs/getting-started/new-react-vis-project.md
+++ b/docs/getting-started/new-react-vis-project.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 ### Create a new project with react-vis
 
 Let's create a new vis app from scratch.

--- a/docs/getting-started/react-vis-in-codepen.md
+++ b/docs/getting-started/react-vis-in-codepen.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 ### Jump right in on codepen!
 
 You can use react-vis directly on [codepen](https://codepen.io/ubervisualization/pen/BZOeZB) (or equivalent).  

--- a/docs/getting-started/your-first-chart.md
+++ b/docs/getting-started/your-first-chart.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 ### Your first chart
 
 We tried to make react-vis syntax as close to the traditional react syntax. You have components which have props and possibly children. 

--- a/docs/gradients.md
+++ b/docs/gradients.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 ## Gradient
 
 Sometimes it is useful to style our svg components using gradients. The way that this is done in React-vis is by making use of the GradientDefs component, which is a simple wrapper on the svg <defs> tag.

--- a/docs/grids.md
+++ b/docs/grids.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 ## Cartesian Grids
 
 <!-- INJECT:"CustomAxisChartWithLink" -->

--- a/docs/heatmap-series.md
+++ b/docs/heatmap-series.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 ## HeatmapSeries:
 
 <!-- INJECT:"HeatmapChartWithLink" -->

--- a/docs/hexbin-series.md
+++ b/docs/hexbin-series.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 ## HexbinSeries
 
 The hexbin series enables the easy creation of aggregated and binned data. This can be useful if you have a lot of overlapping data or if you simply want to provide a courser representation of data to your user. Unlike many other series this one performs the aggregation computation, simply provide a scatterplot like collection of data (points in linear x and y space) and your off!

--- a/docs/highlight.md
+++ b/docs/highlight.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 ## Highlight
 
 The highlight component enables use interaction via direct manipulation of chart through dragging and brushing. This component is stateful and can maintain a notion of a dragged box. It can be applied either in two directions or in one!

--- a/docs/hint.md
+++ b/docs/hint.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 ## Hint
 
 <!-- INJECT:"DynamicComplexEdgeHintsWithLink" -->

--- a/docs/interaction.md
+++ b/docs/interaction.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 ## Interaction
 
 Interaction in react-vis happens through _event handlers_ which are triggered by certain interactive events, such as mouse movement or clicks.

--- a/docs/label-series.md
+++ b/docs/label-series.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 ## LabelSeries:
 
 <!-- INJECT:"LabelSeriesExampleWithLink" -->

--- a/docs/legends.md
+++ b/docs/legends.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 ## Legends
 
 <!-- INJECT:"HorizontalDiscreteColorLegendExampleWithLink" -->

--- a/docs/line-mark-series.md
+++ b/docs/line-mark-series.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 # LineMarkSeries
 
 The Line Mark series is a combination of a LineSeries and a MarkSeries: under the hood, it creates both a LineSeries and a MarkSeries and passes them all of its properties.

--- a/docs/line-series.md
+++ b/docs/line-series.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 # LineSeries/LineMarkSeries
 
 <!-- INJECT:"LineChartWithLink" -->

--- a/docs/mark-series.md
+++ b/docs/mark-series.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 ## MarkSeries & MarkSeriesCanvas
 
 <!-- INJECT:"ScatterplotChartWithLink" -->

--- a/docs/parallel-coordinates.md
+++ b/docs/parallel-coordinates.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 # Parallel Coordinates
 
 Parallel Coordinates provide a robust method for displaying many variables simultaneously. It allows for rapid at-a-glance comparisons across a bunch of dimensions. These graphics can effectively be used either with several data rows on a single chart (as below) or as a small multiple. For more information, check out the [Wiki](https://en.wikipedia.org/wiki/Parallel_coordinates), it's got some really neat examples.

--- a/docs/polygon-series.md
+++ b/docs/polygon-series.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 ## PolygonSeries:
 
 <!-- INJECT:"TriangleExampleWithLink" -->

--- a/docs/presentation.md
+++ b/docs/presentation.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 # React-vis
 
 __React-vis__ is a React visualization library. It's been designed with the following principles in mind:

--- a/docs/radar-chart.md
+++ b/docs/radar-chart.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 # Radar Charts
 
 Radar charts provide a cute method for displaying many variables simultaneously. It allows for rapid at-a-glance comparisons across a bunch of dimensions. These graphics can effectively be used either with several data rows on a single chart (as below) or as a small multiple. For more information, check out the [Wiki](https://en.wikipedia.org/wiki/Radar_chart), it's got some really neat examples.

--- a/docs/radial-chart.md
+++ b/docs/radial-chart.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 # Radial chart
 
 `RadialChart` is responsible for creating pie and donut charts. While this kind of chart is easy to overlook as insignificant, intentionally confusing, or almost always replaceable with a treemap; they can be useful for quickly showing small groups. People don't understand angles very well [(such is our biology)](https://www.interaction-design.org/literature/book/the-encyclopedia-of-human-computer-interaction-2nd-ed/data-visualization-for-human-perception), but over the last hundred years we have seen a lot of pie charts! This has caused us to become intimately familiar with them.

--- a/docs/rect-series.md
+++ b/docs/rect-series.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 # Rect Series
 
 RectSeries is a generalization of [BarSeries](bar-series.md) which allows users to build a series of rectangles of arbitrary dimensions. Whereas in barSeries, one dimension of the bars is fixed (width for vertical bar series, height for horizontal bar series), in RectSeries, both dimensions can be controlled.

--- a/docs/sankey.md
+++ b/docs/sankey.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 # Sankey
 
 Sankey diagrams are a form of graph that allows for the easy communication of flows and other transferal processes.

--- a/docs/scales-and-data.md
+++ b/docs/scales-and-data.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 ## Scales and data
 
 ### Data

--- a/docs/series.md
+++ b/docs/series.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 ## Series
 
 The library supports several types of series:

--- a/docs/style.md
+++ b/docs/style.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 ## Style
 
 In order to control the look and feel of your React-Vis components, you have four strategies.

--- a/docs/sunburst.md
+++ b/docs/sunburst.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 # Sunbursts
 
 Sunbursts are a powerful way to demonstrate part to whole relationships. While they certainly have the many of easily criticized problems of pie charts, they allow for

--- a/docs/treemap.md
+++ b/docs/treemap.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 # Treemap
 
 Treemaps are a splendid way to represent data that has a nested aspect to it. They allow for the easy display of complicated

--- a/docs/voronoi.md
+++ b/docs/voronoi.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 ## Voronoi
 
 Voronoi diagrams are useful for making a chart interactive by creating target areas for events like hover and click.

--- a/docs/whisker-series.md
+++ b/docs/whisker-series.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 ## WhiskerSeries
 
 <!-- INJECT:"WhiskerChartWithLink" -->

--- a/docs/xy-plot.md
+++ b/docs/xy-plot.md
@@ -1,5 +1,3 @@
-> This library is deprecated. Please see `DEPRECATED.md`.
-
 # XYPlot
 
 XYPlot allows you to make line charts, area charts, scatterplots, heat maps, etc with animations and different interactions between them.


### PR DESCRIPTION
Hi there, I'm happy to see react-vis is now not deprecated. I hope react18 is supported officially. 