### PR TITLE
Fix build

### DIFF
--- a/packages/react-vis/build-browser.sh
+++ b/packages/react-vis/build-browser.sh
@@ -38,7 +38,7 @@ do
   MAIN="var_$KEY"
   if ! [ -z  "${!MAIN}" ]
   then
-    MOD=$(jq --arg var $UNPKG '.main = $var' $PACKAGE_JSON)
+    MOD=$(jq --arg var "${!MAIN}" '.main = $var' $PACKAGE_JSON)
     cat <<< $MOD | jq . > $PACKAGE_JSON
   fi
 done

--- a/packages/react-vis/build-browser.sh
+++ b/packages/react-vis/build-browser.sh
@@ -28,7 +28,7 @@ do
   fi
 done
 
-browserify src/index.js -t [ babelify --rootMode upward --global ] --standalone reactVis > dist/dist.min.js
+browserify src/index.js -t [ babelify --rootMode upward --global ] --standalone reactVis | uglifyjs > dist/dist.min.js
 
 # set the main fields of package.json back to original
 for D3_LIB_PATH in $D3_LIB_PATHS

--- a/packages/react-vis/build-browser.sh
+++ b/packages/react-vis/build-browser.sh
@@ -1,16 +1,45 @@
 #!/bin/bash
+# Browserify doesn't seem to support defining custom entry point for modules in node_modules
+# This build script replaces the entry point (the main field of package.json) of d3 libraries to the files
+# defined in the unpkg field when building browser bundles.
+# The replacement are reverted after the build finishes.
 D3_LIB_PATHS=$(ls -d ../../node_modules/d3-*)
+
+get_key_from_d3_path() {
+  local KEY=$(echo $1 | sed 's/..\/..\/node_modules\/d3-//')
+  local KEY=$(echo $KEY | sed 's/-/_/')
+  echo $KEY
+}
 
 for D3_LIB_PATH in $D3_LIB_PATHS
 do
   PACKAGE_JSON=$D3_LIB_PATH/package.json
   UNPKG=$(jq -r '.unpkg' $PACKAGE_JSON)
-  MAIN=$(jq -r '.main' $PACKAGE_JSON)
   if ! [ -z $UNPKG ] && [ $UNPKG != null ]
   then
+    # save the main field
+    MAIN=$(jq -r '.main' $PACKAGE_JSON)
+    KEY=$(get_key_from_d3_path $D3_LIB_PATH)
+    declare var_$KEY=$MAIN
+
+    # modify the main field
     MOD=$(jq --arg unpkg $UNPKG '.main = $unpkg' $PACKAGE_JSON)
     cat <<< $MOD | jq . > $PACKAGE_JSON
   fi
 done
 
 browserify src/index.js -t [ babelify --rootMode upward --global ] --standalone reactVis > dist/dist.min.js
+
+# set the main fields of package.json back to original
+for D3_LIB_PATH in $D3_LIB_PATHS
+do
+  PACKAGE_JSON=$D3_LIB_PATH/package.json
+  KEY=$(get_key_from_d3_path $D3_LIB_PATH)
+  MAIN="var_$KEY"
+  if ! [ -z  "${!MAIN}" ]
+  then
+    MOD=$(jq --arg var $UNPKG '.main = $var' $PACKAGE_JSON)
+    cat <<< $MOD | jq . > $PACKAGE_JSON
+  fi
+done
+

--- a/packages/react-vis/build-browser.sh
+++ b/packages/react-vis/build-browser.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+D3_LIB_PATHS=$(ls -d ../../node_modules/d3-*)
+
+for D3_LIB_PATH in $D3_LIB_PATHS
+do
+  PACKAGE_JSON=$D3_LIB_PATH/package.json
+  UNPKG=$(jq -r '.unpkg' $PACKAGE_JSON)
+  MAIN=$(jq -r '.main' $PACKAGE_JSON)
+  if ! [ -z $UNPKG ] && [ $UNPKG != null ]
+  then
+    MOD=$(jq --arg unpkg $UNPKG '.main = $unpkg' $PACKAGE_JSON)
+    cat <<< $MOD | jq . > $PACKAGE_JSON
+  fi
+done
+
+browserify src/index.js -t [ babelify --rootMode upward --global ] --standalone reactVis > dist/dist.min.js

--- a/packages/react-vis/package.json
+++ b/packages/react-vis/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "author": "Visualization Team <visualization@uber.com>",
   "description": "Data visualization library based on React and d3.",
-  "main": "dist",
+  "main": "$UNPKG",
   "module": "es",
   "jsnext:main": "es",
   "files": [
@@ -23,7 +23,7 @@
     "docs": "./publish-docs.sh",
     "clean": "rm -rf dist es bundle.* index.html && mkdir dist es",
     "start": "(cd ../showcase && command -v yarn >/dev/null && yarn start)",
-    "build:browser": "browserify src/index.js -t [ babelify --rootMode upward --global ] --standalone reactVis | uglifyjs > dist/dist.min.js && find dist -maxdepth 1 -not \\( -name 'dist.min.js' -or -name 'style.css' -or -name 'main.scss' -or -name 'styles' -or -name 'dist' \\) -exec rm -rf {} +",
+    "build:browser": "./build-browser.sh",
     "build": "yarn run clean && babel --root-mode upward src -d dist --copy-files && BABEL_ENV=es babel --root-mode upward src -d es --copy-files && node-sass src/main.scss dist/style.css --output-style compressed && yarn run build:browser",
     "lint-styles": "stylelint src/styles/*.scss --syntax scss",
     "test:windows": "babel-node --inspect ./tests/index.js",

--- a/packages/react-vis/package.json
+++ b/packages/react-vis/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "author": "Visualization Team <visualization@uber.com>",
   "description": "Data visualization library based on React and d3.",
-  "main": "$UNPKG",
+  "main": "dist",
   "module": "es",
   "jsnext:main": "es",
   "files": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -5591,15 +5591,10 @@ d3-collection@1, d3-collection@^1.0.7:
   resolved "https://registry.yarnpkg.com/d3-collection/-/d3-collection-1.0.7.tgz#349bd2aa9977db071091c13144d5e4f16b5b310e"
   integrity sha1-NJvSqpl32wcQkcExRNXk8WtbMQ4=
 
-"d3-color@1 - 3", d3-color@^3.1.0:
+"d3-color@1 - 3", d3-color@3.1.0, d3-color@^1.0.3, d3-color@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-3.1.0.tgz#395b2833dfac71507f12ac2f7af23bf819de24e2"
   integrity sha1-OVsoM9+scVB/EqwvevI7+BneJOI=
-
-d3-color@^1.0.3:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.4.1.tgz#c52002bf8846ada4424d55d97982fef26eb3bc8a"
-  integrity sha1-xSACv4hGraRCTVXZeYL+8m6zvIo=
 
 d3-contour@^4.0.0:
   version "4.0.0"
@@ -9667,10 +9662,10 @@ js-base64@^2.1.8, js-base64@^2.1.9:
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.5.2.tgz#313b6274dda718f714d00b3330bbae6e38e90209"
   integrity sha1-MTtidN2nGPcU0AszMLuubjjpAgk=
 
-js-beautify@^1.8.8:
+js-beautify@1.10.3, js-beautify@^1.8.8:
   version "1.10.3"
   resolved "https://registry.yarnpkg.com/js-beautify/-/js-beautify-1.10.3.tgz#c73fa10cf69d3dfa52d8ed624f23c64c0a6a94c1"
-  integrity sha512-wfk/IAWobz1TfApSdivH5PJ0miIHgDoYb1ugSqHcODPmaYu46rYe5FVuIEkhjg8IQiv6rDNPyhsqbsohI/C2vQ==
+  integrity sha1-xz+hDPadPfpS2O1iTyPGTApqlME=
   dependencies:
     config-chain "^1.1.12"
     editorconfig "^0.15.3"


### PR DESCRIPTION
Browserify doesn't seem to support defining custom entry point for modules in node_modules
Add a build script that replaces the entry point (the main field of package.json) of d3 libraries to the files defined in the unpkg field when building browser bundles.
The replacement are reverted after the build finishes.